### PR TITLE
fix(portal): 修复配置BASE_PATH的话jupyter无法连接问题

### DIFF
--- a/apps/gateway/nginx.conf
+++ b/apps/gateway/nginx.conf
@@ -34,7 +34,7 @@ server {
     include includes/websocket;
   }
   location ~ ^${BASE_PATH}/proxy/(?<node>.*)/(?<port>\d+)(?<rest>.*)$ {
-    proxy_pass http://$node:$port/proxy/$node/$port$rest;
+    proxy_pass http://$node:$port${BASE_PATH}/proxy/$node/$port$rest;
 
     include includes/headers;
     include includes/websocket;


### PR DESCRIPTION
当前，对于Jupyter等交互式应用，如果配置了BASE_PATH，nginx反向代理发送到后端计算节点的uri不正确，没有考虑到包括BASE_PATH的完整路径. 比如访问`https://hpc.pku.edu/scow_base_path/proxy/192.168.220.133/7383/index.html`, `/proxy/192.168.220.133/7383/index.html`会被发送到计算节点，这是一个不完整的路径。

PR解决了这个问题，现在` /scow_base_path/proxy/192.168.220.133/7383/index.html` 会被发送到计算节点。
