### PR TITLE
Improve dockerfile

### DIFF
--- a/apps/portal-web/package.json
+++ b/apps/portal-web/package.json
@@ -8,7 +8,7 @@
     "serve": "next start",
     "build": "pnpm prepareDev && npm run build:nogen",
     "build:nogen": "cross-env BUILDING=1 next build",
-    "prepareDev": "pnpm protos && ntar schema && pnpm cloneNoVnc",
+    "prepareDev": "pnpm protos && ntar schema",
     "protos": "tsgrpc-cli protos",
     "cloneNoVnc": "git -C ./public/vnc pull || git clone -c advice.detachedHead=false --depth=1 --branch v1.3.0 https://github.com/novnc/noVNC ./public/vnc"
   },

--- a/dockerfiles/Dockerfile.auth
+++ b/dockerfiles/Dockerfile.auth
@@ -2,21 +2,15 @@ FROM node:gallium-alpine@sha256:1a9a71ea86aad332aa7740316d4111ee1bd4e890df47d3b5
 
 RUN apk update && apk add libc6-compat python3 make gcc g++
 
-RUN npm install -g pnpm@7.0.1
+RUN corepack enable
 
 WORKDIR /app
-COPY pnpm-lock.yaml ./
-RUN pnpm fetch
 
-COPY package.json pnpm-workspace.yaml .npmrc ./
-
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
 COPY libs/config/package.json ./libs/config/
 COPY apps/auth/package.json ./apps/auth/
 
-# Must run twice
-# First run doesn't create node_modules on libs
-RUN pnpm install --offline
-RUN pnpm install --offline
+RUN pnpm i --frozen-lockfile
 
 COPY tsconfig.json .eslintrc.json ./
 
@@ -25,10 +19,9 @@ COPY protos ./protos
 COPY libs/config ./libs/config
 COPY apps/auth ./apps/auth
 
-
 RUN pnpm run build
 
-RUN rm -rf node_modules && pnpm install -r --prod --offline
+RUN rm -rf node_modules && pnpm i --prod --frozen-lockfile --offline
 
 FROM node:gallium-alpine@sha256:1a9a71ea86aad332aa7740316d4111ee1bd4e890df47d3b5eff3e5bded3b3d10 AS runner
 

--- a/dockerfiles/Dockerfile.clusterops-slurm
+++ b/dockerfiles/Dockerfile.clusterops-slurm
@@ -2,23 +2,15 @@ FROM node:gallium-alpine@sha256:1a9a71ea86aad332aa7740316d4111ee1bd4e890df47d3b5
 
 RUN apk update && apk add libc6-compat python3 make gcc g++
 
-RUN npm install -g pnpm@7.0.1
-
+RUN corepack enable
 
 WORKDIR /app
-COPY pnpm-lock.yaml ./
-RUN pnpm fetch
 
-COPY package.json pnpm-workspace.yaml .npmrc ./
-
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
 COPY libs/config/package.json ./libs/config/
 COPY apps/clusterops-slurm/package.json ./apps/clusterops-slurm/
 
-# Must run twice
-# First run doesn't create node_modules on libs
-RUN pnpm install --offline
-RUN pnpm install --offline
-
+RUN pnpm i --frozen-lockfile
 
 COPY tsconfig.json .eslintrc.json ./
 
@@ -29,10 +21,9 @@ COPY apps/clusterops-slurm ./apps/clusterops-slurm
 
 RUN pnpm run build
 
-RUN rm -rf node_modules && pnpm install -r --prod --offline
+RUN rm -rf node_modules && pnpm i --prod --frozen-lockfile --offline
 
 FROM node:gallium-alpine@sha256:1a9a71ea86aad332aa7740316d4111ee1bd4e890df47d3b5eff3e5bded3b3d10 AS runner
-
 
 WORKDIR /app
 COPY --from=builder /app/node_modules ./node_modules

--- a/dockerfiles/Dockerfile.docs
+++ b/dockerfiles/Dockerfile.docs
@@ -2,33 +2,30 @@ FROM node:gallium-alpine@sha256:1a9a71ea86aad332aa7740316d4111ee1bd4e890df47d3b5
 
 RUN apk update && apk add libc6-compat python3 make gcc g++
 
-RUN npm install -g pnpm@7.0.1
+RUN corepack enable
 
 WORKDIR /app
-COPY pnpm-lock.yaml ./
-RUN pnpm fetch
 
