### PR TITLE
feat: simplify config design

### DIFF
--- a/apps/auth/config/ui.yaml
+++ b/apps/auth/config/ui.yaml
@@ -1,0 +1,2 @@
+footer:
+  defaultText: footer default text

--- a/apps/auth/src/config/ui.ts
+++ b/apps/auth/src/config/ui.ts
@@ -1,4 +1,3 @@
-import { getConfigFromFile } from "@scow/config";
-import { UI_CONFIG_NAME, UiConfigSchema }  from "@scow/config/build/appConfig/ui";
+import { getUiConfig }  from "@scow/config/build/appConfig/ui";
 
-export const uiConfig = getConfigFromFile(UiConfigSchema, UI_CONFIG_NAME, true);
+export const uiConfig = getUiConfig();

--- a/apps/mis-server/src/config/mis.ts
+++ b/apps/mis-server/src/config/mis.ts
@@ -1,5 +1,5 @@
-import { getConfigFromFile } from "@scow/config";
-import { MIS_CONFIG_NAME, MisConfigSchema } from "@scow/config/build/appConfig/mis";
+import { getMisConfig } from "@scow/config/build/appConfig/mis";
 
-export const misConfig = getConfigFromFile(MisConfigSchema, MIS_CONFIG_NAME);
+export const misConfig = getMisConfig();
+
 

