### PR TITLE
fix(portal): allow different homedir paths for the same user on different clusters

### DIFF
--- a/apps/auth/tests/ssh.test.ts
+++ b/apps/auth/tests/ssh.test.ts
@@ -1,11 +1,12 @@
 process.env.AUTH_TYPE = "ssh";
 
 import { FastifyInstance } from "fastify";
+import os from "os";
 import { buildApp } from "src/app";
 import { createFormData } from "tests/utils";
 
-const username = "test";
-const password = "test";
+const username = os.userInfo().username;
+const password = username;
 
 let server: FastifyInstance;
 
@@ -19,7 +20,7 @@ afterEach(async () => {
   await server.close();
 });
 
-it.only("logs in to the ssh login", async () => {
+it("logs in to the ssh login", async () => {
 
   const callbackUrl = "/callback";
 

--- a/apps/portal-web/README.md
+++ b/apps/portal-web/README.md
@@ -1,12 +1,14 @@
 # scow Web
 
-# 本地测试文件管理功能
+# 开发和测试环境下的文件管理功能
 
-可以直接在本地SSH连接localhost测试文件管理功能。
+在开发和测试环境下，hpc01集群的登录节点设置为localhost:22222，hpc02集群为localhost:22。
 
-确保本地的sshd服务已启动。
+如果在本地22端口启动sshd服务，那么通过hpc02集群的文件管理功能可以直接管理本地文件。
 
 ```bash
-# 在WSL下
+# 在WSL下启动sshd服务，sshd服务将会在22端口启动
 sudo /usr/bin/sshd
 ```
+
+`pnpm devenv`将会在本地22222端口启动一个单独的ssh服务器用于测试。通过hpc01集群的文件管理可以管理这个SSH服务器的文件。

--- a/apps/portal-web/config.js
+++ b/apps/portal-web/config.js
@@ -12,6 +12,7 @@ const { getAppConfigs } = require("@scow/config/build/appConfig/app");
 const { getClusterConfigs } = require("@scow/config/build/appConfig/cluster");
 const { getKeyPair, testRootUserSshLogin } = require("@scow/lib-ssh");
 const pino = require("pino");
+const os = require("os");
 
 /**
  * Get auth capabilities
@@ -39,8 +40,6 @@ const specs = {
   SSH_PRIVATE_KEY_PATH: str({ desc: "SSH私钥路径", default: join(homedir(), ".ssh", "id_rsa") }),
   SSH_PUBLIC_KEY_PATH: str({ desc: "SSH公钥路径", default: join(homedir(), ".ssh", "id_rsa.pub") }),
 
-  MOCK_USER_ID: str({ desc: "覆盖已登录用户的用户ID", default: undefined }),
-
   PROXY_BASE_PATH: str({ desc: "网关的代理路径。相对于整个系统的base path。", default: "/proxy" }),
 
   MIS_DEPLOYED: bool({ desc: "是否部署了管理系统", default: false }),
@@ -66,7 +65,6 @@ const buildRuntimeConfig = async (phase) => {
   if (dev) {
     require("dotenv").config({ path: "env/.env.dev" });
   }
-
 
   // reload config after envs are applied
   const config = envConfig(specs, process.env);
@@ -112,7 +110,8 @@ const buildRuntimeConfig = async (phase) => {
     PORTAL_CONFIG: portalConfig,
     DEFAULT_PRIMARY_COLOR,
     APPS: apps,
-    MOCK_USER_ID: config.MOCK_USER_ID,
+    // use os username in test
+    MOCK_USER_ID: process.env.NODE_ENV === "test" ? os.userInfo().username : undefined,
     UI_CONFIG: uiConfig,
     LOGIN_NODES: parseKeyValue(config.LOGIN_NODES),
   };

--- a/apps/portal-web/config/clusters/hpc02.yaml
+++ b/apps/portal-web/config/clusters/hpc02.yaml
@@ -1,5 +1,7 @@
 displayName: hpc02Name
 slurm:
+  loginNodes:
+    - localhost:22
   partitions:
       - name: GPU
         nodes: 2
@@ -9,7 +11,7 @@ slurm:
         qos:
           - normal
           - high
-          - highest         
+          - highest
         comment: 说明
 
       - name: another

--- a/apps/portal-web/env/.env.test
+++ b/apps/portal-web/env/.env.test
@@ -1,2 +1,1 @@
 MIS_URL=/admin
-MOCK_USER_ID=test

--- a/apps/portal-web/src/pages/api/file/getHome.ts
+++ b/apps/portal-web/src/pages/api/file/getHome.ts
@@ -1,6 +1,4 @@
 import { sftpRealPath } from "@scow/lib-ssh";
-import os from "os";
-import { USE_MOCK } from "src/apis/useMock";
 import { authenticate } from "src/auth/server";
 import { route } from "src/utils/route";
 import { getClusterLoginNode, sshConnect } from "src/utils/ssh";
@@ -21,11 +19,6 @@ export interface GetHomeDirectorySchema {
 const auth = authenticate(() => true);
 
 export default route<GetHomeDirectorySchema>("GetHomeDirectorySchema", async (req, res) => {
-
-
-  if (USE_MOCK) {
-    return { 200: { path: os.homedir() } };
-  }
 
   const info = await auth(req, res);
 

--- a/apps/portal-web/src/pages/files/[cluster]/[[...path]].tsx
+++ b/apps/portal-web/src/pages/files/[cluster]/[[...path]].tsx
@@ -27,18 +27,12 @@ export const FileManagerPage: NextPage = requireAuth(() => true)(() => {
     router.push(`/files/${cluster}/${homePathMemo.current[cluster]}`);
   };
 
-  // if cluster changes, go to home dir
-  useEffect(() => {
-    toHomeDir();
-  }, [cluster]);
-
-
-  // if accessing homedir, find the homedir and go to it
+  // if cluster changes and accesses homedir, find the homedir and go to it
   useEffect(() => {
     if (pathParts && pathParts.length === 1 && pathParts[0] === "~") {
       toHomeDir();
     }
-  }, [fullPath]);
+  }, [cluster, fullPath]);
 
   return (
     <>

--- a/apps/portal-web/src/pages/files/[cluster]/[[...path]].tsx
+++ b/apps/portal-web/src/pages/files/[cluster]/[[...path]].tsx
@@ -17,19 +17,26 @@ export const FileManagerPage: NextPage = requireAuth(() => true)(() => {
     ? "~"
     : "/" + (pathParts?.join("/") ?? "");
 
-  const homePathMemo = useRef<string | undefined>(undefined);
+  const homePathMemo = useRef({} as Record<string, string>);
 
-  const getHomePath = async () => {
-    return homePathMemo.current
-    ?? (homePathMemo.current = await api.getHomeDirectory({ query: { cluster } }).then((x) => x.path));
+  const toHomeDir = async () => {
+    if (!homePathMemo.current[cluster]) {
+      homePathMemo.current[cluster] = await api.getHomeDirectory({ query: { cluster } }).then((x) => x.path);
+    }
+
+    router.push(`/files/${cluster}/${homePathMemo.current[cluster]}`);
   };
 
+  // if cluster changes, go to home dir
+  useEffect(() => {
+    toHomeDir();
+  }, [cluster]);
 
+
+  // if accessing homedir, find the homedir and go to it
   useEffect(() => {
     if (pathParts && pathParts.length === 1 && pathParts[0] === "~") {
-      getHomePath().then((path) => {
-        router.push(`/files/${cluster}/${path}`);
-      });
+      toHomeDir();
     }
   }, [fullPath]);
 

--- a/apps/portal-web/tests/file/utils.ts
+++ b/apps/portal-web/tests/file/utils.ts
@@ -3,6 +3,7 @@ import { randomBytes } from "crypto";
 import FormData from "form-data";
 import { createMocks, RequestOptions } from "node-mocks-http";
 import { NodeSSH } from "node-ssh";
+import os from "os";
 import path from "path";
 import pino from "pino";
 import { TOKEN_KEY } from "src/auth/cookie";
@@ -10,7 +11,7 @@ import { runtimeConfig } from "src/utils/config";
 import { SFTPWrapper } from "ssh2";
 
 const target = "localhost:22222";
-const user = "test";
+const user = os.userInfo().username;
 export const CLUSTER = "hpc01";
 export const TEST_COOKIE = { [TOKEN_KEY]: "123" };
 

--- a/dev/docker-compose.dev.yml
+++ b/dev/docker-compose.dev.yml
@@ -31,9 +31,9 @@ services:
     environment:
       - PUID=1000
       - PGID=1000
-      - USER_NAME=test
+      - USER_NAME=$USER
       - PASSWORD_ACCESS=true
-      - USER_PASSWORD=test
+      - USER_PASSWORD=$USER
       - PUBLIC_KEY_FILE=/id_rsa.pub
     volumes:
       - ./ssh-server/custom-cont-init.d:/config/custom-cont-init.d

--- a/docs/docs/refs/env/portal-web.md
+++ b/docs/docs/refs/env/portal-web.md
@@ -17,7 +17,6 @@ title: "portal-web"
 |`LOGIN_NODES`|字符串|集群的登录节点。将会覆写配置文件。格式：集群ID=登录节点,集群ID=登录节点||
 |`SSH_PRIVATE_KEY_PATH`|字符串|SSH私钥路径|~/.ssh/id_rsa|
 |`SSH_PUBLIC_KEY_PATH`|字符串|SSH公钥路径|~/.ssh/id_rsa.pub|
-|`MOCK_USER_ID`|字符串|覆盖已登录用户的用户ID|不设置|
 |`PROXY_BASE_PATH`|字符串|网关的代理路径。相对于整个系统的base path。|/proxy|
 |`MIS_DEPLOYED`|布尔值|是否部署了管理系统|false|
 |`MIS_URL`|字符串|如果部署了管理系统，设置URL或者路径。相对于整个系统的base path。将会覆盖配置文件。空字符串等价于未部署管理系统||


### PR DESCRIPTION
Different clusters might have different homedir path for the same user. This PR

- redirects to home dir when cluster is changed, and
- use the homedir path for the cluster

This PR also changes the test ssh server to use the same username as the host os username instead of "test".