### PR TITLE
feat(mis)!: replace assoc table name with slurm cluster name config

### DIFF
--- a/apps/mis-server/config/clusters/hpc00.yml
+++ b/apps/mis-server/config/clusters/hpc00.yml
@@ -4,7 +4,7 @@ slurm:
   mis:
     managerUrl: haha
     dbPassword: password
-    associationTableName: user_association
+    clusterName: pkuhpc
     scriptPath: /test/slurm.sh
   partitions:
     C032M0128G:

--- a/apps/mis-server/config/mis.yaml
+++ b/apps/mis-server/config/mis.yaml
@@ -20,5 +20,5 @@ clusters:
     slurm:
       managerUrl: haha
       dbPassword: password
-      associationTableName: user_association
+      clusterName: pkuhpc
       scriptPath: /test/slurm.sh

--- a/apps/mis-server/config/mis.yaml
+++ b/apps/mis-server/config/mis.yaml
@@ -14,11 +14,3 @@ fetchJobs:
     dbName: jobs
     tableName: jobs
 
-clusters:
-  hpc01:
-    ignore: true
-    slurm:
-      managerUrl: haha
-      dbPassword: password
-      clusterName: pkuhpc
-      scriptPath: /test/slurm.sh

--- a/apps/mis-server/scripts/slurm.sh
+++ b/apps/mis-server/scripts/slurm.sh
@@ -201,7 +201,7 @@ basePartition=($BASE_PARTITIONS)
 allPartition=("compute")
 declare -A exclPartition
 exclPartition=([compute]="20" )
-assoc_table=$ASSOC_TABLE
+assoc_table=${CLUSTER_NAME}_assoc_table
 
 addUser() #abandon !!!!!2017-09-24
 {

--- a/apps/mis-server/src/clusterops/slurm/utils/slurm.ts
+++ b/apps/mis-server/src/clusterops/slurm/utils/slurm.ts
@@ -44,7 +44,7 @@ export const executeSlurmScript = async (
   const result = await executeScript(slurmMisConfig, slurmMisConfig.scriptPath, params, {
     MYSQL_PASSWORD: slurmMisConfig.dbPassword,
     BASE_PARTITIONS: partitionsParam,
-    ASSOC_TABLE: slurmMisConfig.associationTableName,
+    CLUSTER_NAME: slurmMisConfig.clusterName,
   }, logger);
 
   return result;

--- a/docs/docs/mis/schedulers/slurm.md
+++ b/docs/docs/mis/schedulers/slurm.md
@@ -24,8 +24,8 @@ slurm:
     scriptPath: /test/slurm.sh
     # slurmdbd的数据库密码
     dbPassword: password
-    # slurm accounting功能中，保存user_association信息的数据库的表名
-    associationTableName: user_association
+    # slurm中这个集群的集群名
+    clusterName: hpc01
 ```
 
 ## 导入已有用户信息
@@ -35,7 +35,7 @@ slurm:
 把[slurm-users.py](%REPO_FILE_URL%/apps/mis-server/scripts/slurm-users.py)复制到`slurm.sh`的目录下，运行以下命令，获得一个`users.json`文件。
 
 ```bash
-MYSQL_PASSWORD={slurmdbd的数据库密码} python3 slurm-users.py
+MYSQL_PASSWORD={slurmdbd的数据库密码} CLUSTER_NAME={slurm中这个集群的集群名} python3 slurm-users.py
 ```
 
 `users.json`的文件初始数据格式如下。不存在名字的用户的初始名字为自己的ID。

--- a/libs/config/src/appConfig/cluster.ts
+++ b/libs/config/src/appConfig/cluster.ts
@@ -1,13 +1,7 @@
 import { Static, Type } from "@sinclair/typebox";
+import { SlurmMisConfigSchema } from "src/appConfig/mis";
 
 import { getDirConfig } from "../fileConfig";
-
-export const SlurmMisConfigSchema = Type.Object({
-  managerUrl: Type.String({ description: "slurm manager节点的URL" }),
-  dbPassword: Type.String({ description: "slurmdbd的数据库密码" }),
-  associationTableName: Type.String({ description: "user_association表名" }),
-  scriptPath: Type.String({ description: "slurm.sh绝对路径" }),
-}, { description: "slurm的MIS配置" });
 
 export const ClusterConfigSchema = Type.Object({
   displayName: Type.String({ description: "集群的显示名称" }),
@@ -32,7 +26,6 @@ export const ClusterConfigSchema = Type.Object({
 });
 
 export type ClusterConfigSchema = Static<typeof ClusterConfigSchema>;
-export type SlurmMisConfigSchema = Static<typeof SlurmMisConfigSchema>;
 
 const CLUSTER_CONFIG_BASE_PATH = "clusters";
 

--- a/libs/config/src/appConfig/mis.ts
+++ b/libs/config/src/appConfig/mis.ts
@@ -3,7 +3,7 @@ import { Static, Type } from "@sinclair/typebox";
 export const SlurmMisConfigSchema = Type.Object({
   managerUrl: Type.String({ description: "slurm manager节点的URL" }),
   dbPassword: Type.String({ description: "slurmdbd的数据库密码" }),
-  associationTableName: Type.String({ description: "user_association表名" }),
+  clusterName: Type.String({ description: "这个集群在slurm中的集群名字" }),
   scriptPath: Type.String({ description: "slurm.sh绝对路径" }),
 }, { description: "slurm的MIS配置" });
 


### PR DESCRIPTION
# Description

The slurm script needs the name of the table `associationTableName` containing user association information. Most users don't care about the db structure created by slurm. Actually, the value is generated by slurm with format `{cluster name}_assoc_table` where the `cluster name` is set by user. 

This PR replaces `associationTableName` config key to `clusterName` config key so that the user don't have to know the table name, but only need the cluster name in slurm.

# Migration

This is a BREAKING change. Current deployed SCOW needs the following steps to migrate to the latest version

- Replace the `slurm.sh` with the latest version
- In the `clusters/{cluster}.yaml` files, replace the `associationTableName` config with `clusterName` and set the values to the name in slurm

