### PR TITLE
fix(portal): 交互式应用配置文件proxyType移动到web配置子项

### DIFF
--- a/apps/portal-server/config/apps/vscode.yml
+++ b/apps/portal-server/config/apps/vscode.yml
@@ -1,13 +1,13 @@
 id: vscode
 name: VSCode
 type: web
-proxyType: relative
 
 slurm:
   options:
     - "-x node[1-2]"
 
 web:
+  proxyType: relative
   beforeScript: |
     export PORT=$(get_port)
     export PASSWORD=$(get_password 12)

--- a/apps/portal-server/src/services/app.ts
+++ b/apps/portal-server/src/services/app.ts
@@ -1,14 +1,13 @@
 import { plugin } from "@ddadaal/tsgrpc-server";
 import { ServiceError } from "@grpc/grpc-js";
 import { Status } from "@grpc/grpc-js/build/src/constants";
-import { AppType, ProxyType } from "@scow/config/build/app";
+import { AppType } from "@scow/config/build/app";
 import { getClusterOps } from "src/clusterops";
 import { apps } from "src/config/apps";
 import {
   AppServiceServer,
   AppServiceService,
   ConnectToAppResponse,
-  ConnectToAppResponse_ProxyType,
 } from "src/generated/portal/app";
 import { clusterNotFound } from "src/utils/errors";
 
@@ -64,28 +63,28 @@ export const appServiceServer = plugin((server) => {
         throw new Error(`Unknown app type ${app.type} of app id ${reply.appId}`);
       }
 
-      let proxyType: ConnectToAppResponse["proxyType"];
-
-      switch (app.proxyType) {
-      case ProxyType.relative:
-        proxyType = ConnectToAppResponse_ProxyType.relative;
-        break;
-      case ProxyType.absolute:
-        proxyType = ConnectToAppResponse_ProxyType.absolute;
-        break;
-      case ProxyType.websocket:
-        proxyType = ConnectToAppResponse_ProxyType.websocket;
-        break;
-      default:
-        throw new Error(`Unknown proxy type ${app.proxyType} of app id ${reply.appId}`);
-      }
+      // let proxyType: ConnectToAppResponse["proxyType"];
+      //
+      // switch (app.web!.proxyType) {
+      // case ProxyType.relative:
+      //   proxyType = ConnectToAppResponse_ProxyType.relative;
+      //   break;
+      // case ProxyType.absolute:
+      //   proxyType = ConnectToAppResponse_ProxyType.absolute;
+      //   break;
+      // case ProxyType.websocket:
+      //   proxyType = ConnectToAppResponse_ProxyType.websocket;
+      //   break;
+      // default:
+      //   throw new Error(`Unknown proxy type ${app.web!.proxyType} of app id ${reply.appId}`);
+      // }
 
       return [{
         host: reply.host,
         port: reply.port,
         password: reply.password,
         appProps,
-        proxyType: proxyType,
+        proxyType: app.web!.proxyType,
       }];
     },
 

--- a/apps/portal-server/src/services/app.ts
+++ b/apps/portal-server/src/services/app.ts
@@ -84,7 +84,7 @@ export const appServiceServer = plugin((server) => {
         port: reply.port,
         password: reply.password,
         appProps,
-        proxyType: app.web!.proxyType,
+        proxyType: app.type === "web" ? app.web!.proxyType : "websocket",
       }];
     },
 

--- a/apps/portal-server/src/services/app.ts
+++ b/apps/portal-server/src/services/app.ts
@@ -56,6 +56,7 @@ export const appServiceServer = plugin((server) => {
             query: app.web!.connect.query ?? {},
             method: app.web!.connect.method,
             path: app.web!.connect.path,
+            proxyType: app.web!.proxyType,
           },
         };
         break;
@@ -84,7 +85,6 @@ export const appServiceServer = plugin((server) => {
         port: reply.port,
         password: reply.password,
         appProps,
-        proxyType: app.type === "web" ? app.web!.proxyType : "websocket",
       }];
     },
 

--- a/apps/portal-server/src/services/app.ts
+++ b/apps/portal-server/src/services/app.ts
@@ -8,6 +8,7 @@ import {
   AppServiceServer,
   AppServiceService,
   ConnectToAppResponse,
+  WebAppProps_ProxyType,
 } from "src/generated/portal/app";
 import { clusterNotFound } from "src/utils/errors";
 
