### PR TITLE
fix bug: get_password function returns "password"

### DIFF
--- a/apps/portal-web/assets/slurm/server_entry.sh
+++ b/apps/portal-web/assets/slurm/server_entry.sh
@@ -5,7 +5,7 @@ function get_port {
 # $1: the length of password
 function get_password {
   local password=$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c$1)
-  echo password
+  echo $password
 }
 
 export HOST=$(hostname)


### PR DESCRIPTION
bug: get_password function returns "password" instead of a random string.