### PR TITLE
fix(portal): 修改了"已保存作业"界面ui的一些命名并去掉“提交时间”的column

### DIFF
--- a/apps/portal-web/src/layouts/routes/index.tsx
+++ b/apps/portal-web/src/layouts/routes/index.tsx
@@ -43,7 +43,7 @@ export const userRoutes: () => NavItemProps[] = () => [
       },
       {
         Icon: SaveOutlined,
-        text: "已保存的作业",
+        text: "作业模板",
         path: "/jobs/savedJobs",
       },
     ],

--- a/apps/portal-web/src/pageComponents/job/SavedJobsTable.tsx
+++ b/apps/portal-web/src/pageComponents/job/SavedJobsTable.tsx
@@ -8,7 +8,6 @@ import { FilterFormContainer } from "src/components/FilterFormContainer";
 import { JobTemplate } from "src/generated/portal/job";
 import type { Cluster } from "src/utils/config";
 import { publicConfig } from "src/utils/config";
-import { compareDateTime, formatDateTime } from "src/utils/datetime";
 
 interface Props {}
 
@@ -87,19 +86,12 @@ const InfoTable: React.FC<InfoTableProps> = ({
     >
       <Table.Column<JobTemplate>
         dataIndex="jobName"
-        title="作业名"
+        title="模板名"
         sorter={(a, b) => a.jobName.localeCompare(b.jobName)}
-      />
-      <Table.Column<JobTemplate>
-        dataIndex="submitTime"
-        title="提交时间"
-        render={(v) => formatDateTime(v)}
-        sorter={(a, b) => (a.submitTime && b.submitTime) ? compareDateTime(a.submitTime, b.submitTime) : 0}
-        defaultSortOrder="descend"
       />
       <Table.Column<JobTemplate> dataIndex="comment" title="备注" />
       <Table.Column<JobTemplate>
-        title="更多"
+        title="操作"
         render={(_, r) => (
           <Space>
             <Link href={{
@@ -110,7 +102,7 @@ const InfoTable: React.FC<InfoTableProps> = ({
               },
             }}
             >
-              作为模板提交作业
+              使用模板
             </Link>
           </Space>
         )}

--- a/apps/portal-web/src/pages/jobs/savedJobs.tsx
+++ b/apps/portal-web/src/pages/jobs/savedJobs.tsx
@@ -8,8 +8,8 @@ export const SavedJobsPage: NextPage = requireAuth(() => true)(
   () => {
     return (
       <div>
-        <Head title="已保存的作业" />
-        <PageTitle titleText={"已保存的作业"} />
+        <Head title="作业模板" />
+        <PageTitle titleText={"作业模板列表"} />
         <SavedJobsTable />
       </div>
     );


### PR DESCRIPTION
<img width="1253" alt="image" src="https://user-images.githubusercontent.com/96867690/201086619-f8b91ed7-ded7-47e4-be23-9091ebbefa7d.png">
在提交作业页面的选项为“保存为模板”，已保存的作业的即为模板，这里将命名修改，使得命名统一。另外去掉了“提交时间”的column。