-COPY package.json pnpm-workspace.yaml .npmrc ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
 
 COPY libs/config/package.json ./libs/config/
-COPY docs/package.json ./docs/
+COPY apps/docs/package.json ./apps/docs/
 
-# Must run twice
-# First run doesn't create node_modules on libs
-RUN pnpm install
-RUN pnpm install
-
+RUN pnpm i --frozen-lockfile
 
 COPY tsconfig.json .eslintrc.json ./
 
+COPY protos ./protos
+
 COPY libs/config ./libs/config
-COPY docs ./docs
+COPY apps/docs ./apps/docs
 
 ARG BASE_PATH="/"
 ENV BASE_PATH=${BASE_PATH}
 
-
 RUN pnpm run build
+
+RUN rm -rf node_modules && pnpm i --prod --frozen-lockfile --offline
 
 FROM nginx:stable-alpine as runner
 

--- a/dockerfiles/Dockerfile.docs
+++ b/dockerfiles/Dockerfile.docs
@@ -18,14 +18,12 @@ COPY tsconfig.json .eslintrc.json ./
 COPY protos ./protos
 
 COPY libs/config ./libs/config
-COPY apps/docs ./apps/docs
+COPY docs ./docs
 
 ARG BASE_PATH="/"
 ENV BASE_PATH=${BASE_PATH}
 
 RUN pnpm run build
-
-RUN rm -rf node_modules && pnpm i --prod --frozen-lockfile --offline
 
 FROM nginx:stable-alpine as runner
 

--- a/dockerfiles/Dockerfile.job-server-slurm
+++ b/dockerfiles/Dockerfile.job-server-slurm
@@ -2,21 +2,15 @@ FROM node:gallium-alpine@sha256:1a9a71ea86aad332aa7740316d4111ee1bd4e890df47d3b5
 
 RUN apk update && apk add libc6-compat python3 make gcc g++
 
-RUN npm install -g pnpm@7.0.1
+RUN corepack enable
 
 WORKDIR /app
-COPY pnpm-lock.yaml ./
-RUN pnpm fetch
 
-COPY package.json pnpm-workspace.yaml .npmrc ./
-
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
 COPY libs/config/package.json ./libs/config/
 COPY apps/job-server-slurm/package.json ./apps/job-server-slurm/
 
-# Must run twice
-# First run doesn't create node_modules on libs
-RUN pnpm install --offline
-RUN pnpm install --offline
+RUN pnpm i --frozen-lockfile
 
 COPY tsconfig.json .eslintrc.json ./
 
@@ -27,7 +21,7 @@ COPY apps/job-server-slurm ./apps/job-server-slurm
 
 RUN pnpm run build
 
-RUN rm -rf node_modules && pnpm install -r --prod --offline
+RUN rm -rf node_modules && pnpm i --prod --frozen-lockfile --offline
 
 FROM node:gallium-alpine@sha256:1a9a71ea86aad332aa7740316d4111ee1bd4e890df47d3b5eff3e5bded3b3d10 AS runner
 

--- a/dockerfiles/Dockerfile.mis-server
+++ b/dockerfiles/Dockerfile.mis-server
@@ -2,23 +2,18 @@ FROM node:gallium-alpine@sha256:1a9a71ea86aad332aa7740316d4111ee1bd4e890df47d3b5
 
 RUN apk update && apk add libc6-compat python3 make gcc g++
 
-RUN npm install -g pnpm@7.0.1
+RUN corepack enable
 
 WORKDIR /app
-COPY pnpm-lock.yaml ./
-RUN pnpm fetch
 
-COPY package.json pnpm-workspace.yaml .npmrc ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
 
 COPY libs/config/package.json ./libs/config/
 COPY libs/auth/package.json ./libs/auth/
 COPY libs/decimal/package.json ./libs/decimal/
 COPY apps/mis-server/package.json ./apps/mis-server/
 
-# Must run twice
-# First run doesn't create node_modules on libs
-RUN pnpm install --offline
-RUN pnpm install --offline
+RUN pnpm i --frozen-lockfile
 
 COPY tsconfig.json .eslintrc.json ./
 
@@ -31,7 +26,7 @@ COPY apps/mis-server ./apps/mis-server
 
 RUN pnpm run build
 
