### PR TITLE
fix(ssh): 创建用户时，如果以用户身份登录后用户家目录仍不存在，使用insertKeyAsRoot配置免密登录

### DIFF
--- a/.github/workflows/test-build-publish.yaml
+++ b/.github/workflows/test-build-publish.yaml
@@ -56,7 +56,7 @@ jobs:
       - name: Upload test converage
         uses: codecov/codecov-action@v3
         with:
-          files: ./libs/auth/coverage/lcov.info,./libs/libconfig/coverage/lcov.info,./libs/decimal/coverage/lcov.info,./apps/auth/coverage/lcov.info,./apps/mis-server/coverage/lcov.info,./apps/portal-server/coverage/lcov.info
+          files: ./libs/auth/coverage/lcov.info,./libs/ssh/coverage/lcov.info,./libs/libconfig/coverage/lcov.info,./libs/decimal/coverage/lcov.info,./apps/auth/coverage/lcov.info,./apps/mis-server/coverage/lcov.info,./apps/portal-server/coverage/lcov.info
 
   build-images:
     needs: test


### PR DESCRIPTION
之前我们假设创建用户后，以用户身份第一次登录后，系统会自动创建用户的家目录并配置bash的一些参数。我们也同时在此时给新的用户配置免密登录的文件。但是目前发现在一些集群中，即使以新用户登录后，系统仍然不会创建家目录，此时原来的逻辑将会报错。

此PR处理了这一情况，当以新用户登录后发现用户家目录不存在，则调用insertKeyAsRoot来配置免密登录。