### PR TITLE
feat(libs): 在lib-auth中实现了修改密码的api的接口，并在web端调用

### DIFF
--- a/apps/mis-web/src/pages/api/profile/changePassword.ts
+++ b/apps/mis-web/src/pages/api/profile/changePassword.ts
@@ -1,4 +1,5 @@
-import { jsonFetch, route } from "@ddadaal/next-typed-api-routes-runtime";
+import { route } from "@ddadaal/next-typed-api-routes-runtime";
+import { changePassword as changePa } from "@scow/lib-auth"; 
 import { authenticate } from "src/auth/server";
 import { publicConfig, runtimeConfig } from "src/utils/config";
 
@@ -41,15 +42,7 @@ export default /* #__PURE__*/route<ChangePasswordSchema>("ChangePasswordSchema",
 
   const { newPassword, oldPassword } = req.body;
 
-  return await jsonFetch({
-    method: "PATCH",
-    path: `${runtimeConfig.AUTH_INTERNAL_URL}/password`,
-    body: {
-      identityId: info.identityId,
-      newPassword,
-      oldPassword,
-    },
-  })
+  return await changePa(runtimeConfig.AUTH_INTERNAL_URL, info.identityId, oldPassword, newPassword)
     .then(() => ({ 204: null }))
     .catch((e) => ({ [e.status]: null }));
 

--- a/apps/mis-web/src/pages/api/profile/changePassword.ts
+++ b/apps/mis-web/src/pages/api/profile/changePassword.ts
@@ -1,5 +1,5 @@
 import { route } from "@ddadaal/next-typed-api-routes-runtime";
-import { changePassword as changePa } from "@scow/lib-auth"; 
+import { changePassword as changePass } from "@scow/lib-auth"; 
 import { authenticate } from "src/auth/server";
 import { publicConfig, runtimeConfig } from "src/utils/config";
 
@@ -19,9 +19,12 @@ export interface ChangePasswordSchema {
     /** 更改成功 */
     204: null;
 
+    /** 用户未找到 */
+    404: null;
+
     /** 密码不正确 */
     412: null;
-
+    
     /** 本功能在当前配置下不可用。 */
     501: null;
   }
@@ -42,7 +45,7 @@ export default /* #__PURE__*/route<ChangePasswordSchema>("ChangePasswordSchema",
 
   const { newPassword, oldPassword } = req.body;
 
-  return await changePa(runtimeConfig.AUTH_INTERNAL_URL, info.identityId, oldPassword, newPassword)
+  return await changePass(runtimeConfig.AUTH_INTERNAL_URL, info.identityId, oldPassword, newPassword)
     .then(() => ({ 204: null }))
     .catch((e) => ({ [e.status]: null }));
 

--- a/apps/portal-web/src/pages/api/profile/changePassword.ts
+++ b/apps/portal-web/src/pages/api/profile/changePassword.ts
@@ -1,4 +1,5 @@
-import { jsonFetch, route } from "@ddadaal/next-typed-api-routes-runtime";
+import { route } from "@ddadaal/next-typed-api-routes-runtime";
+import { changePassword as changePa } from "@scow/lib-auth"; 
 import { authenticate } from "src/auth/server";
 import { publicConfig, runtimeConfig } from "src/utils/config";
 
@@ -41,15 +42,7 @@ export default /* #__PURE__*/route<ChangePasswordSchema>("ChangePasswordSchema",
 
   const { newPassword, oldPassword } = req.body;
 
-  return await jsonFetch({
-    method: "PATCH",
-    path: `${runtimeConfig.AUTH_INTERNAL_URL}/password`,
-    body: {
-      identityId: info.identityId,
-      newPassword,
-      oldPassword,
-    },
-  })
+  return await changePa(runtimeConfig.AUTH_INTERNAL_URL, info.identityId, oldPassword, newPassword)
     .then(() => ({ 204: null }))
     .catch((e) => ({ [e.status]: null }));
 

--- a/apps/portal-web/src/pages/api/profile/changePassword.ts
+++ b/apps/portal-web/src/pages/api/profile/changePassword.ts
@@ -1,5 +1,5 @@
 import { route } from "@ddadaal/next-typed-api-routes-runtime";
-import { changePassword as changePa } from "@scow/lib-auth"; 
+import { changePassword as changePass } from "@scow/lib-auth"; 
 import { authenticate } from "src/auth/server";
 import { publicConfig, runtimeConfig } from "src/utils/config";
 
@@ -19,9 +19,12 @@ export interface ChangePasswordSchema {
     /** 更改成功 */
     204: null;
 
+    /** 用户未找到 */
+    404: null;
+
     /** 密码不正确 */
     412: null;
-
+    
     /** 本功能在当前配置下不可用。 */
     501: null;
   }
@@ -42,7 +45,7 @@ export default /* #__PURE__*/route<ChangePasswordSchema>("ChangePasswordSchema",
 
   const { newPassword, oldPassword } = req.body;
 
-  return await changePa(runtimeConfig.AUTH_INTERNAL_URL, info.identityId, oldPassword, newPassword)
+  return await changePass(runtimeConfig.AUTH_INTERNAL_URL, info.identityId, oldPassword, newPassword)
     .then(() => ({ 204: null }))
     .catch((e) => ({ [e.status]: null }));
 

--- a/libs/auth/src/changePassword.ts
+++ b/libs/auth/src/changePassword.ts
@@ -11,8 +11,8 @@ export async function changePassword(
     method: "PATCH",
     body: JSON.stringify({
       identityId,
-      newPassword,
       oldPassword,
+      newPassword,
     }),
   });
 

--- a/libs/auth/src/changePassword.ts
+++ b/libs/auth/src/changePassword.ts
@@ -6,7 +6,7 @@ interface ResponseStatusSchema {
 
 export async function changePassword(
   authUrl: string, identityId: string, oldPassword: string, newPassword: string, logger?: Logger)
-  : Promise<ResponseStatusSchema | undefined> {
+  : Promise<ResponseStatusSchema> {
   const resp = await fetch(authUrl + "/password", {
     method: "PATCH",
     body: JSON.stringify({
@@ -18,7 +18,6 @@ export async function changePassword(
 
   if (resp.status !== 204) {
     logger?.warn("Change password failed. Status code %s", resp.status);
-    return;
   }
   logger?.trace("Change password successful");
 

--- a/libs/auth/src/changePassword.ts
+++ b/libs/auth/src/changePassword.ts
@@ -1,8 +1,12 @@
 import { Logger } from "ts-log";
 
+interface ResponseStatusSchema {
+  status: number;
+}
 
 export async function changePassword(
-  authUrl: string, identityId: string, oldPassword: string, newPassword: string, logger?: Logger): Promise<Response> {
+  authUrl: string, identityId: string, oldPassword: string, newPassword: string, logger?: Logger)
+  : Promise<ResponseStatusSchema | undefined> {
   const resp = await fetch(authUrl + "/password", {
     method: "PATCH",
     body: JSON.stringify({
@@ -14,14 +18,9 @@ export async function changePassword(
 
   if (resp.status !== 204) {
     logger?.warn("Change password failed. Status code %s", resp.status);
-    if (resp.status === 412) {
-      throw new Error("Password is incorrect");
-    }
-    else if (resp.status === 501) {
-      throw new Error("This feature is not available in the current configuration.");
-    }
+    return;
   }
   logger?.trace("Change password successful");
 
-  return resp;
+  return { status: resp.status };
 }

--- a/libs/auth/src/changePassword.ts
+++ b/libs/auth/src/changePassword.ts
@@ -1,0 +1,27 @@
+import { Logger } from "ts-log";
+
+
+export async function changePassword(
+  authUrl: string, identityId: string, oldPassword: string, newPassword: string, logger?: Logger): Promise<Response> {
+  const resp = await fetch(authUrl + "/password", {
+    method: "PATCH",
+    body: JSON.stringify({
+      identityId,
+      newPassword,
+      oldPassword,
+    }),
+  });
+
+  if (resp.status !== 204) {
+    logger?.warn("Change password failed. Status code %s", resp.status);
+    if (resp.status === 412) {
+      throw new Error("Password is incorrect");
+    }
+    else if (resp.status === 501) {
+      throw new Error("This feature is not available in the current configuration.");
+    }
+  }
+  logger?.trace("Change password successful");
+
+  return resp;
+}

--- a/libs/auth/src/index.ts
+++ b/libs/auth/src/index.ts
@@ -1,3 +1,4 @@
+export { changePassword } from "./changePassword";
 export type { Capabilities } from "./getCapabilities";
 export { getCapabilities } from "./getCapabilities";
 export { validateToken } from "./validateToken";

--- a/libs/auth/tests/changePassword.test.ts
+++ b/libs/auth/tests/changePassword.test.ts
@@ -1,4 +1,4 @@
-import { changePassword } from "src/changePassword";
+import { changePassword } from "../src/changePassword";
 
 const authUrl = "auth:5000";
 
@@ -8,12 +8,26 @@ const oldPassword = "123456";
 
 const newPassword = "654321";
 
+
+interface RequstSchema {
+  method: string,
+  body: string,
+}
+
 // @ts-ignore
-globalThis.fetch = jest.fn((url: string) => {
-  if (new URL(url).pathname === "/changePassword") {
-    return { status: 204 };
-  } else {
-    return { status: 404 };
+globalThis.fetch = jest.fn((url:string, req:RequstSchema) => {
+  const testBody = JSON.parse(req.body);
+  const testIdentityId = testBody.identityId;
+  const testOldPassword = testBody.oldPassword;
+
+  if (testIdentityId !== identityId) {
+    return { status: 404, json: () => ({}) };
+  }
+  else if (testOldPassword !== oldPassword) {
+    return { status: 412, json: () => ({}) };
+  }
+  else {
+    return { status: 204, json: () => ({}) };
   }
 });
 
@@ -21,19 +35,24 @@ it("raises correct request for changing password", async () => {
   await changePassword(authUrl, identityId, oldPassword, newPassword);
     
   expect(fetch).toHaveBeenCalledWith(
-    authUrl + "/changePassword",
+    authUrl + "/password",
     {
-      method: "POST",
+      method: "PATCH",
       body: JSON.stringify({ identityId, oldPassword, newPassword }),
-      headers: { "Content-Type": "application/json" },
     },
   );
 });
 
 it("fails test for changing password with wrong oldpassword", async () => {
-  const result = await changePassword(authUrl, identityId, oldPassword + "123", newPassword);
+  const result = await changePassword(authUrl, identityId + "123", oldPassword, newPassword);
     
-  expect(result).toBeUndefined();
+  expect(result).toEqual({ status: 404 });
+});
+
+it("fails test for changing password with the user who cannot be found", async () => {
+  const result = await changePassword(authUrl, identityId, oldPassword + "123", newPassword);
+      
+  expect(result).toEqual({ status: 412 });
 });
 
 it("returns true for changing password", async () => {

--- a/libs/auth/tests/changePassword.test.ts
+++ b/libs/auth/tests/changePassword.test.ts
@@ -1,0 +1,44 @@
+import { changePassword } from "src/changePassword";
+
+const authUrl = "auth:5000";
+
+const identityId = "123";
+
+const oldPassword = "123456";
+
+const newPassword = "654321";
+
+// @ts-ignore
+globalThis.fetch = jest.fn((url: string) => {
+  if (new URL(url).pathname === "/changePassword") {
+    return { status: 204 };
+  } else {
+    return { status: 404 };
+  }
+});
+
+it("raises correct request for changing password", async () => {
+  await changePassword(authUrl, identityId, oldPassword, newPassword);
+    
+  expect(fetch).toHaveBeenCalledWith(
+    authUrl + "/changePassword",
+    {
+      method: "POST",
+      body: JSON.stringify({ identityId, oldPassword, newPassword }),
+      headers: { "Content-Type": "application/json" },
+    },
+  );
+});
+
+it("fails test for changing password with wrong oldpassword", async () => {
+  const result = await changePassword(authUrl, identityId, oldPassword + "123", newPassword);
+    
+  expect(result).toBeUndefined();
+});
+
+it("returns true for changing password", async () => {
+  const result = await changePassword(authUrl, identityId, oldPassword, newPassword);
+        
+  expect(result).toEqual({ status: 204 });
+});
+  


### PR DESCRIPTION
此次PR在libs/auth/src下实现了changePassword的api接口，并在libs/auth下的test中使用mock添加了对该方法的测试。最终将mis/portal-web中对changePassword的调用改为了使用该封装好的接口。