### PR TITLE
fix(mis): assign initial user with tenant_admin role

### DIFF
--- a/apps/mis-server/src/services/init.ts
+++ b/apps/mis-server/src/services/init.ts
@@ -3,7 +3,7 @@ import { ServiceError, status } from "@grpc/grpc-js";
 import { UniqueConstraintViolationException } from "@mikro-orm/core";
 import { SystemState } from "src/entities/SystemState";
 import { Tenant } from "src/entities/Tenant";
-import { PlatformRole, User } from "src/entities/User";
+import { PlatformRole, TenantRole, User } from "src/entities/User";
 import { InitServiceServer, InitServiceService } from "src/generated/server/init";
 import { DEFAULT_TENANT_NAME } from "src/utils/constants";
 
@@ -17,13 +17,16 @@ export const initServiceServer = plugin((server) => {
       return [{ initialized: initializationTime !== null }];
     },
 
-    createPlatformAdmin: async ({ request, em }) => {
+    createInitAdmin: async ({ request, em }) => {
       // get default tenant
       const tenant = await em.findOneOrFail(Tenant, { name: DEFAULT_TENANT_NAME });
 
       // create the user
       const { userId, email, name } = request;
-      const user = new User({ email, name, tenant, userId, platformRoles: [PlatformRole.PLATFORM_ADMIN]});
+      const user = new User({
+        email, name, tenant, userId,
+        platformRoles: [PlatformRole.PLATFORM_ADMIN], tenantRoles: [TenantRole.TENANT_ADMIN],
+      });
       await em.persistAndFlush([tenant, user]);
 
       return [{}];

--- a/apps/mis-server/tests/init/init.test.ts
+++ b/apps/mis-server/tests/init/init.test.ts
@@ -2,8 +2,8 @@ import { Server } from "@ddadaal/tsgrpc-server";
 import { asyncClientCall } from "@ddadaal/tsgrpc-utils";
 import { ChannelCredentials, status } from "@grpc/grpc-js";
 import { createServer } from "src/app";
-import { PlatformRole, User } from "src/entities/User";
-import { CreatePlatformAdminRequest, InitServiceClient } from "src/generated/server/init";
+import { PlatformRole, TenantRole, User } from "src/entities/User";
+import { CreateInitAdminRequest, InitServiceClient } from "src/generated/server/init";
 import { dropDatabase } from "tests/data/helpers";
 
 let server: Server;
@@ -46,14 +46,14 @@ it("fails to complete if already init", async () => {
 
 });
 
-it("creates platform user", async () => {
-  const userInfo: CreatePlatformAdminRequest = {
+it("creates an init admin user", async () => {
+  const userInfo: CreateInitAdminRequest = {
     email: "test@test.com",
     name: "123",
     userId: "123",
   };
 
-  await asyncClientCall(client, "createPlatformAdmin", userInfo);
+  await asyncClientCall(client, "createInitAdmin", userInfo);
 
   const em = server.ext.orm.em.fork();
 
@@ -61,5 +61,6 @@ it("creates platform user", async () => {
 
   expect(user).toMatchObject(userInfo);
   expect(user.platformRoles).toIncludeSameMembers([PlatformRole.PLATFORM_ADMIN]);
+  expect(user.tenantRoles).toIncludeSameMembers([TenantRole.TENANT_ADMIN]);
 });
 

--- a/apps/mis-web/src/apis/api.mock.ts
+++ b/apps/mis-web/src/apis/api.mock.ts
@@ -84,7 +84,7 @@ export const mockApi: MockApi<typeof api> = {
 
   getIcon: async () => undefined,
 
-  createPlatformUser: async () => null,
+  createInitAdmin: async () => null,
 
   importUsers: async () => null,
 

--- a/apps/mis-web/src/apis/api.ts
+++ b/apps/mis-web/src/apis/api.ts
@@ -20,7 +20,7 @@ import type { GetUsedPayTypesSchema } from "src/pages/api/finance/getUsedPayType
 import type { FinancePaySchema } from "src/pages/api/finance/pay";
 import type { GetPaymentsSchema } from "src/pages/api/finance/payments";
 import type { CompleteInitSchema } from "src/pages/api/init/completeInit";
-import type { CreatePlatformUserSchema } from "src/pages/api/init/createPlatformAdminUser";
+import type { CreateInitAdminSchema } from "src/pages/api/init/createInitAdmin";
 import type { AddBillingItemSchema } from "src/pages/api/job/addBillingItem";
 import type { ChangeJobTimeLimitSchema } from "src/pages/api/job/changeJobTimeLimit";
 import type { GetBillingItemsSchema } from "src/pages/api/job/getBillingItems";
@@ -68,7 +68,7 @@ export const api = {
   getPayments: fromApi<GetPaymentsSchema>("GET", join(process.env.NEXT_PUBLIC_BASE_PATH || "", "/api/finance/payments")),
   getIcon: fromApi<GetIconSchema>("GET", join(process.env.NEXT_PUBLIC_BASE_PATH || "", "/api//icon")),
   completeInit: fromApi<CompleteInitSchema>("POST", join(process.env.NEXT_PUBLIC_BASE_PATH || "", "/api/init/completeInit")),
-  createPlatformUser: fromApi<CreatePlatformUserSchema>("POST", join(process.env.NEXT_PUBLIC_BASE_PATH || "", "/api/init/createPlatformAdminUser")),
+  createInitAdmin: fromApi<CreateInitAdminSchema>("POST", join(process.env.NEXT_PUBLIC_BASE_PATH || "", "/api/init/createInitAdmin")),
   addBillingItem: fromApi<AddBillingItemSchema>("POST", join(process.env.NEXT_PUBLIC_BASE_PATH || "", "/api/job/addBillingItem")),
   changeJobTimeLimit: fromApi<ChangeJobTimeLimitSchema>("PATCH", join(process.env.NEXT_PUBLIC_BASE_PATH || "", "/api/job/changeJobTimeLimit")),
   getBillingItems: fromApi<GetBillingItemsSchema>("GET", join(process.env.NEXT_PUBLIC_BASE_PATH || "", "/api/job/getBillingItems")),

--- a/apps/mis-web/src/pageComponents/init/InitAdminForm.tsx
+++ b/apps/mis-web/src/pageComponents/init/InitAdminForm.tsx
@@ -32,7 +32,7 @@ export const InitAdminForm: React.FC = () => {
   return (
     <Centered>
       <FormLayout maxWidth={800}>
-        <p>您可以在此创建初始管理员用户。这里添加的用户将会自动拥有<strong>平台管理员</strong>和<strong>默认租户的租户管理员权限。</strong></p>
+        <p>您可以在此创建初始管理员用户。这里添加的用户将会自动拥有<strong>平台管理员</strong>和<strong>默认租户的租户管理员权限</strong>。</p>
         <AlertContainer>
           <Alert type="warning" showIcon
             message="请确认平台管理员用户必须已经存在于认证系统，且用户的ID必须和认证系统中的用户ID保持一致。"

--- a/apps/mis-web/src/pageComponents/init/InitAdminForm.tsx
+++ b/apps/mis-web/src/pageComponents/init/InitAdminForm.tsx
@@ -12,7 +12,7 @@ const AlertContainer = styled.div`
   margin-bottom: 16px;
 `;
 
-export const PlatformAdminUserForm: React.FC = () => {
+export const InitAdminForm: React.FC = () => {
   const [form] = Form.useForm<FormFields>();
 
   const [loading, setLoading] = useState(false);
@@ -20,7 +20,7 @@ export const PlatformAdminUserForm: React.FC = () => {
     const { email, identityId, name } = await form.validateFields();
     setLoading(true);
 
-    api.createPlatformUser({ body: { email, identityId, name } })
+    api.createInitAdmin({ body: { email, identityId, name } })
       .then(() => {
         message.success("添加完成！");
         form.resetFields();
@@ -32,7 +32,7 @@ export const PlatformAdminUserForm: React.FC = () => {
   return (
     <Centered>
       <FormLayout maxWidth={800}>
-        <p>您可以在此创建初始平台管理员用户。</p>
+        <p>您可以在此创建初始管理员用户。这里添加的用户将会自动拥有<strong>平台管理员</strong>和<strong>默认租户的租户管理员权限。</strong></p>
         <AlertContainer>
           <Alert type="warning" showIcon
             message="请确认平台管理员用户必须已经存在于认证系统，且用户的ID必须和认证系统中的用户ID保持一致。"

--- a/apps/mis-web/src/pages/api/init/createInitAdmin.ts
+++ b/apps/mis-web/src/pages/api/init/createInitAdmin.ts
@@ -4,7 +4,7 @@ import { InitServiceClient } from "src/generated/server/init";
 import { getClient } from "src/utils/client";
 import { queryIfInitialized } from "src/utils/init";
 
-export interface CreatePlatformUserSchema {
+export interface CreateInitAdminSchema {
   method: "POST";
 
   body: {
@@ -26,7 +26,7 @@ export interface CreatePlatformUserSchema {
   }
 }
 
-export default route<CreatePlatformUserSchema>("CreatePlatformUserSchema", async (req) => {
+export default route<CreateInitAdminSchema>("CreateInitAdminSchema", async (req) => {
   const result = await queryIfInitialized();
 
   if (result) { return { 409: { code: "ALREADY_INITIALIZED" } }; }
@@ -35,7 +35,7 @@ export default route<CreatePlatformUserSchema>("CreatePlatformUserSchema", async
 
   const client = getClient(InitServiceClient);
 
-  await asyncClientCall(client, "createPlatformAdmin", {
+  await asyncClientCall(client, "createInitAdmin", {
     email, name, userId: identityId,
   });
 

--- a/apps/mis-web/src/pages/init.tsx
+++ b/apps/mis-web/src/pages/init.tsx
@@ -6,8 +6,8 @@ import { SSRProps } from "src/auth/server";
 import { UnifiedErrorPage } from "src/components/errorPages/UnifiedErrorPage";
 import { Centered } from "src/components/layouts";
 import { EditJobPriceTableForm } from "src/pageComponents/init/EditJobPriceTableForm";
+import { InitAdminForm } from "src/pageComponents/init/InitAdminForm";
 import { InitImportUsersForm } from "src/pageComponents/init/InitImportUsersForm";
-import { PlatformAdminUserForm } from "src/pageComponents/init/PlatformAdminUserForm";
 import { Head } from "src/utils/head";
 import { queryIfInitialized } from "src/utils/init";
 import styled from "styled-components";
@@ -69,8 +69,8 @@ export const InitSystemPage: NextPage<Props> = (props) => {
         </CompleteButtonContainer>
       </Title>
       <Tabs centered defaultActiveKey="1">
-        <Tabs.TabPane tab="创建平台管理员用户" key="1">
-          <PlatformAdminUserForm />
+        <Tabs.TabPane tab="创建初始管理员用户" key="1">
+          <InitAdminForm />
         </Tabs.TabPane>
         <Tabs.TabPane tab="导入用户" key="2">
           <InitImportUsersForm />

--- a/apps/mis-web/tsconfig.json
+++ b/apps/mis-web/tsconfig.json
@@ -30,5 +30,5 @@
     "**/*.tsx",
     "scripts/generateSchemas.ts",
     "scripts/generateClients.ts"
-, "../../libs/config/src/appConfig/clusterTexts.ts"  ]
+, "../../libs/config/src/appConfig/clusterTexts.ts", "src/pages/api/init/createInitAdmin.ts"  ]
 }

--- a/protos/server/init.proto
+++ b/protos/server/init.proto
@@ -5,12 +5,12 @@ package scow.server;
 message QuerySystemInitializedRequest {}
 message QuerySystemInitializedReply { bool initialized = 1; }
 
-message CreatePlatformAdminRequest {
+message CreateInitAdminRequest {
   string user_id = 1;
   string name = 2;
   string email = 3;
 }
-message CreatePlatformAdminReply {}
+message CreateInitAdminReply {}
 
 message CompleteInitRequest {}
 
@@ -20,8 +20,8 @@ service InitService {
   rpc QuerySystemInitialized(QuerySystemInitializedRequest)
       returns (QuerySystemInitializedReply);
 
-  rpc CreatePlatformAdmin(CreatePlatformAdminRequest)
-      returns (CreatePlatformAdminReply);
+  rpc CreateInitAdmin(CreateInitAdminRequest)
+      returns (CreateInitAdminReply);
 
   // ALREADY_EXISTS: already initialized
   rpc CompleteInit(CompleteInitRequest) returns (CompleteInitReply);


### PR DESCRIPTION
Assign users with tenant_admin role when creating init admin users. Also rename APIs and pages to avoid confusion.