### PR TITLE
refactor(deps): Change the slurm partition information in the cluster configuration to a list

### DIFF
--- a/apps/portal-web/config/clusters/hpc01.yaml
+++ b/apps/portal-web/config/clusters/hpc01.yaml
@@ -2,24 +2,30 @@ displayName: "hpc01Name"
 slurm:
   loginNodes: ["localhost:22222"]
   partitions:
-    compute:
-      nodes: 3
-      mem: 262144
-      cores: 32
-      gpus: 0
-      qos:
-        - "low"
-        - "normal"
-        - "high"
-      comment: 说明
-    GPU:
-      nodes: 1
-      mem: 262144
-      cores: 48
-      gpus: 8
-      qos:
-        - low
-        - normal
-        - high
-        - highest
-      comment: "说明"
+    [
+      {
+        name: compute,
+        nodes: 3,
+        mem: 262144,
+        cores: 32,
+        gpus: 0,
+        qos:
+          - "low"
+          - "normal"
+          - "high",
+        comment: 说明
+      },
+      {
+        name: GPU,
+        nodes: 1,
+        mem: 262144,
+        cores: 48,
+        gpus: 8,
+        qos:
+          - low
+          - normal
+          - high
+          - highest,
+        comment: "说明"
+      }
+    ]

--- a/apps/portal-web/config/clusters/hpc01.yaml
+++ b/apps/portal-web/config/clusters/hpc01.yaml
@@ -22,9 +22,9 @@ slurm:
         cores: 48,
         gpus: 8,
         qos:
-          - low
-          - normal
-          - high
+          - low,
+          - normal,
+          - high,
           - highest,
         comment: "说明"
       }

--- a/apps/portal-web/config/clusters/hpc01.yaml
+++ b/apps/portal-web/config/clusters/hpc01.yaml
@@ -4,28 +4,32 @@ slurm:
   partitions:
     [
       {
-        name: compute,
+        name: "compute",
         nodes: 3,
         mem: 262144,
         cores: 32,
         gpus: 0,
         qos:
-          - "low",
-          - "normal",
-          - "high",
-        comment: 说明
+          [
+            "low",
+            "normal",
+            "high"
+          ],
+        comment: "说明"
       },
       {
-        name: GPU,
+        name: "GPU",
         nodes: 1,
         mem: 262144,
         cores: 48,
         gpus: 8,
         qos:
-          - low,
-          - normal,
-          - high,
-          - highest,
+          [
+            low,
+            normal,
+            high,
+            highest
+          ],
         comment: "说明"
       }
     ]

--- a/apps/portal-web/config/clusters/hpc01.yaml
+++ b/apps/portal-web/config/clusters/hpc01.yaml
@@ -10,8 +10,8 @@ slurm:
         cores: 32,
         gpus: 0,
         qos:
-          - "low"
-          - "normal"
+          - "low",
+          - "normal",
           - "high",
         comment: 说明
       },

--- a/apps/portal-web/config/clusters/hpc02.yaml
+++ b/apps/portal-web/config/clusters/hpc02.yaml
@@ -1,19 +1,25 @@
 displayName: "hpc02Name"
 slurm:
   partitions:
-    GPU:
-      nodes: 2
-      mem: 262144
-      cores: 29
-      gpus: 8
-      qos:
-        - normal
-        - high
-        - highest
-      comment: "说明"
-    another:
-      nodes: 2
-      mem: 262144
-      cores: 29
-      gpus: 8
-      comment: "说明"
+    [
+      {
+        name: GPU,
+        nodes: 2,
+        mem: 262144,
+        cores: 29,
+        gpus: 8,
+        qos:
+          - normal
+          - high
+          - highest,
+        comment: "说明"
+      }
+      {
+        name: another,
+        nodes: 2,
+        mem: 262144,
+        cores: 29,
+        gpus: 8,
+        comment: "说明"
+      }
+    ]

--- a/apps/portal-web/config/clusters/hpc02.yaml
+++ b/apps/portal-web/config/clusters/hpc02.yaml
@@ -9,11 +9,13 @@ slurm:
         cores: 29,
         gpus: 8,
         qos:
-          - normal,
-          - high,
-          - highest,
+          [
+            normal,
+            high,
+            highest          
+          ],
         comment: "说明"
-      }
+      },
       {
         name: another,
         nodes: 2,

--- a/apps/portal-web/config/clusters/hpc02.yaml
+++ b/apps/portal-web/config/clusters/hpc02.yaml
@@ -9,8 +9,8 @@ slurm:
         cores: 29,
         gpus: 8,
         qos:
-          - normal
-          - high
+          - normal,
+          - high,
           - highest,
         comment: "说明"
       }

--- a/libs/config/src/appConfig/cluster.ts
+++ b/libs/config/src/appConfig/cluster.ts
@@ -50,7 +50,7 @@ export const ClusterListConfigSchema = Type.Object({
         }
       ),
       {
-        describe: "分区信息，分区名、内存、核心数、GPU卡数、节点数、QOS、计费项说明",
+        description: "分区信息，分区名、内存、核心数、GPU卡数、节点数、QOS、计费项说明",
         default: []
       }
     ),

