### PR TITLE
feat(mis): allow to customize user id pattern

### DIFF
--- a/apps/mis-web/config.js
+++ b/apps/mis-web/config.js
@@ -96,6 +96,9 @@ const buildRuntimeConfig = async (phase) => {
     ACCOUNT_NAME_PATTERN: misConfig.accountNamePattern?.regex,
     ACCOUNT_NAME_PATTERN_MESSAGE: misConfig.accountNamePattern?.errorMessage,
 
+    USERID_PATTERN: misConfig.userIdPattern?.regex,
+    USERID_PATTERN_MESSAGE: misConfig.userIdPattern?.errorMessage,
+
     PORTAL_URL: config.PORTAL_DEPLOYED ? join(config.BASE_PATH, config.PORTAL_URL || misConfig.portalUrl || "") : undefined,
   };
 

--- a/apps/mis-web/src/pageComponents/users/CreateUserForm.tsx
+++ b/apps/mis-web/src/pageComponents/users/CreateUserForm.tsx
@@ -1,5 +1,6 @@
 import { Form, Input } from "antd";
 import React from "react";
+import { publicConfig } from "src/utils/config";
 import { confirmPasswordFormItemProps, emailRule, passwordRule } from "src/utils/form";
 
 export interface CreateUserFormFields {
@@ -24,9 +25,14 @@ export const CreateUserForm: React.FC<Props> = ({ noPassword }) => {
         label="用户ID"
         name="identityId"
         rules={[
-          { pattern: /^[a-z0-9_]+$/, message: "只能由小写英文字符、数字和下划线组成" },
           { required: true },
+          ...publicConfig.USERID_PATTERN
+            ? [{
+              pattern: new RegExp(publicConfig.USERID_PATTERN),
+              message: publicConfig.USERID_PATTERN_MESSAGE }]
+            : [],
         ]}
+
       >
         <Input placeholder="只能由小写英文字符、数字和下划线组成" />
       </Form.Item>

--- a/apps/mis-web/src/pageComponents/users/CreateUserForm.tsx
+++ b/apps/mis-web/src/pageComponents/users/CreateUserForm.tsx
@@ -34,7 +34,7 @@ export const CreateUserForm: React.FC<Props> = ({ noPassword }) => {
         ]}
 
       >
-        <Input placeholder="只能由小写英文字符、数字和下划线组成" />
+        <Input placeholder={publicConfig.USERID_PATTERN_MESSAGE} />
       </Form.Item>
       <Form.Item label="用户姓名" name="name" rules={[{ required: true }]}>
         <Input />

--- a/apps/mis-web/src/pages/api/tenant/createAccount.ts
+++ b/apps/mis-web/src/pages/api/tenant/createAccount.ts
@@ -15,7 +15,6 @@ export interface CreateAccountSchema {
   body: {
     /**
      * 账户名
-     * @pattern ^[a-z0-9_]+$
      */
     accountName: string;
     ownerId: string;

--- a/apps/mis-web/src/pages/api/users/create.ts
+++ b/apps/mis-web/src/pages/api/users/create.ts
@@ -14,9 +14,7 @@ export interface CreateUserSchema {
   body: {
     /**
      * 用户ID
-     * @pattern ^[a-z1-9_]+$
      */
-
     identityId: string;
     name: string;
     email: string;

--- a/apps/mis-web/src/pages/tenant/accounts/create.tsx
+++ b/apps/mis-web/src/pages/tenant/accounts/create.tsx
@@ -16,7 +16,6 @@ interface FormProps {
   comment: string;
 }
 
-const accountNameRegex = publicConfig.ACCOUNT_NAME_PATTERN ? new RegExp(publicConfig.ACCOUNT_NAME_PATTERN) : undefined;
 
 const CreateAccountForm: React.FC = () => {
 
@@ -51,10 +50,9 @@ const CreateAccountForm: React.FC = () => {
         label="账户名"
         rules={[
           { required: true },
-          { pattern: /^[a-z0-9_]+$/, message: "只能由小写英文字符、数字和下划线组成" },
-          ...accountNameRegex
+          ...publicConfig.ACCOUNT_NAME_PATTERN
             ? [{
-              pattern: accountNameRegex,
+              pattern: new RegExp(publicConfig.ACCOUNT_NAME_PATTERN),
               message: publicConfig.ACCOUNT_NAME_PATTERN_MESSAGE }]
             : [],
         ]}
@@ -64,7 +62,15 @@ const CreateAccountForm: React.FC = () => {
       <Form.Item
         name="ownerId"
         label="拥有者用户ID"
-        rules={[{ required: true }]}
+        rules={[
+          { required: true },
+          ...publicConfig.USERID_PATTERN
+            ? [{
+              pattern: new RegExp(publicConfig.USERID_PATTERN),
+              message: publicConfig.USERID_PATTERN_MESSAGE }]
+            : [],
+        ]}
+
       >
         <Input />
       </Form.Item>

--- a/apps/mis-web/src/utils/config.ts
+++ b/apps/mis-web/src/utils/config.ts
@@ -25,6 +25,9 @@ export interface PublicRuntimeConfig {
   ACCOUNT_NAME_PATTERN: string | undefined;
   ACCOUNT_NAME_PATTERN_MESSAGE: string | undefined;
 
+  USERID_PATTERN: string | undefined;
+  USERID_PATTERN_MESSAGE: string | undefined;
+
   PORTAL_URL: string | undefined;
 }
 

--- a/docs/docs/mis/deployment.md
+++ b/docs/docs/mis/deployment.md
@@ -98,7 +98,15 @@ predefinedChargingTypes:
   - 测试
 
 # 账户名的规则
-accountNamePattern:
+# accountNamePattern:
+  # 正则表达式
+  # regex: ""
+
+  # 出错时的消息
+  # errorMessage: ""
+
+# 用户ID的规则
+# userIdPattern:
   # 正则表达式
   # regex: ""
 

--- a/libs/config/src/appConfig/mis.ts
+++ b/libs/config/src/appConfig/mis.ts
@@ -32,6 +32,11 @@ export const MisConfigSchema = Type.Object({
     errorMessage: Type.Optional(Type.String({ description: "如果账户名不符合规则显示什么" })),
   })),
 
+  userIdPattern: Type.Optional(Type.Object({
+    regex: Type.String({ description: "用户ID的正则规则" }),
+    errorMessage: Type.Optional(Type.String({ description: "如果用户ID不符合规则显示什么" })),
+  })),
+
   fetchJobs: Type.Object({
     db: Type.Object({
       host: Type.String({ description: "job_table数据库地址" }),


### PR DESCRIPTION
# Description

Allow to customize user id using `userIdPattern` config in `mis.yaml` like account name.

Notice that this PR removes default user id rule. To use the previously default rule, use `^[a-z0-9_]+$` as `userIdPattern.regex`.

# Config Change

Add a new property `userIdPattern` in mis.yaml to specify the regex and error message for user id values.