-RUN rm -rf node_modules && pnpm install -r --prod --offline
+RUN rm -rf node_modules && pnpm i --prod --frozen-lockfile --offline
 
 FROM node:gallium-alpine@sha256:1a9a71ea86aad332aa7740316d4111ee1bd4e890df47d3b5eff3e5bded3b3d10 AS runner
 

--- a/dockerfiles/Dockerfile.mis-web
+++ b/dockerfiles/Dockerfile.mis-web
@@ -2,22 +2,17 @@ FROM node:gallium-alpine@sha256:1a9a71ea86aad332aa7740316d4111ee1bd4e890df47d3b5
 
 RUN apk update && apk add libc6-compat python3 make gcc g++
 
-RUN npm install -g pnpm@7.0.1
+RUN corepack enable
 
 WORKDIR /app
-COPY pnpm-lock.yaml ./
-RUN pnpm fetch
 
-COPY package.json pnpm-workspace.yaml .npmrc ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
 
 COPY libs/config/package.json ./libs/config/
 COPY libs/decimal/package.json ./libs/decimal/
 COPY apps/mis-web/package.json apps/mis-web/
 
-# Must run twice
-# First run doesn't create node_modules on libs
-RUN pnpm install --offline
-RUN pnpm install --offline
+RUN pnpm i --frozen-lockfile
 
 COPY tsconfig.json .eslintrc.json ./
 
@@ -27,12 +22,9 @@ COPY libs/config ./libs/config
 COPY libs/decimal ./libs/decimal
 COPY apps/mis-web apps/mis-web
 
-ARG BASE_PATH="/"
-ENV NEXT_PUBLIC_BASE_PATH=${BASE_PATH}
-
 RUN pnpm run build
 
-RUN rm -rf node_modules && pnpm install -r --prod --offline
+RUN rm -rf node_modules && pnpm i --prod --frozen-lockfile --offline
 
 FROM node:gallium-alpine@sha256:1a9a71ea86aad332aa7740316d4111ee1bd4e890df47d3b5eff3e5bded3b3d10 AS runner
 

--- a/dockerfiles/Dockerfile.portal-web
+++ b/dockerfiles/Dockerfile.portal-web
@@ -17,6 +17,8 @@ RUN pnpm i --frozen-lockfile
 
 RUN apk add git
 
+RUN pnpm run --filter portal-web cloneNoVnc
+
 COPY tsconfig.json .eslintrc.json ./
 
 COPY protos ./protos

--- a/dockerfiles/Dockerfile.portal-web
+++ b/dockerfiles/Dockerfile.portal-web
@@ -2,24 +2,20 @@ FROM node:gallium-alpine@sha256:1a9a71ea86aad332aa7740316d4111ee1bd4e890df47d3b5
 
 RUN apk update && apk add libc6-compat python3 make gcc g++
 
-RUN npm install -g pnpm@7.0.1
+RUN corepack enable
 
 WORKDIR /app
-COPY pnpm-lock.yaml ./
-RUN pnpm fetch
 
-RUN apk add git
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
 
-COPY package.json pnpm-workspace.yaml .npmrc ./
 
 COPY libs/config/package.json ./libs/config/
 COPY libs/decimal/package.json ./libs/decimal/
 COPY apps/portal-web/package.json ./apps/portal-web/
 
-# Must run twice
-# First run doesn't create node_modules on libs
-RUN pnpm install --offline
-RUN pnpm install --offline
+RUN pnpm i --frozen-lockfile
+
+RUN apk add git
 
 COPY tsconfig.json .eslintrc.json ./
 
@@ -29,13 +25,9 @@ COPY libs/config ./libs/config
 COPY libs/decimal ./libs/decimal
 COPY apps/portal-web ./apps/portal-web
 
-
-ARG BASE_PATH="/"
-ENV NEXT_PUBLIC_BASE_PATH=${BASE_PATH}
-
 RUN pnpm run build
 
-RUN rm -rf node_modules && pnpm install -r --prod --offline
+RUN rm -rf node_modules && pnpm i --prod --frozen-lockfile --offline
 
 FROM node:gallium-alpine@sha256:1a9a71ea86aad332aa7740316d4111ee1bd4e890df47d3b5eff3e5bded3b3d10 AS runner
 


### PR DESCRIPTION
Improve dockerfiles

- Avoid `pnpm fetch` and install dependencies independently for each container so that each container only installs needed dependencies
- Using `corepack` to sync pnpm version
- portal-web build can cache to git clone novnc. Code change no longer causes git clone to rerun