--- a/libs/config/src/appConfig/cluster.ts
+++ b/libs/config/src/appConfig/cluster.ts
@@ -29,9 +29,73 @@ export type ClusterConfigSchema = Static<typeof ClusterConfigSchema>;
 
 const CLUSTER_CONFIG_BASE_PATH = "clusters";
 
+
+//将partitions内容改为列表
+export const ClusterListConfigSchema = Type.Object({
+  displayName: Type.String({ description: "集群的显示名称" }),
+  scheduler: Type.Enum({ slurm: "slurm" }, { description: "集群所使用的调度器，目前只支持slurm", default: "slurm" }),
+  slurm: Type.Object({
+    loginNodes: Type.Array(Type.String(), {  description: "集群的登录节点地址", default: []}),
+    computeNodes: Type.Array(Type.String(), { description: "集群的计算节点地址", default: []}),
+    partitions: Type.Array(
+      Type.Object(
+        {
+          name: Type.String({ description: "分区名" }),
+          mem: Type.Integer({ description: "内存，单位M" }),
+          cores: Type.Integer({ description: "核心数" }),
+          gpus: Type.Integer({ description: "GPU卡数" }),
+          nodes: Type.Integer({ description: "节点数" }),
+          qos: Type.Optional(Type.Array(Type.String({ description: "QOS" }))),
+          comment: Type.Optional(Type.String({ description: "计费项说明" })),
+        }
+      ),
+      {
+        describe: "分区信息，分区名、内存、核心数、GPU卡数、节点数、QOS、计费项说明",
+        default: []
+      }
+    ),
+    mis: Type.Optional(SlurmMisConfigSchema),
+  }),
+  misIgnore: Type.Boolean({ description: "在实际进行MIS操作时忽略这个集群", default: false }),
+});
+
+export type ClusterListConfigSchema = Static<typeof ClusterListConfigSchema>;
+
+const List2Map = (src: Record<string, ClusterListConfigSchema>): Record<string, ClusterConfigSchema> => {
+  let result: Record<string, ClusterConfigSchema> = {};
+  for (const key in src) {
+    let dir  = key;
+    let temp = src[key];
+    let partitionstemp: ClusterConfigSchema["slurm"]["partitions"] = {};
+    for(const partition of temp.slurm.partitions) {
+      partitionstemp[partition.name] = {
+        mem: partition.mem,
+        cores: partition.cores,
+        gpus: partition.gpus,
+        nodes: partition.nodes,
+        qos: partition.qos,
+        comment: partition.comment,
+      };
+    }
+    result[dir] = {
+      displayName: temp.displayName,
+      scheduler: temp.scheduler,
+      misIgnore: temp.misIgnore,
+      slurm: {
+        loginNodes: temp.slurm.loginNodes,
+        computeNodes: temp.slurm.computeNodes,
+        partitions: partitionstemp   
+      }
+    }
+  }
+  return result;
+};
+
 export const getClusterConfigs = (baseConfigPath?: string): Record<string, ClusterConfigSchema> => {
 
-  const appsConfig = getDirConfig(ClusterConfigSchema, CLUSTER_CONFIG_BASE_PATH, baseConfigPath);
+  // const appsConfig = getDirConfig(ClusterConfigSchema, CLUSTER_CONFIG_BASE_PATH, baseConfigPath);
+  let appsListConfig = getDirConfig(ClusterListConfigSchema, CLUSTER_CONFIG_BASE_PATH, baseConfigPath);
+  let appsConfig  =  List2Map(appsListConfig)
 
   Object.entries(appsConfig).forEach(([id, config]) => {
     if (!config[config.scheduler]) {


### PR DESCRIPTION
# Description

The format of the previous slurm partition information is map: 

```yaml
partitions:
    partition1's name:
        cores: ...
    partition2's name:
        cores: ...
```

However, in the actual deployment found that this map form is not so intuitive, some users do not understand this map (or dictionary) format, it is not easy to understand what exactly the key and value in the example refers to.

So, we should change the format of the slurm partition to a list:

```yaml
partitions:
    - name: partition1's name
      cores: ...
    - name: partition2's name
      cores: ...
```

This PR created a new schema  `ClusterListConfigSchema` in `libs\config\src\appConfig\cluster.ts` and achieved a new function  `List2Map` that can convert the new schema to the original schema `ClusterConfigSchema`. Finally, the `getClusterconfigs` function was refactored to receive the partition information as a list.

# Migration

This is a BREAKING change. Current deployed SCOW needs the following steps to migrate to the latest version

+ Replace the `libs\config\src\appConfig\cluster.ts`with the latest version

+ The configuration files like `xxx.yaml` in `apps\portal-web\config\clusters` for a test should change to the following format: （e.g.`hpc01.yaml`）

  ```yaml
    partitions:
      [
        {
          name: "compute",
          nodes: 3,
          mem: 262144,
          cores: 32,
          gpus: 0,
          qos:
            [
              "low",
              "normal",
              "high"
            ],
          comment: "说明"
        },
        {
          name: "GPU",
          nodes: 1,
          mem: 262144,
          cores: 48,
          gpus: 8,
          qos:
            [
              low,
              normal,
              high,
              highest
            ],
          comment: "说明"
        }
      ]
  ```
