### PR TITLE
refactor: Changing template format from {a} to {{ a }}

### DIFF
--- a/apps/auth/src/config/auth.ts
+++ b/apps/auth/src/config/auth.ts
@@ -12,7 +12,10 @@ export const LdapConfigSchema = Type.Object({
   addUser: Type.Object({
     userBase: Type.String({ description: "LDAP增加用户节点时，把用户增加到哪个节点下" }),
     groupBase: Type.String({ description: "LDAP增加用户对应的组时，把组节点增加到哪个节点下" }),
-    homeDir: Type.String({ description: "LDAP增加用户时，用户的homeDirectory值。使用{userId}代替新用户的用户名", default: "/nfs/{userId}" }),
+    homeDir: Type.String({
+      description: "LDAP增加用户时，用户的homeDirectory值。使用{{ userId }}代替新用户的用户名",
+      default: "/nfs/{{ userId }}",
+    }),
     userToGroup: Type.Optional(Type.String({ description: "LDAP增加用户时，应该把用户增加到哪个Group下。如果不填，创建用户后不会增加用户到Group" })),
     uidStart: Type.Integer({
       description: "LDAP创建用户时，uid从多少开始。生成的用户的uid等于此值加上用户账户中创建的用户ID。创建的Group的gid和uid和此相同。",
@@ -20,13 +23,13 @@ export const LdapConfigSchema = Type.Object({
     }),
     extraProps: Type.Optional(
       Type.Record(
-        Type.String(), 
-        Type.Union([Type.String(), Type.Array(Type.String())]), 
+        Type.String(),
+        Type.Union([Type.String(), Type.Array(Type.String())]),
         { description: `
           LDAP增加用户时，用户项除了id、name和mail，还应该添加哪些属性
           如果这里出现了uid, name或email同名的属性，这里的值将替代用户输入的值。
-          属性值支持使用 {LDAP属性值key} 格式来使用用户填入的值。
-          例如：LDAP_ATTR_NAME=cn, LDAP_ADD_ATTRS=sn={cn}，那么添加时将会增加一个sn项，其值为cn项，即为用户输入的姓名
+          属性值支持使用 {{ LDAP属性值key }} 格式来使用用户填入的值。
+          例如：{ sn: "{{ cn }}" }，那么添加时将会增加一个sn属性，其值为cn的属性，即为用户输入的姓名
         `,
         })),
   }, { description: "添加用户的配置" }),

--- a/apps/mis-server/src/tasks/fetch.ts
+++ b/apps/mis-server/src/tasks/fetch.ts
@@ -4,6 +4,7 @@ import { Status } from "@grpc/grpc-js/build/src/constants";
 import { MikroORM, QueryOrder } from "@mikro-orm/core";
 import { MariaDbDriver } from "@mikro-orm/mariadb";
 import { SqlEntityManager } from "@mikro-orm/mysql";
+import { parsePlaceholder } from "@scow/config";
 import { charge } from "src/bl/charging";
 import { misConfig } from "src/config/mis";
 import { Account } from "src/entities/Account";
@@ -12,7 +13,6 @@ import { OriginalJob } from "src/entities/OriginalJob";
 import { UserAccount } from "src/entities/UserAccount";
 import { ClusterPlugin } from "src/plugins/clusters";
 import { PricePlugin } from "src/plugins/price";
-import { parseCommentPlaceholder } from "src/utils/parse";
 
 export const createSourceDbOrm = async (logger: Logger) => {
   logger.info("Connecting to source db.");
@@ -173,7 +173,7 @@ export async function fetchJobs(
             };
           }
 
-          const comment = parseCommentPlaceholder(misConfig.jobChargeComment, x);
+          const comment = parsePlaceholder(misConfig.jobChargeComment, x);
 
           // charge account
           await charge({

--- a/apps/mis-server/src/utils/parse.ts
+++ b/apps/mis-server/src/utils/parse.ts
@@ -1,4 +1,0 @@
-/** Parse {key} in str to valueObj[key] */
-export function parseCommentPlaceholder(str: string, valueObj: object) {
-  return str.replace(/\{([a-zA-Z0-9_]+)\}/g, (_, p1: string) => valueObj[p1] ?? "");
-}

--- a/docs/docs/common/auth/ldap.md
+++ b/docs/docs/common/auth/ldap.md
@@ -49,7 +49,7 @@ LDAP认证系统支持的功能如下表：
 | sn                              | 用户名                                                 |
 | loginShell                      | /bin/bash                                              |
 | objectClass                     | ["inetOrgPerson", "posixAccount", "shadowAccount"]     |
-| homeDirectory                   | `ldap.addUser.homeDir`，其中的`{username}`替换为用户名 |
+| homeDirectory                   | `ldap.addUser.homeDir`，其中的`{{ username }}`替换为用户名 |
 | uidNumber                       | 数据库中的用户项的id + `ldap.addUsaer.uidStart`        |
 | gidNumber                       | 数据库中的用户项的id + `ldap.addUser.uidStart`         |
 | `ldap.attrs.mail`（如果设置了） | 用户的邮箱                                             |

--- a/docs/docs/portal/apps/configure-web-app.md
+++ b/docs/docs/portal/apps/configure-web-app.md
@@ -48,7 +48,7 @@ web:
     method: POST
     path: /login
     formData:
-      password: "{PASSWORD}"
+      password: "{{ PASSWORD }}"
 ```
 
 增加了此文件后，运行以下命令重启job-server和portal-web即可
@@ -81,5 +81,5 @@ docker compose restart portal-web job-server
 
 ### `connect`
 
-`connect`部分定义如何连接到应用。我们推荐将应用使用密码方式进行加密，所以一般在连接时需要将密码输入给应用。具体如何连接应用和应用本身有关。`connect`的`path`, `query`和`formData`部分可以使用`{PASSWORD}`代替应用在创建时生成的密码。
+`connect`部分定义如何连接到应用。我们推荐将应用使用密码方式进行加密，所以一般在连接时需要将密码输入给应用。具体如何连接应用和应用本身有关。`connect`的`path`, `query`和`formData`部分可以使用`{{ PASSWORD }}`代替应用在创建时生成的密码。
 

--- a/docs/docs/portal/deployment.md
+++ b/docs/docs/portal/deployment.md
@@ -69,8 +69,8 @@ homeText:
 # 是否启用终端功能
 shell: true
 
-# 提交作业的默认工作目录。使用{name}代替作业名称。相对于用户的家目录
-# submitJobDefaultPwd: scow/jobs/{name}
+# 提交作业的默认工作目录。使用{{ name }}代替作业名称。相对于用户的家目录
+# submitJobDefaultPwd: scow/jobs/{{ name }}
 
 # 将保存的作业保存到什么位置。相对于用户家目录
 # savedJobsDir: scow/savedJobs

--- a/libs/config/src/appConfig/mis.ts
+++ b/libs/config/src/appConfig/mis.ts
@@ -57,8 +57,8 @@ export const MisConfigSchema = Type.Object({
   changeJobPriceType: Type.String({ description: "修改作业费用时所使用的付款/充值类型", default: "作业费用更改" }),
 
   jobChargeComment: Type.String({
-    description: "给作业扣费时，扣费项的备注。可以使用{price}使用作业信息中的字段。字段参考src/entities/JobInfo",
-    default: "集群: {cluster}，作业ID：{idJob}",
+    description: "给作业扣费时，扣费项的备注。可以使用{{ 属性名 }}使用作业信息中的属性。字段参考src/entities/JobInfo",
+    default: "集群: {{ cluster }}，作业ID：{{ idJob }}",
   }),
 });
 

--- a/libs/config/src/appConfig/portal.ts
+++ b/libs/config/src/appConfig/portal.ts
@@ -34,7 +34,7 @@ export const PortalConfigSchema = Type.Object({
   shell: Type.Boolean({ description: "是否启用终端功能", default: true }),
 
   submitJobDefaultPwd: Type.String({
-    description: "提交作业的默认工作目录。使用{name}代替作业名称。相对于用户的家目录", default: "scow/jobs/{name}" }),
+    description: "提交作业的默认工作目录。使用{{ name }}代替作业名称。相对于用户的家目录", default: "scow/jobs/{{ name }}" }),
 
   savedJobsDir: Type.String({ description: "将保存的作业保存到什么位置。相对于用户家目录", default: "scow/savedJobs" }),
 

--- a/libs/config/src/parse.ts
+++ b/libs/config/src/parse.ts
@@ -16,13 +16,13 @@ export function parseKeyValue(input: string): Record<string, string> {
 }
 
 /**
- * Replace {a} to valueObj[a]. If valueObj[a] is undefined, replace with ""
+ * Replace {{ a }} to valueObj[a]. If valueObj[a] is undefined, replace with ""
  * @param str the original string
  * @param valueObj the object containing keys and values
  * @returns replaced string
  */
 export function parsePlaceholder(str: string, valueObj: object) {
-  return str.replace(/\{([a-zA-Z0-9_]+)\}/g, (_, p1: string) => valueObj[p1] ?? "");
+  return str.replace(/\{\{\ ([a-zA-Z0-9_]+)\ \}\}/g, (_, p1: string) => valueObj[p1] ?? "");
 }
 
 /**

--- a/libs/config/tests/parse.test.ts
+++ b/libs/config/tests/parse.test.ts
@@ -2,9 +2,13 @@ import { parseArray, parseKeyValue, parsePlaceholder } from "src/parse";
 
 it.each([
   ["123", {}, "123"],
-  ["123{a}123", {}, "123123"],
-  ["123{a}123", { a: "4" }, "1234123"],
-  ["123{a123_4}", { a123_4: "haha " }, "123haha "],
+  ["123{{ a }}123", {}, "123123"],
+  ["123{{ a }}123", { a: "4" }, "1234123"],
+  ["1{23{{ a123_4 }}", { a123_4: "haha " }, "1{23haha "],
+  ["123{a}", { a: "haha" }, "123{a}"],
+  ["123{{a}}", { a: "haha" }, "123{{a}}"],
+  ["123{{a }}", { a: "haha" }, "123{{a }}"],
+  ["123{{ a }}123{{ b }}{{ a }}", { a: "aaa", b: "bbb" }, "123aaa123bbbaaa"],
 ])("parses placeholder %p with %p to %p", (str: string, obj: object, expected: string) => {
   expect(parsePlaceholder(str, obj)).toBe(expected);
 });


### PR DESCRIPTION
Change the template format from `{a}` to `{{ a }}` to align with most template engines and make it easier to distinguish template part of a string.

This is a BREAKING CHANGE with existing configs. Please update the configs in the following config keys:

- config/auth.yml: `ldap.addUser.homeDir`, `ldap.addUser.extraProps`
- config/mis.yaml: `jobChargeComment`
- config/portal.yaml: `submitJobDefaultPwd`
- config/app/{app}.yml: `web.connect`