### PR TITLE
feat(mis): job table supports mysql

### DIFF
--- a/apps/mis-server/src/tasks/fetch.ts
+++ b/apps/mis-server/src/tasks/fetch.ts
@@ -21,7 +21,7 @@ export const createSourceDbOrm = async (logger: Logger) => {
     user: misConfig.fetchJobs.db.user,
     dbName: misConfig.fetchJobs.db.dbName,
     password: misConfig.fetchJobs.db.password,
-    type: "mariadb",
+    type: misConfig.fetchJobs.db.type,
     forceUndefined: true,
     logger: (msg) => logger.info(msg),
     entities: [OriginalJob],

--- a/docs/docs/mis/deployment.md
+++ b/docs/docs/mis/deployment.md
@@ -76,6 +76,9 @@ fetchJobs:
     password: jobtablepassword
     dbName: jobs
     tableName: jobs
+    # 源作业信息库使用的mariadb或者mysql
+    # 默认为mariadb
+    # type: mariadb
 
   # 周期性获取数据
   periodicFetch:

--- a/libs/config/src/appConfig/mis.ts
+++ b/libs/config/src/appConfig/mis.ts
@@ -11,6 +11,11 @@ export const SlurmMisConfigSchema = Type.Object({
 
 export type SlurmMisConfigSchema = Static<typeof SlurmMisConfigSchema>;
 
+export enum JobTableType {
+  mariadb = "mariadb",
+  mysql = "mysql",
+}
+
 export const MisConfigSchema = Type.Object({
   db: Type.Object({
     host: Type.String({ description: "数据库地址" }),
@@ -40,6 +45,7 @@ export const MisConfigSchema = Type.Object({
       password: Type.String({ description: "job_table数据库密码" }),
       dbName: Type.String({ description: "job_table数据库名" }),
       tableName: Type.String({ description: "job_table中源数据所在的表名" }),
+      type: Type.Enum(JobTableType, { description: "job_table数据库类型", default: JobTableType.mariadb }),
     }),
 
     startIndex: Type.Integer({ description: "从哪个biJobIndex开始获取数据", default: 0 }),


### PR DESCRIPTION
# Description

MIS supports fetching jobs from mysql, eliminating the need to deploy a separate mariadb only to store  export-jobs jobs.

# API Changes

Add a new property `fetchJobs.db.type` in `mis.yaml` to specify the type of job table. Acceptable values are `mysql` and `mariadb`.