### PR TITLE
feat(mis): don't throw when user or account is not found in source jobs

### DIFF
--- a/apps/mis-server/src/entities/JobInfo.ts
+++ b/apps/mis-server/src/entities/JobInfo.ts
@@ -1,8 +1,14 @@
 import { Entity, Index, PrimaryKey, Property } from "@mikro-orm/core";
 import { Decimal } from "@scow/lib-decimal";
 import type { OriginalJob } from "src/entities/OriginalJob";
-import { UNKNOWN_PRICE_ITEM } from "src/utils/constants";
 import { DECIMAL_DEFAULT_RAW, DecimalType } from "src/utils/decimal";
+
+const UNKNOWN_PRICE_ITEM = "UNKNOWN";
+
+export interface JobPriceInfo {
+  tenant: { billingItemId: string; price: Decimal; } | undefined;
+  account: { billingItemId: string; price: Decimal; } | undefined;
+}
 
 @Entity()
 export class JobInfo {
@@ -99,17 +105,14 @@ export class JobInfo {
 
   constructor(
     job: OriginalJob,
-    tenant: string,
-    tenantPrice: Decimal,
-    tenantBillingItemId: string,
-    accountPrice: Decimal,
-    accountBillingItemId: string,
+    tenant: string | undefined,
+    jobPriceInfo: JobPriceInfo,
   ) {
     this.biJobIndex = job.biJobIndex;
     this.idJob = job.idJob;
 
     this.account = job.account;
-    this.tenant = tenant;
+    this.tenant = tenant ?? "";
 
     this.user = job.user;
     this.partition = job.partition;
@@ -128,10 +131,10 @@ export class JobInfo {
     this.timeWait = job.timeWait;
     this.qos = job.qos;
 
-    this.tenantPrice = tenantPrice;
-    this.tenantBillingItemId = tenantBillingItemId;
-    this.accountPrice = accountPrice;
-    this.accountBillingItemId = accountBillingItemId;
+    this.tenantPrice = jobPriceInfo.tenant?.price ?? new Decimal(0);
+    this.tenantBillingItemId = jobPriceInfo.tenant?.billingItemId ?? UNKNOWN_PRICE_ITEM;
+    this.accountPrice = jobPriceInfo.account?.price ?? new Decimal(0);
+    this.accountBillingItemId = jobPriceInfo.tenant?.billingItemId ?? UNKNOWN_PRICE_ITEM;
 
     this.recordTime = job.recordTime;
     this.timeSubmit = job.timeSubmit;

--- a/apps/mis-server/src/utils/constants.ts
+++ b/apps/mis-server/src/utils/constants.ts
@@ -1,3 +1,2 @@
 export const DEFAULT_TENANT_NAME = "default";
 
-export const UNKNOWN_PRICE_ITEM = "UNKNOWN";

--- a/apps/mis-server/tests/job/JobService.test.ts
+++ b/apps/mis-server/tests/job/JobService.test.ts
@@ -9,7 +9,6 @@ import { JobPriceChange } from "src/entities/JobPriceChange";
 import { UserAccount } from "src/entities/UserAccount";
 import { JobServiceClient } from "src/generated/server/job";
 import { range } from "src/utils/array";
-import { UNKNOWN_PRICE_ITEM } from "src/utils/constants";
 import { reloadEntities } from "src/utils/orm";
 import { InitialData, insertInitialData } from "tests/data/data";
 import { dropDatabase } from "tests/data/helpers";
@@ -61,7 +60,10 @@ const mockOriginalJobData = (
   "timeWait": 132,
   "qos": "normal",
   "recordTime": new Date("2020-04-23T23:49:50.000Z"),
-}, data.tenant.name, tenantPrice, UNKNOWN_PRICE_ITEM, accountPrice, UNKNOWN_PRICE_ITEM);
+}, data.tenant.name, {
+  tenant: { billingItemId: "", price: tenantPrice },
+  account: { billingItemId: "", price: accountPrice },
+});
 
 function createClient() {
   return new JobServiceClient(server.serverAddress, ChannelCredentials.createInsecure());

--- a/apps/mis-server/tests/job/billingItems.test.ts
+++ b/apps/mis-server/tests/job/billingItems.test.ts
@@ -205,15 +205,15 @@ it("calculates price", async () => {
   // select json_object('biJobIndex', bi_job_index, 'cluster', cluster, 'partition', `partition`, 'qos', qos, 'timeUsed', time_used, 'cpusAlloc', cpus_alloc, 'gpu', gpu, 'memReq', mem_req, 'memAlloc', mem_alloc, 'price', price) from job_info where cluster="未名生科一号" limit 20;
   const testData = (await import("./testData.json")).default;
 
-  const wrongPrices = [] as { biJobIndex: number; tenantPrice: { expected: number; actual: number }; accountPrice: { expected: number; actual: number } }[];
+  const wrongPrices = [] as { biJobIndex: number; tenantPrice: { expected: number; actual: number | undefined }; accountPrice: { expected: number; actual: number | undefined } }[];
 
   testData.forEach((t) => {
     const price = calculateJobPrice(t, priceMap.getPriceItem, server.logger);
-    if (price.tenant.price.toNumber() !== t.tenantPrice || price.account.price.toNumber() !== t.accountPrice) {
+    if (price.tenant?.price.toNumber() !== t.tenantPrice || price.account?.price.toNumber() !== t.accountPrice) {
       wrongPrices.push({
         biJobIndex: t.biJobIndex,
-        tenantPrice: { expected: t.tenantPrice, actual: price.tenant.price.toNumber() },
-        accountPrice: { expected: t.accountPrice, actual: price.account.price.toNumber() },
+        tenantPrice: { expected: t.tenantPrice, actual: price.tenant?.price.toNumber() },
+        accountPrice: { expected: t.accountPrice, actual: price.account?.price.toNumber() },
       });
     }
   });

--- a/apps/mis-server/tests/job/fetchJobs.test.ts
+++ b/apps/mis-server/tests/job/fetchJobs.test.ts
@@ -32,7 +32,7 @@ beforeEach(async () => {
 
   // insert raw job table info data
   jobTableOrm = await createSourceDbOrm(server.logger);
-  const jobsData = testData.map(({ tenantPrice, accountPrice, ...rest }) => {
+  const jobsData = testData.map(({ tenantPrice, accountPrice, tenant, ...rest }) => {
     const job = new OriginalJob();
     Object.assign(job, rest);
     return job;

--- a/apps/mis-server/tests/job/testData.json
+++ b/apps/mis-server/tests/job/testData.json
@@ -943,5 +943,32 @@
     "accountPrice": 0,
     "tenantPrice": 0,
     "nodelist": ""
+  },
+  {
+    "gpu": 0,
+    "qos": "normal",
+    "memReq": 2250,
+    "cluster": "hpc01",
+    "memAlloc": 2250,
+    "timeUsed": 0,
+    "cpusAlloc": 1,
+    "partition": "compute",
+    "biJobIndex": 6623,
+    "account": "hpca",
+    "user": "not-exist-user",
+    "timeEnd": "2022-01-13T03:19:50.715Z",
+    "timeSubmit": "2022-01-13T03:19:50.715Z",
+    "timeStart": "2022-01-13T03:19:50.715Z",
+    "idJob": 0,
+    "timeWait": 0,
+    "timelimit": 0,
+    "nodesAlloc": 0,
+    "nodesReq": 0,
+    "cpusReq": 0,
+    "jobName": "test",
+    "tenant": "default",
+    "accountPrice": 0,
+    "tenantPrice": 0,
+    "nodelist": ""
   }
 ]


### PR DESCRIPTION
Don't throw when source jobs contain users and accounts that do not exist in scow db. For those jobs, the tenant is "", the account and tenant prices are both zero, and the job price item id is UNKNOWN.