### PR TITLE
fix(portal-web): 修复桌面列表选择集群死循环

### DIFF
--- a/apps/portal-web/src/pageComponents/desktop/DesktopTable.tsx
+++ b/apps/portal-web/src/pageComponents/desktop/DesktopTable.tsx
@@ -35,7 +35,7 @@ export const DesktopTable: React.FC<Props> = () => {
   const { data, isLoading, reload } = useAsync({
     promiseFn: useCallback(async () => {
       // List all desktop
-      const result = await api.listDesktops({ query: { cluster: cluster.name } });
+      const result = await api.listDesktops({ query: { cluster: cluster.id } });
 
       return result.displayId.map((x) => ({ desktopId: x, addr: result.node }));
 

--- a/apps/portal-web/src/pageComponents/desktop/DesktopTable.tsx
+++ b/apps/portal-web/src/pageComponents/desktop/DesktopTable.tsx
@@ -1,7 +1,7 @@
 import { PlusOutlined } from "@ant-design/icons";
 import { Form, Table } from "antd";
 import { ColumnsType } from "antd/lib/table";
-import Router from "next/router";
+import { useRouter } from "next/router";
 import React, { useCallback } from "react";
 import { useAsync } from "react-async";
 import { api } from "src/apis";
@@ -12,7 +12,7 @@ import { PageTitle } from "src/components/PageTitle";
 import { DesktopTableActions } from "src/pageComponents/desktop/DesktopTableActions";
 import { NewDesktopTableModal } from "src/pageComponents/desktop/NewDesktopTableModal";
 import { publicConfig } from "src/utils/config";
-import { queryToString, useQuerystring } from "src/utils/querystring";
+import { queryToString } from "src/utils/querystring";
 
 const NewDesktopTableModalButton = ModalButton(NewDesktopTableModal, { type: "primary", icon: <PlusOutlined /> });
 
@@ -27,9 +27,9 @@ export type DesktopItem = {
 
 export const DesktopTable: React.FC<Props> = () => {
 
-  const qs = useQuerystring();
+  const router = useRouter();
 
-  const clusterQuery = queryToString(qs.cluster);
+  const clusterQuery = queryToString(router.query.cluster);
   const cluster = publicConfig.CLUSTERS.find((x) => x.id === clusterQuery) ?? publicConfig.CLUSTERS[0];
 
   const { data, isLoading, reload } = useAsync({
@@ -77,7 +77,7 @@ export const DesktopTable: React.FC<Props> = () => {
             <SingleClusterSelector
               value={cluster}
               onChange={(x) => {
-                Router.push({ query: { cluster: x.id } });
+                router.push({ query: { cluster: x.id } });
               }}
             />
           </Form.Item>

--- a/apps/portal-web/src/pageComponents/desktop/DesktopTable.tsx
+++ b/apps/portal-web/src/pageComponents/desktop/DesktopTable.tsx
@@ -29,16 +29,13 @@ export const DesktopTable: React.FC<Props> = () => {
 
   const qs = useQuerystring();
 
-  const clusterParam = queryToString(qs.cluster);
-  const cluster = publicConfig.CLUSTERS_CONFIG[clusterParam]
-    ? { id: clusterParam, name: publicConfig.CLUSTERS_CONFIG[clusterParam].displayName }
-    : publicConfig.CLUSTERS[0];
-
+  const clusterQuery = queryToString(qs.cluster);
+  const cluster = publicConfig.CLUSTERS.find((x) => x.id === clusterQuery) ?? publicConfig.CLUSTERS[0];
 
   const { data, isLoading, reload } = useAsync({
     promiseFn: useCallback(async () => {
       // List all desktop
-      const result = await api.listDesktops({ query: { cluster: cluster.id } });
+      const result = await api.listDesktops({ query: { cluster: cluster.name } });
 
       return result.displayId.map((x) => ({ desktopId: x, addr: result.node }));
 


### PR DESCRIPTION
是个比较傻的bug。原来的代码中，DesktopTable组件刷新时，会根据当前querystring的cluster现场构建一个cluster类型对象。每次cluster对象是不一样的，但是创建新的clusdter对象又会触发一次新的查询，刷新一次组件。这样就会进入一个死循环。