### PR TITLE
ci: 去除上传到阿里云镜像

### DIFF
--- a/.github/workflows/test-build-publish.yaml
+++ b/.github/workflows/test-build-publish.yaml
@@ -10,8 +10,8 @@ on:
 
 env:
   GITHUB_CR: ghcr.io
-  ALIYUN_CR: registry.cn-hangzhou.aliyuncs.com
-  ALIYUN_PROJECT_NAME: scow
+  # ALIYUN_CR: registry.cn-hangzhou.aliyuncs.com
+  # ALIYUN_PROJECT_NAME: scow
 
 jobs:
   test:
@@ -111,20 +111,12 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Log in to the Aliyun CR
-        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
-        with:
-          registry: ${{ env.ALIYUN_CR }}
-          username: ${{ secrets.ALIYUN_CR_USERNAME }}
-          password: ${{ secrets.ALIYUN_CR_PASSWORD }}
-
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
         with:
           images: |
             ${{ env.GITHUB_CR }}/${{ github.repository }}/${{ matrix.name }}
-            ${{ env.ALIYUN_CR }}/${{ env.ALIYUN_PROJECT_NAME }}/${{ matrix.name }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v3


### PR DESCRIPTION
阿里云镜像库极度不稳定，而且速度相比GitHub CR没有明显优势。在CI中去除上传到阿里云镜像库。之后入股有需求的话，使用一些镜像库同步工具，把镜像从GHCR同步到国内镜像中去。

![image](https://user-images.githubusercontent.com/8363856/200237628-596a0d03-8b8b-4be5-a144-20d26f1e6de0.png)