@@ -56,29 +57,15 @@ export const appServiceServer = plugin((server) => {
             query: app.web!.connect.query ?? {},
             method: app.web!.connect.method,
             path: app.web!.connect.path,
-            proxyType: app.web!.proxyType,
+            proxyType: app.web!.proxyType === "absolute"
+              ? WebAppProps_ProxyType.absolute
+              : WebAppProps_ProxyType.relative,
           },
         };
         break;
       default:
         throw new Error(`Unknown app type ${app.type} of app id ${reply.appId}`);
       }
-
-      // let proxyType: ConnectToAppResponse["proxyType"];
-      //
-      // switch (app.web!.proxyType) {
-      // case ProxyType.relative:
-      //   proxyType = ConnectToAppResponse_ProxyType.relative;
-      //   break;
-      // case ProxyType.absolute:
-      //   proxyType = ConnectToAppResponse_ProxyType.absolute;
-      //   break;
-      // case ProxyType.websocket:
-      //   proxyType = ConnectToAppResponse_ProxyType.websocket;
-      //   break;
-      // default:
-      //   throw new Error(`Unknown proxy type ${app.web!.proxyType} of app id ${reply.appId}`);
-      // }
 
       return [{
         host: reply.host,

--- a/apps/portal-web/config/apps/vscode.yml
+++ b/apps/portal-web/config/apps/vscode.yml
@@ -1,13 +1,13 @@
 id: vscode
 name: VSCode
 type: web
-proxyType: relative
 
 slurm:
   options:
     - "-x node[1-2]"
 
 web:
+  proxyType: relative
   beforeScript: |
     export PORT=$(get_port)
     export PASSWORD=$(get_password 12)

--- a/apps/portal-web/src/apis/api.mock.ts
+++ b/apps/portal-web/src/apis/api.mock.ts
@@ -1,7 +1,6 @@
 import { JsonFetchResultPromiseLike } from "@ddadaal/next-typed-api-routes-runtime/lib/client";
 import { api } from "src/apis/api";
 import type { RunningJob } from "src/generated/common/job";
-import { WebAppProps_ProxyType } from "src/generated/portal/app";
 import { JobInfo } from "src/generated/portal/job";
 
 export type MockApi<TApi extends Record<
@@ -86,8 +85,8 @@ export const mockApi: MockApi<typeof api> = {
         path: "/test",
         query: { test: "!23" },
         formData: { test: "123" },
-        proxyType: WebAppProps_ProxyType.relative,
       },
+      proxyType: "relative",
     }
     : {
       host: "127.0.0.1", port: 3000, password: "123", type: "vnc",

--- a/apps/portal-web/src/apis/api.mock.ts
+++ b/apps/portal-web/src/apis/api.mock.ts
@@ -1,6 +1,7 @@
 import { JsonFetchResultPromiseLike } from "@ddadaal/next-typed-api-routes-runtime/lib/client";
 import { api } from "src/apis/api";
 import type { RunningJob } from "src/generated/common/job";
+import { WebAppProps_ProxyType } from "src/generated/portal/app";
 import { JobInfo } from "src/generated/portal/job";
 
 export type MockApi<TApi extends Record<
@@ -85,7 +86,7 @@ export const mockApi: MockApi<typeof api> = {
         path: "/test",
         query: { test: "!23" },
         formData: { test: "123" },
-        proxyType: "relative",
+        proxyType: WebAppProps_ProxyType.relative,
       },
     }
     : {

--- a/apps/portal-web/src/apis/api.mock.ts
+++ b/apps/portal-web/src/apis/api.mock.ts
@@ -85,11 +85,11 @@ export const mockApi: MockApi<typeof api> = {
         path: "/test",
         query: { test: "!23" },
         formData: { test: "123" },
+        proxyType: "relative",
       },
-      proxyType: "relative",
     }
     : {
-      host: "127.0.0.1", port: 3000, password: "123", type: "vnc", proxyType: "websocket",
+      host: "127.0.0.1", port: 3000, password: "123", type: "vnc",
     }
   ,
 

--- a/apps/portal-web/src/pageComponents/app/ConnectToAppLink.tsx
+++ b/apps/portal-web/src/pageComponents/app/ConnectToAppLink.tsx
@@ -4,7 +4,6 @@ import { join } from "path";
 import { api } from "src/apis";
 import { ClickableA } from "src/components/ClickableA";
 import type { AppSession } from "src/generated/portal/app";
-import { WebAppProps_ProxyType } from "src/generated/portal/app";
 import { Cluster, publicConfig } from "src/utils/config";
 import { openDesktop } from "src/utils/vnc";
 
@@ -23,7 +22,7 @@ export const ConnectTopAppLink: React.FC<Props> = ({
       .httpError(409, () => { message.error("此应用目前无法连接"); });
 
     if (reply.type === "web") {
-      const { connect, host, password, port } = reply;
+      const { connect, host, password, port, proxyType } = reply;
       const interpolatedValues = { HOST: host, PASSWORD: password, PORT: port };
       const path = parsePlaceholder(connect.path, interpolatedValues);
 
@@ -37,8 +36,7 @@ export const ConnectTopAppLink: React.FC<Props> = ({
       const query = connect.query ? interpolateValues(connect.query) : {};
       const formData = connect.formData ? interpolateValues(connect.formData) : undefined;
 
-      const proxyType = connect.proxyType;
-      const proxyBasePath = proxyType === WebAppProps_ProxyType.relative
+      const proxyBasePath = proxyType === "relative"
         ? publicConfig.RPROXY_BASE_PATH
         : publicConfig.PROXY_BASE_PATH;
 

--- a/apps/portal-web/src/pageComponents/app/ConnectToAppLink.tsx
+++ b/apps/portal-web/src/pageComponents/app/ConnectToAppLink.tsx
@@ -4,6 +4,7 @@ import { join } from "path";
 import { api } from "src/apis";
 import { ClickableA } from "src/components/ClickableA";
 import type { AppSession } from "src/generated/portal/app";
+import { WebAppProps_ProxyType } from "src/generated/portal/app";
 import { Cluster, publicConfig } from "src/utils/config";
 import { openDesktop } from "src/utils/vnc";
 
@@ -37,7 +38,9 @@ export const ConnectTopAppLink: React.FC<Props> = ({
       const formData = connect.formData ? interpolateValues(connect.formData) : undefined;
 
       const proxyType = connect.proxyType;
-      const proxyBasePath = proxyType === "relative" ? publicConfig.RPROXY_BASE_PATH : publicConfig.PROXY_BASE_PATH;
+      const proxyBasePath = proxyType === WebAppProps_ProxyType.relative
+        ? publicConfig.RPROXY_BASE_PATH
+        : publicConfig.PROXY_BASE_PATH;
 
       const pathname = join(proxyBasePath, host, String(port), path);
 

--- a/apps/portal-web/src/pageComponents/app/ConnectToAppLink.tsx
+++ b/apps/portal-web/src/pageComponents/app/ConnectToAppLink.tsx
@@ -22,7 +22,7 @@ export const ConnectTopAppLink: React.FC<Props> = ({
       .httpError(409, () => { message.error("此应用目前无法连接"); });
 
     if (reply.type === "web") {
-      const { connect, host, password, port, proxyType } = reply;
+      const { connect, host, password, port } = reply;
       const interpolatedValues = { HOST: host, PASSWORD: password, PORT: port };
       const path = parsePlaceholder(connect.path, interpolatedValues);
 
@@ -36,6 +36,7 @@ export const ConnectTopAppLink: React.FC<Props> = ({
       const query = connect.query ? interpolateValues(connect.query) : {};
       const formData = connect.formData ? interpolateValues(connect.formData) : undefined;
 
+      const proxyType = connect.proxyType;
       const proxyBasePath = proxyType === "relative" ? publicConfig.RPROXY_BASE_PATH : publicConfig.PROXY_BASE_PATH;
 
       const pathname = join(proxyBasePath, host, String(port), path);

--- a/apps/portal-web/src/pages/api/app/connectToApp.ts
+++ b/apps/portal-web/src/pages/api/app/connectToApp.ts
@@ -1,7 +1,7 @@
 import { asyncUnaryCall } from "@ddadaal/tsgrpc-client";
 import { status } from "@grpc/grpc-js";
 import { authenticate } from "src/auth/server";
-import { AppServiceClient } from "src/generated/portal/app";
+import { AppServiceClient, WebAppProps_ProxyType } from "src/generated/portal/app";
 import { getClient } from "src/utils/client";
 import { dnsResolve } from "src/utils/dns";
 import { route } from "src/utils/route";
@@ -9,7 +9,7 @@ import { handlegRPCError } from "src/utils/server";
 
 // Cannot use ServerConnectPropsConfig from appConfig package
 export type AppConnectProps = {
-  proxyType: string;
+  proxyType: WebAppProps_ProxyType;
   method: string;
   path: string;
   query?: { [key: string]: string };

--- a/apps/portal-web/src/pages/api/app/connectToApp.ts
+++ b/apps/portal-web/src/pages/api/app/connectToApp.ts
@@ -1,7 +1,7 @@
 import { asyncUnaryCall } from "@ddadaal/tsgrpc-client";
 import { status } from "@grpc/grpc-js";
 import { authenticate } from "src/auth/server";
-import { AppServiceClient, ConnectToAppResponse_ProxyType } from "src/generated/portal/app";
+import { AppServiceClient } from "src/generated/portal/app";
 import { getClient } from "src/utils/client";
 import { dnsResolve } from "src/utils/dns";
 import { route } from "src/utils/route";
@@ -65,9 +65,7 @@ export default /* #__PURE__*/route<ConnectToAppSchema>("ConnectToAppSchema", asy
           password: x.password,
           type: "web" as const,
           connect: x.appProps.web,
-          proxyType: x.proxyType === ConnectToAppResponse_ProxyType.absolute
-            ? "absolute" : x.proxyType === ConnectToAppResponse_ProxyType.websocket
-              ? "websocket" : "relative",
+          proxyType: x.proxyType === "absolute" ? "absolute" : "relative",
         },
       };
     } else {
@@ -77,9 +75,7 @@ export default /* #__PURE__*/route<ConnectToAppSchema>("ConnectToAppSchema", asy
           port: x.port,
           password: x.password,
           type: "vnc" as const,
-          proxyType: x.proxyType === ConnectToAppResponse_ProxyType.absolute
-            ? "absolute" : x.proxyType === ConnectToAppResponse_ProxyType.websocket
-              ? "websocket" : "relative",
+          proxyType: x.proxyType === "absolute" ? "absolute" : "relative",
         },
       };
     }

--- a/apps/portal-web/src/pages/api/app/connectToApp.ts
+++ b/apps/portal-web/src/pages/api/app/connectToApp.ts
@@ -9,7 +9,6 @@ import { handlegRPCError } from "src/utils/server";
 
 // Cannot use ServerConnectPropsConfig from appConfig package
 export type AppConnectProps = {
-  proxyType: WebAppProps_ProxyType;
   method: string;
   path: string;
   query?: { [key: string]: string };
@@ -26,7 +25,8 @@ export interface ConnectToAppSchema {
 
   responses: {
     200: { host: string; port: number; password: string} & (
-      | { type: "web"; connect: AppConnectProps}
+      | { type: "web"; connect: AppConnectProps; proxyType: "relative" | "absolute";
+    }
       | { type: "vnc"; }
     );
 
@@ -66,6 +66,9 @@ export default /* #__PURE__*/route<ConnectToAppSchema>("ConnectToAppSchema", asy
           password: x.password,
           type: "web" as const,
           connect: x.appProps.web,
+          proxyType: x.appProps.web.proxyType === WebAppProps_ProxyType.relative
+            ? "relative"
+            : "absolute",
         },
       };
     } else {

--- a/apps/portal-web/src/pages/api/app/connectToApp.ts
+++ b/apps/portal-web/src/pages/api/app/connectToApp.ts
@@ -9,6 +9,7 @@ import { handlegRPCError } from "src/utils/server";
 
 // Cannot use ServerConnectPropsConfig from appConfig package
 export type AppConnectProps = {
+  proxyType: string;
   method: string;
   path: string;
   query?: { [key: string]: string };
@@ -24,8 +25,8 @@ export interface ConnectToAppSchema {
   }
 
   responses: {
-    200: { host: string; port: number; password: string; proxyType: "relative" | "absolute" | "websocket" } & (
-      | { type: "web"; connect: AppConnectProps }
+    200: { host: string; port: number; password: string} & (
+      | { type: "web"; connect: AppConnectProps}
       | { type: "vnc"; }
     );
 
@@ -65,7 +66,6 @@ export default /* #__PURE__*/route<ConnectToAppSchema>("ConnectToAppSchema", asy
           password: x.password,
           type: "web" as const,
           connect: x.appProps.web,
-          proxyType: x.proxyType === "absolute" ? "absolute" : "relative",
         },
       };
     } else {
@@ -75,7 +75,6 @@ export default /* #__PURE__*/route<ConnectToAppSchema>("ConnectToAppSchema", asy
           port: x.port,
           password: x.password,
           type: "vnc" as const,
-          proxyType: x.proxyType === "absolute" ? "absolute" : "relative",
         },
       };
     }

--- a/docs/docs/portal/apps/configure-jupyter-app.md
+++ b/docs/docs/portal/apps/configure-jupyter-app.md
@@ -25,11 +25,10 @@ name: jupyter
 # 指定应用类型为web
 type: web
 
-# 指定反向代理类型
-proxyType: absolute
-
 # Web应用的配置
 web:
+  # 指定反向代理类型
+  proxyType: absolute
   # 准备脚本
   beforeScript: |
     export PORT=$(get_port)

--- a/docs/docs/portal/apps/configure-vscode-app.md
+++ b/docs/docs/portal/apps/configure-vscode-app.md
@@ -25,12 +25,12 @@ name: VSCode
 # 指定应用类型为web
 type: web
 
-# 指定反向代理类型
-proxyType: relative
-
 # Web应用的配置
 web:
 
+  # 指定反向代理类型
+  proxyType: relative
+  
   # 准备脚本
   beforeScript: |
     export PORT=$(get_port)

--- a/docs/docs/portal/apps/configure-web-app.md
+++ b/docs/docs/portal/apps/configure-web-app.md
@@ -66,23 +66,23 @@ web:
 
 对于web类型的应用，需要配置`proxyType`。不同的交互式应用使用了不同的nginx proxy方式，通过配置`proxyType`，可以允许应用携带不同类型的uri到后端计算节点。
 
-`proxyType`可以配置为"relative"或者"absolute"，VSCode配置为"relative"，Jupyter配置为"absolute"。
+`proxyType`可以配置为`relative`或者`absolute`。
 
-- 如果设置成"absolute"，会把完整URL请求路径反向代理到给定的主机和端口。比如访问以下地址：
+- 如果设置成`absolute`，会把完整URL请求路径反向代理到给定的主机和端口。比如访问以下地址：
   
-      https://hpc.pku.edu/proxy/192.168.220.133/7383/index.html
+  > https://hpc.pku.edu/proxy/192.168.220.133/7383/index.html
 
   以下URL请求将会被发送给计算节点`192.168.220.133`的`7383`端口。
 
-      /proxy/192.168.220.133/7383/index.html
+  > /proxy/192.168.220.133/7383/index.html
   
-- 如果设置成"relative"，只使用URL请求路径的路径部分将请求反向代理到给定的主机和端口。比如访问以下地址：
-      
-      https://hpc.pku.edu/rproxy/192.168.220.133/4253/index.html
+- 如果设置成`relative`，只使用URL请求路径的路径部分将请求反向代理到给定的主机和端口。比如访问以下地址：
+
+  > https://hpc.pku.edu/rproxy/192.168.220.133/4253/index.html
 
   以下URL请求将会被发送给计算节点`192.168.220.133`的`4253`端口。
 
-      /index.html
+  > /index.html
 
 
 ### `beforeScript`和`script`

--- a/docs/docs/portal/apps/configure-web-app.md
+++ b/docs/docs/portal/apps/configure-web-app.md
@@ -25,8 +25,6 @@ name: VSCode
 # 指定应用类型为web
 type: web
 
-# 指定反向代理类型
-proxyType: relative
 
 # slurm配置
 slurm:
@@ -35,6 +33,9 @@ slurm:
 
 # Web应用的配置
 web:
+
+  # 指定反向代理类型
+  proxyType: relative
 
   # 准备脚本
   beforeScript: |
@@ -60,6 +61,29 @@ web:
 ```
 
 ## 配置解释
+
+### `proxyType`
+
+对于web类型的应用，需要配置`proxyType`。不同的交互式应用使用了不同的nginx proxy方式，通过配置`proxyType`，可以允许应用携带不同类型的uri到后端计算节点。
+
+`proxyType`可以配置为"relative"或者"absolute"，VSCode配置为"relative"，Jupyter配置为"absolute"。
+
+- 如果设置成"absolute"，会把完整URL请求路径反向代理到给定的主机和端口。比如访问以下地址：
+  
+      https://hpc.pku.edu/proxy/192.168.220.133/7383/index.html
+
+  以下URL请求将会被发送给计算节点`192.168.220.133`的`7383`端口。
+
+      /proxy/192.168.220.133/7383/index.html
+  
+- 如果设置成"relative"，只使用URL请求路径的路径部分将请求反向代理到给定的主机和端口。比如访问以下地址：
+      
+      https://hpc.pku.edu/rproxy/192.168.220.133/4253/index.html
+
+  以下URL请求将会被发送给计算节点`192.168.220.133`的`4253`端口。
+
+      /index.html
+
 
 ### `beforeScript`和`script`
 

--- a/libs/config/src/app.ts
+++ b/libs/config/src/app.ts
@@ -17,13 +17,8 @@ export enum AppType {
   vnc = "vnc"
 }
 
-export enum ProxyType {
-  relative = "relative",
-  absolute = "absolute",
-  websocket = "websocket"
-}
-
 export const WebAppConfigSchema = Type.Object({
+  proxyType: Type.Enum({ relative: "relative", absolute: "absolute" }, { description: "proxy 类型" }),
   beforeScript: Type.String({ description: "启动应用之前的准备命令。具体参考文档" }),
   script: Type.String({ description: "启动应用的命令。可以使用beforeScript中定义的变量" }),
   connect: AppConnectPropsSchema,
@@ -52,7 +47,6 @@ export const AppConfigSchema = Type.Object({
   slurm: Type.Optional(SlurmConfigSchema),
   web: Type.Optional(WebAppConfigSchema),
   vnc: Type.Optional(VncAppConfigSchema),
-  proxyType: Type.Enum(ProxyType, { description: "proxy 类型" }),
 });
 
 export type AppConfigSchema = Static<typeof AppConfigSchema>;

--- a/protos/portal/app.proto
+++ b/protos/portal/app.proto
@@ -15,7 +15,11 @@ message WebAppProps {
   string path = 2;
   map<string, string> query = 3;
   map<string, string> form_data = 4;
-  string proxyType = 5;
+  enum ProxyType {
+    relative = 0;
+    absolute = 1;
+  }
+  ProxyType proxyType = 5;
 }
 
 message VncAppProps {}

--- a/protos/portal/app.proto
+++ b/protos/portal/app.proto
@@ -29,12 +29,7 @@ message ConnectToAppResponse {
     WebAppProps web = 4;
     VncAppProps vnc = 5;
   }
-  enum ProxyType {
-    relative = 0;
-    absolute = 1;
-    websocket = 2;
-  }
-  ProxyType proxyType = 6;
+  string proxyType = 6;
 }
 
 message CreateAppSessionRequest {

--- a/protos/portal/app.proto
+++ b/protos/portal/app.proto
@@ -15,6 +15,7 @@ message WebAppProps {
   string path = 2;
   map<string, string> query = 3;
   map<string, string> form_data = 4;
+  string proxyType = 5;
 }
 
 message VncAppProps {}
@@ -29,7 +30,6 @@ message ConnectToAppResponse {
     WebAppProps web = 4;
     VncAppProps vnc = 5;
   }
-  string proxyType = 6;
 }
 
 message CreateAppSessionRequest {


### PR DESCRIPTION
# 不兼容的更改
在交互式应用的配置文件中，在web配置子项指定proxyType，取值为relative和absolute。当type为vnc时，proxyType不设置