--- a/apps/mis-server/src/tasks/createBillingItems.ts
+++ b/apps/mis-server/src/tasks/createBillingItems.ts
@@ -29,7 +29,7 @@ const PriceItemsJsonSchema = Type.Record(
 
 export async function createPriceItems(em: SqlEntityManager, logger: Logger) {
 
-  const priceItems = getConfigFromFile(PriceItemsJsonSchema, "priceItems", false);
+  const priceItems = getConfigFromFile(PriceItemsJsonSchema, "priceItems");
 
   logger.info("priceItems.json content: %o", priceItems);
 

--- a/apps/mis-web/config.js
+++ b/apps/mis-web/config.js
@@ -1,10 +1,10 @@
 // @ts-check
 
 const { envConfig, getConfigFromFile, parseKeyValue, regex, str } = require("@scow/config");
-const { ClusterConfigSchema, getClusterConfigs } = require("@scow/config/build/appConfig/cluster");
-const { SlurmMisConfigSchema, MisConfigSchema, MIS_CONFIG_NAME } = require("@scow/config/build/appConfig/mis");
-const { ClusterTextsConfigName, ClusterTextsConfigSchema } = require("@scow/config/build/appConfig/clusterTexts");
-const { DEFAULT_PRIMARY_COLOR, UI_CONFIG_NAME, UiConfigSchema } = require("@scow/config/build/appConfig/ui");
+const { getClusterConfigs } = require("@scow/config/build/appConfig/cluster");
+const { getMisConfig } = require("@scow/config/build/appConfig/mis");
+const { getClusterTextsConfig } = require("@scow/config/build/appConfig/clusterTexts");
+const { DEFAULT_PRIMARY_COLOR, getUiConfig } = require("@scow/config/build/appConfig/ui");
 const { PHASE_DEVELOPMENT_SERVER, PHASE_PRODUCTION_BUILD, PHASE_PRODUCTION_SERVER } = require("next/constants");
 const { join } = require("path");
 const { fetch } = require("undici");
@@ -60,9 +60,9 @@ const buildRuntimeConfig = async (phase) => {
   const basePath = production ? undefined : join(__dirname, "config");
 
   const clusters = getClusterConfigs(basePath);
-  const clusterTexts = getConfigFromFile(ClusterTextsConfigSchema, ClusterTextsConfigName, false, basePath);
-  const uiConfig = getConfigFromFile(UiConfigSchema, UI_CONFIG_NAME, true, basePath);
-  const misConfig = getConfigFromFile(MisConfigSchema, MIS_CONFIG_NAME, false, basePath);
+  const clusterTexts = getClusterTextsConfig(basePath);
+  const uiConfig = getUiConfig(basePath);
+  const misConfig = getMisConfig(basePath);
 
   /**
    * @type {import ("./src/utils/config").ServerRuntimeConfig}

--- a/apps/mis-web/src/pages/user/partitions.tsx
+++ b/apps/mis-web/src/pages/user/partitions.tsx
@@ -1,4 +1,4 @@
-import { ClusterTexts } from "@scow/config/build/appConfig/clusterTexts";
+import type { ClusterTextsConfigSchema } from "@scow/config/build/appConfig/clusterTexts";
 import { Divider } from "antd";
 import { GetServerSideProps, NextPage } from "next";
 import { checkCookie } from "src/auth/server";
@@ -13,7 +13,7 @@ type ValueOf<T> = T[keyof T];
 
 interface Props {
   items: JobBillingTableItem[];
-  text: ValueOf<ClusterTexts> | undefined;
+  text: ValueOf<ClusterTextsConfigSchema> | undefined;
 }
 
 const ClusterCommentTitle = styled.h2`

--- a/apps/mis-web/src/utils/config.ts
+++ b/apps/mis-web/src/utils/config.ts
@@ -1,6 +1,6 @@
 import type { ClusterConfigSchema } from "@scow/config/build/appConfig/cluster";
 import { CONFIG_BASE_PATH } from "@scow/config/build/constants";
-import type { ClusterTexts } from "@scow/config/src/appConfig/clusterTexts";
+import type { ClusterTextsConfigSchema } from "@scow/config/src/appConfig/clusterTexts";
 import type { UiConfigSchema } from "@scow/config/src/appConfig/ui";
 import getConfig from "next/config";
 
@@ -13,7 +13,7 @@ export interface ServerRuntimeConfig {
   DEFAULT_PRIMARY_COLOR: string;
 
   CLUSTERS_CONFIG: {[clusterId: string]: ClusterConfigSchema};
-  CLUSTER_TEXTS_CONFIG: ClusterTexts;
+  CLUSTER_TEXTS_CONFIG: ClusterTextsConfigSchema;
 }
 
 export interface PublicRuntimeConfig {

--- a/apps/portal-web/config.js
+++ b/apps/portal-web/config.js
@@ -5,10 +5,9 @@ const { join } = require("path");
 const { homedir } = require("os");
 const { PHASE_DEVELOPMENT_SERVER, PHASE_PRODUCTION_BUILD, PHASE_PRODUCTION_SERVER, PHASE_TEST } = require("next/constants");
 
-const { getConfigFromFile } = require("@scow/config");
 const { getCapabilities } = require("@scow/lib-auth");
-const { UI_CONFIG_NAME, UiConfigSchema, DEFAULT_PRIMARY_COLOR } = require("@scow/config/build/appConfig/ui");
-const { PORTAL_CONFIG_NAME, PortalConfigSchema } = require("@scow/config/build/appConfig/portal");
+const { DEFAULT_PRIMARY_COLOR, getUiConfig } = require("@scow/config/build/appConfig/ui");
+const { getPortalConfig } = require("@scow/config/build/appConfig/portal");
 const { getAppConfigs } = require("@scow/config/build/appConfig/app");
 const { getClusterConfigs } = require("@scow/config/build/appConfig/cluster");
 const { getKeyPair, testRootUserSshLogin } = require("@scow/lib-ssh");
@@ -79,8 +78,8 @@ const buildRuntimeConfig = async (phase) => {
 
   const apps = getAppConfigs(configPath);
 
-  const uiConfig = getConfigFromFile(UiConfigSchema, UI_CONFIG_NAME, true, configPath);
-  const portalConfig = getConfigFromFile(PortalConfigSchema, PORTAL_CONFIG_NAME, false, configPath);
+  const uiConfig = getUiConfig(configPath);
+  const portalConfig = getPortalConfig(configPath);
 
   const keyPair = getKeyPair(config.SSH_PRIVATE_KEY_PATH, config.SSH_PUBLIC_KEY_PATH);
 

--- a/libs/config/src/appConfig/clusterTexts.ts
+++ b/libs/config/src/appConfig/clusterTexts.ts
@@ -1,5 +1,7 @@
 import { Static, Type } from "@sinclair/typebox";
 
+import { GetConfigFn, getConfigFromFile } from "../fileConfig";
+
 export const ClusterTextsConfigSchema = Type.Record(
   Type.String({ description: "租户，如果为default则是对所有租户" }),
   Type.Object({
@@ -11,6 +13,9 @@ export const ClusterTextsConfigSchema = Type.Record(
   ),
 );
 
-export const ClusterTextsConfigName = "clusterTexts";
+const CLUSTER_TEXTS_CONFIG_SCHEMA = "clusterTexts";
 
-export type ClusterTexts = Static<typeof ClusterTextsConfigSchema>;
+export type ClusterTextsConfigSchema = Static<typeof ClusterTextsConfigSchema>;
+
+export const getClusterTextsConfig: GetConfigFn<ClusterTextsConfigSchema> = (baseConfigPath) =>
+  getConfigFromFile(ClusterTextsConfigSchema, CLUSTER_TEXTS_CONFIG_SCHEMA, baseConfigPath);

--- a/libs/config/src/appConfig/mis.ts
+++ b/libs/config/src/appConfig/mis.ts
@@ -1,5 +1,7 @@
 import { Static, Type } from "@sinclair/typebox";
 
+import { GetConfigFn, getConfigFromFile } from "../fileConfig";
+
 export const SlurmMisConfigSchema = Type.Object({
   managerUrl: Type.String({ description: "slurm manager节点的URL" }),
   dbPassword: Type.String({ description: "slurmdbd的数据库密码" }),
@@ -62,6 +64,9 @@ export const MisConfigSchema = Type.Object({
   }),
 });
 
-export const MIS_CONFIG_NAME = "mis";
+const MIS_CONFIG_NAME = "mis";
 
+export type MisConfigSchema = Static<typeof MisConfigSchema>;
 
+export const getMisConfig: GetConfigFn<MisConfigSchema> = (baseConfigPath) =>
+  getConfigFromFile(MisConfigSchema, MIS_CONFIG_NAME, baseConfigPath);

--- a/libs/config/src/appConfig/portal.ts
+++ b/libs/config/src/appConfig/portal.ts
@@ -1,4 +1,5 @@
 import { Static, Type } from "@sinclair/typebox";
+import { GetConfigFn, getConfigFromFile } from "src/fileConfig";
 
 export const PortalConfigSchema = Type.Object({
   jobManagement: Type.Boolean({ description: "是否启动作业管理功能", default: true }),
@@ -44,6 +45,9 @@ export const PortalConfigSchema = Type.Object({
 
 });
 
-export const PORTAL_CONFIG_NAME = "portal";
+const PORTAL_CONFIG_NAME = "portal";
 
 export type PortalConfigSchema = Static<typeof PortalConfigSchema>;
+
+export const getPortalConfig: GetConfigFn<PortalConfigSchema> = (baseConfigPath) =>
+  getConfigFromFile(PortalConfigSchema, PORTAL_CONFIG_NAME, baseConfigPath);

--- a/libs/config/src/appConfig/ui.ts
+++ b/libs/config/src/appConfig/ui.ts
@@ -1,21 +1,26 @@
 import { Static, Type } from "@sinclair/typebox";
 
+import { GetConfigFn, getConfigFromFile } from "../fileConfig";
+
 export const DEFAULT_PRIMARY_COLOR = "#9B0000";
 
 export const UiConfigSchema = Type.Object({
   footer: Type.Optional(Type.Object({
     defaultText: Type.Optional(Type.String({ description: "默认的footer文本" })),
-    hostnameTextMap: Type.Optional(Type.Record(Type.String(), Type.String(), 
+    hostnameTextMap: Type.Optional(Type.Record(Type.String(), Type.String(),
       { description: "根据域名（hostname，不包括port）不同，显示在footer上的文本" })),
   })),
 
   primaryColor: Type.Optional(Type.Object({
-    defaultColor: Type.String({ description: "默认主题色", default: DEFAULT_PRIMARY_COLOR }), 
-    hostnameMap: Type.Optional(Type.Record(Type.String(), Type.String(), 
+    defaultColor: Type.String({ description: "默认主题色", default: DEFAULT_PRIMARY_COLOR }),
+    hostnameMap: Type.Optional(Type.Record(Type.String(), Type.String(),
       { description: "根据域名（hostname，不包括port）不同，应用的主题色" })),
   })),
 });
 
-export const UI_CONFIG_NAME = "ui";
+const UI_CONFIG_NAME = "ui";
 
 export type UiConfigSchema = Static<typeof UiConfigSchema>;
+
+export const getUiConfig: GetConfigFn<UiConfigSchema> = (baseConfigPath) =>
+  getConfigFromFile(UiConfigSchema, UI_CONFIG_NAME, baseConfigPath);

--- a/libs/config/src/fileConfig.ts
+++ b/libs/config/src/fileConfig.ts
@@ -20,16 +20,12 @@ const candidates = Object.entries(parsers);
  *
  * @param schema JSON Schema对象
  * @param filename 文件名，不要带扩展名
- * @param allowNotExistent 是否允许配置文件不存在
  * @param basePath 配置文件路径。当NODE_ENV === production时，默认为/etc/scow, 否则为$PWD/config
  * @returns 配置对象
+ * @throws 如果配置文件不存在，抛出异常
  */
 export function getConfigFromFile<T extends TSchema>(
-  schema: T, filename: string, allowNotExistent: true, basePath?: string): Static<T> | undefined
-export function getConfigFromFile<T extends TSchema>(
-  schema: T, filename: string, allowNotExistent?: false, basePath?: string): Static<T>
-export function getConfigFromFile<T extends TSchema>(
-  schema: T, filename: string, allowNotExistent = false,
+  schema: T, filename: string,
   basePath = process.env.NODE_ENV === "production" ? CONFIG_BASE_PATH : "config") {
 
   for (const [ext, loader] of candidates) {
@@ -40,11 +36,7 @@ export function getConfigFromFile<T extends TSchema>(
     }
   }
 
-  if (!allowNotExistent) {
-    throw new Error(`No config named ${filename} exists.`);
-  } else {
-    return undefined;
-  }
+  throw new Error(`config ${filename} doesn't exist in ${basePath}`);
 }
 
 export function getDirConfig<T extends TSchema>(
@@ -77,3 +69,6 @@ export function getDirConfig<T extends TSchema>(
     return m;
   }, {});
 }
+
+export type GetConfigFn<T> = (baseConfigPath?: string) => T;
+

--- a/libs/config/tests/fileConfig.test.ts
+++ b/libs/config/tests/fileConfig.test.ts
@@ -36,16 +36,12 @@ afterEach(() => {
   fs.rmSync(folderPath, { recursive: true });
 });
 
-function runTest(createdFiles: readonly Ext[], expectedLoaded: Ext | undefined) {
+function runTest(createdFiles: readonly Ext[], expectedLoaded: Ext) {
   createdFiles.forEach(createConfig);
 
-  const mustExists = expectedLoaded !== undefined;
-  // @ts-ignore
-  const obj = getConfigFromFile(Schema, configName, !mustExists, folderPath);
+  const obj = getConfigFromFile(Schema, configName, folderPath);
 
-  if (mustExists) {
-    expect(obj?.loaded).toBe(expectedLoaded);
-  }
+  expect(obj.loaded).toBe(expectedLoaded);
 }
 
 it.each([
@@ -63,6 +59,3 @@ it("reports error if config not exist", async () => {
   expect(() => runTest([], "yml")).toThrow();
 });
 
-it("allows non exist", async () => {
-  runTest([], undefined);
-});


### PR DESCRIPTION
Simplify config design.

- Consistent schema type naming. All schema types are the same as their respective schema object.
- All file configs have a function to get config file. Greatly simplifies importing.
- Disallow optional config. All config files are required to exists