### PR TITLE
add extra slurm params when running interactive apps

### DIFF
--- a/apps/portal-web/config/apps/vscode.yml
+++ b/apps/portal-web/config/apps/vscode.yml
@@ -2,6 +2,10 @@ id: vscode
 name: VSCode
 type: web
 
+slurm:
+  options:
+    - "-X node[1-2]"
+
 web:
   beforeScript: |
     export PORT=$(get_port)

--- a/apps/portal-web/src/clusterops/slurm/app.ts
+++ b/apps/portal-web/src/clusterops/slurm/app.ts
@@ -98,6 +98,7 @@ export const slurmAppOps = (cluster: string): AppOps => {
             partition: partition,
             workingDirectory,
             qos: qos,
+            otherOptions: appConfig.slurm?.options,
           });
 
           return await submitAndWriteMetadata(script, { SERVER_SESSION_INFO });
@@ -117,6 +118,7 @@ export const slurmAppOps = (cluster: string): AppOps => {
             workingDirectory,
             qos: qos,
             output: VNC_OUTPUT_FILE,
+            otherOptions: appConfig.slurm?.options,
           });
 
           return await submitAndWriteMetadata(script, { VNC_SESSION_INFO, VNCSERVER_BIN_PATH });

--- a/apps/portal-web/src/clusterops/slurm/bl/submitJob.ts
+++ b/apps/portal-web/src/clusterops/slurm/bl/submitJob.ts
@@ -22,11 +22,12 @@ export interface JobMetadata {
 
 export function generateJobScript(jobInfo: NewJobInfo & {
   output?: string;
+  otherOptions?: string[];
 }) {
   const {
     jobName, account, coreCount, maxTime, nodeCount,
     partition, qos, command, workingDirectory,
-    output, 
+    output, otherOptions,
   } = jobInfo;
   let script = "#!/bin/bash\n";
 
@@ -44,6 +45,11 @@ export function generateJobScript(jobInfo: NewJobInfo & {
   append("--chdir=" + workingDirectory);
   if (output) {
     append("--output=" + output);
+  }
+  if (otherOptions) {
+    otherOptions.forEach((opt) => {
+      append(opt);
+    });
   }
 
 

--- a/docs/docs/portal/apps/configure-vnc-app.md
+++ b/docs/docs/portal/apps/configure-vnc-app.md
@@ -28,6 +28,11 @@ name: emacs
 # 指定应用类型为vnc
 type: vnc
 
+# slurm配置
+slurm:
+  options:
+     - "-X node[1-2]"
+
 # VNC应用的配置
 vnc: 
 

--- a/docs/docs/portal/apps/configure-web-app.md
+++ b/docs/docs/portal/apps/configure-web-app.md
@@ -25,6 +25,11 @@ name: VSCode
 # 指定应用类型为web
 type: web
 
+# slurm配置
+slurm:
+  options:
+     - "-X node[1-2]"
+
 # Web应用的配置
 web:
 

--- a/libs/config/src/appConfig/app.ts
+++ b/libs/config/src/appConfig/app.ts
@@ -32,7 +32,10 @@ export const VncAppConfigSchema = Type.Object({
 export type VncAppConfigSchema = Static<typeof VncAppConfigSchema>;
 
 export const SlurmConfigSchema = Type.Object({
-  options: Type.Array(Type.String(), { description:"运行slurm脚本时可添加的选项" }),
+  options: Type.Array(
+    Type.String({ description: "sbatch选项" }), 
+    { description:"运行slurm脚本时可添加的选项" },
+  ),
 });
 
 export type SlurmConfigSchema = Static<typeof SlurmConfigSchema>;

--- a/libs/config/src/appConfig/app.ts
+++ b/libs/config/src/appConfig/app.ts
@@ -31,9 +31,16 @@ export const VncAppConfigSchema = Type.Object({
 
 export type VncAppConfigSchema = Static<typeof VncAppConfigSchema>;
 
+export const SlurmConfigSchema = Type.Object({
+  options: Type.Array(Type.String(), { description:"运行slurm脚本时可添加的选项" }),
+});
+
+export type SlurmConfigSchema = Static<typeof SlurmConfigSchema>;
+
 export const AppConfigSchema = Type.Object({
   name: Type.String({ description: "App名" }),
   type: Type.Enum(AppType, { description: "应用类型" }),
+  slurm: Type.Optional(SlurmConfigSchema), 
   web: Type.Optional(WebAppConfigSchema),
   vnc: Type.Optional(VncAppConfigSchema),
 });


### PR DESCRIPTION
# new feature
Manager can add extra slurm params when submitting an interactive job.
# how to use
Add an option named `slurm.options` in `config/apps/app1.yml`
```yml
id: emacs

name: emacs

type: vnc

# new option
slurm:
  options:
     - "-X node[1-2]"

vnc: 

  xstartup: |
    emacs -mm
```