### PR TITLE
feat(portal): add error messages when copy or move fails

### DIFF
--- a/apps/portal-web/tests/file/copy.test.ts
+++ b/apps/portal-web/tests/file/copy.test.ts
@@ -63,6 +63,7 @@ it("returns error if target dir contains a dir with the same name as the origina
 
   await sftpMkdir(server.sftp)(actualPath(sourceFolder));
   await createFile(server.sftp, actualPath(join(sourceFolder, containingFile)));
+  await sftpMkdir(server.sftp)(actualPath(targetFolder));
   await sftpMkdir(server.sftp)(actualPath(join(targetFolder, containingFile)));
 
   const { res } = await call(copyFileRoute, { body: {

--- a/apps/portal-web/tests/file/copy.test.ts
+++ b/apps/portal-web/tests/file/copy.test.ts
@@ -19,7 +19,7 @@ afterEach(async () => {
   await resetTestServer(server);
 });
 
-it.only("copies file", async () => {
+it("copies file", async () => {
 
   const newFileName = "newFile";
 

--- a/apps/portal-web/tests/file/mv.test.ts
+++ b/apps/portal-web/tests/file/mv.test.ts
@@ -1,4 +1,5 @@
-import { sftpExists } from "@scow/lib-ssh";
+import { sftpExists, sftpMkdir } from "@scow/lib-ssh";
+import { join } from "path";
 import moveFileRoute from "src/pages/api/file/move";
 import { actualPath, call, CLUSTER, connectToTestServer, createFile,
   createTestItems, resetTestServer, TestServer } from "tests/file/utils";
@@ -29,4 +30,23 @@ it("moves file", async () => {
 
   expect(await sftpExists(server.sftp, actualPath(fileName))).toBeFalse();
   expect(await sftpExists(server.sftp, actualPath(newFileName))).toBeTrue();
+});
+
+
+it("returns error if target dir contains a dir with the same name as the original file", async () => {
+  const sourceFolder = "newFolder";
+  const containingFile = "testfile";
+  const targetFolder = "targetFolder";
+
+  await sftpMkdir(server.sftp)(actualPath(sourceFolder));
+  await createFile(server.sftp, actualPath(join(sourceFolder, containingFile)));
+  await sftpMkdir(server.sftp)(actualPath(join(targetFolder, containingFile)));
+
+  const { res } = await call(moveFileRoute, { body: {
+    cluster: CLUSTER,
+    fromPath: actualPath(actualPath(join(sourceFolder, containingFile))),
+    toPath: actualPath(targetFolder),
+  } });
+
+  expect(res.statusCode).toBe(415);
 });

--- a/apps/portal-web/tests/file/mv.test.ts
+++ b/apps/portal-web/tests/file/mv.test.ts
@@ -40,6 +40,7 @@ it("returns error if target dir contains a dir with the same name as the origina
 
   await sftpMkdir(server.sftp)(actualPath(sourceFolder));
   await createFile(server.sftp, actualPath(join(sourceFolder, containingFile)));
+  await sftpMkdir(server.sftp)(actualPath(targetFolder));
   await sftpMkdir(server.sftp)(actualPath(join(targetFolder, containingFile)));
 
   const { res } = await call(moveFileRoute, { body: {


### PR DESCRIPTION
Add error messages when copy or move fails. Error messages only prompts out when copying or moving one file.

![image](https://user-images.githubusercontent.com/8363856/194698632-34480a37-a6c2-402e-bd85-75b7c81cc34d.png)

![image](https://user-images.githubusercontent.com/8363856/194698641-b37f7463-a765-4a8d-8fbc-7743e53569d5.png)
