### PR TITLE
chore(mis/portal-web): 将web端对ValidateToken的调用改为调用lib-auth中的接口

### DIFF
--- a/apps/mis-web/src/auth/token.ts
+++ b/apps/mis-web/src/auth/token.ts
@@ -1,6 +1,5 @@
-import { jsonFetch } from "@ddadaal/next-typed-api-routes-runtime/lib/client";
 import { asyncClientCall } from "@ddadaal/tsgrpc-client";
-import path from "path";
+import { validateToken as valToken } from "@scow/lib-auth";
 import { MOCK_USER_INFO } from "src/apis/api.mock";
 import { USE_MOCK } from "src/apis/useMock";
 import { GetUserInfoReply, UserServiceClient } from "src/generated/server/user";
@@ -8,13 +7,6 @@ import { UserInfo } from "src/models/User";
 import { getClient } from "src/utils/client";
 import { runtimeConfig } from "src/utils/config";
 
-interface AuthValidateTokenSchema {
-  query: { token: string }
-  responses: {
-    200: UserInfo;
-    400: { code: "INVALID_TOKEN" };
-  }
-}
 
 export async function validateToken(token: string): Promise<UserInfo | undefined> {
 
@@ -22,11 +14,8 @@ export async function validateToken(token: string): Promise<UserInfo | undefined
     return MOCK_USER_INFO;
   }
 
-  const resp = await jsonFetch<AuthValidateTokenSchema>({
-    method: "GET",
-    path: path.join(runtimeConfig.AUTH_INTERNAL_URL, "/validateToken"),
-    query: { token },
-  }).catch(() => undefined);
+  const resp = await valToken(runtimeConfig.AUTH_INTERNAL_URL, token).catch(() => undefined);
+
 
   if (!resp) {
     return undefined;

--- a/apps/portal-web/src/auth/token.ts
+++ b/apps/portal-web/src/auth/token.ts
@@ -1,16 +1,7 @@
-import { jsonFetch } from "@ddadaal/next-typed-api-routes-runtime/lib/client";
-import path from "path";
+import { validateToken as valToken } from "@scow/lib-auth"; 
 import { USE_MOCK } from "src/apis/useMock";
 import { UserInfo } from "src/models/User";
 import { runtimeConfig } from "src/utils/config";
-
-interface AuthValidateTokenSchema {
-  query: { token: string }
-  responses: {
-    200: UserInfo;
-    400: { code: "INVALID_TOKEN" };
-  }
-}
 
 export async function validateToken(token: string | undefined): Promise<UserInfo | undefined> {
 
@@ -23,11 +14,7 @@ export async function validateToken(token: string | undefined): Promise<UserInfo
 
   if (!token) { return undefined; }
 
-  const resp = await jsonFetch<AuthValidateTokenSchema>({
-    method: "GET",
-    path: path.join(runtimeConfig.AUTH_INTERNAL_URL, "/validateToken"),
-    query: { token },
-  }).catch(() => undefined);
+  const resp = await valToken(runtimeConfig.AUTH_INTERNAL_URL, token).catch(() => undefined);
 
   if (!resp) {
     return undefined;


### PR DESCRIPTION
原来是通过jsonFetch的方法，需要记忆Http参数，而调用libs/auth/src/中已经实现了的ValidateToken的接口，则不再需要记忆