### PR TITLE
refactor: 在dockerfile中使用pnpm fetch

### DIFF
--- a/dockerfiles/Dockerfile.auth
+++ b/dockerfiles/Dockerfile.auth
@@ -6,12 +6,15 @@ RUN corepack enable
 
 WORKDIR /app
 
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
+COPY pnpm-lock.yaml ./
+RUN pnpm fetch
+
+COPY package.json pnpm-workspace.yaml .npmrc ./
 COPY libs/libconfig/package.json ./libs/libconfig/
 COPY libs/config/package.json ./libs/config/
 COPY apps/auth/package.json ./apps/auth/
 
-RUN pnpm i --frozen-lockfile
+RUN pnpm i --offline --frozen-lockfile
 
 COPY tsconfig.json .eslintrc.json ./
 

--- a/dockerfiles/Dockerfile.docs
+++ b/dockerfiles/Dockerfile.docs
@@ -6,12 +6,15 @@ RUN corepack enable
 
 WORKDIR /app
 
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
+COPY pnpm-lock.yaml ./
+RUN pnpm fetch
+
+COPY package.json pnpm-workspace.yaml .npmrc ./
 
 COPY libs/config/package.json ./libs/config/
 COPY apps/docs/package.json ./apps/docs/
 
-RUN pnpm i --frozen-lockfile
+RUN pnpm i --offline --frozen-lockfile
 
 COPY tsconfig.json .eslintrc.json ./
 

--- a/dockerfiles/Dockerfile.mis-server
+++ b/dockerfiles/Dockerfile.mis-server
@@ -6,7 +6,11 @@ RUN corepack enable
 
 WORKDIR /app
 
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
+COPY pnpm-lock.yaml ./
+RUN pnpm fetch
+
+COPY package.json pnpm-workspace.yaml .npmrc ./
+
 
 COPY libs/libconfig/package.json ./libs/libconfig/
 COPY libs/config/package.json ./libs/config/
@@ -15,7 +19,7 @@ COPY libs/decimal/package.json ./libs/decimal/
 COPY libs/ssh/package.json ./libs/ssh/
 COPY apps/mis-server/package.json ./apps/mis-server/
 
-RUN pnpm i --frozen-lockfile
+RUN pnpm i --offline --frozen-lockfile
 
 COPY tsconfig.json .eslintrc.json ./
 

--- a/dockerfiles/Dockerfile.mis-web
+++ b/dockerfiles/Dockerfile.mis-web
@@ -6,7 +6,10 @@ RUN corepack enable
 
 WORKDIR /app
 
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
+COPY pnpm-lock.yaml ./
+RUN pnpm fetch
+
+COPY package.json pnpm-workspace.yaml .npmrc ./
 
 COPY libs/auth/package.json ./libs/auth/
 COPY libs/libconfig/package.json ./libs/libconfig/
@@ -14,7 +17,7 @@ COPY libs/config/package.json ./libs/config/
 COPY libs/decimal/package.json ./libs/decimal/
 COPY apps/mis-web/package.json apps/mis-web/
 
-RUN pnpm i --frozen-lockfile
+RUN pnpm i --offline --frozen-lockfile
 
 COPY tsconfig.json .eslintrc.json ./
 

--- a/dockerfiles/Dockerfile.portal-server
+++ b/dockerfiles/Dockerfile.portal-server
@@ -6,7 +6,11 @@ RUN corepack enable
 
 WORKDIR /app
 
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
+
+COPY pnpm-lock.yaml ./
+RUN pnpm fetch
+
+COPY package.json pnpm-workspace.yaml .npmrc ./
 
 COPY libs/libconfig/package.json ./libs/libconfig/
 COPY libs/config/package.json ./libs/config/
@@ -14,7 +18,7 @@ COPY libs/decimal/package.json ./libs/decimal/
 COPY libs/ssh/package.json ./libs/ssh/
 COPY apps/portal-server/package.json ./apps/portal-server/
 
-RUN pnpm i --frozen-lockfile
+RUN pnpm i --offline --frozen-lockfile
 
 COPY tsconfig.json .eslintrc.json ./
 

--- a/dockerfiles/Dockerfile.portal-web
+++ b/dockerfiles/Dockerfile.portal-web
@@ -6,7 +6,10 @@ RUN corepack enable
 
 WORKDIR /app
 
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
+COPY pnpm-lock.yaml ./
+RUN pnpm fetch
+
+COPY package.json pnpm-workspace.yaml .npmrc ./
 
 COPY libs/auth/package.json ./libs/auth/
 COPY libs/libconfig/package.json ./libs/libconfig/
@@ -15,7 +18,7 @@ COPY libs/decimal/package.json ./libs/decimal/
 COPY libs/ssh/package.json ./libs/ssh/
 COPY apps/portal-web/package.json ./apps/portal-web/
 
-RUN pnpm i --frozen-lockfile
+RUN pnpm i --offline --frozen-lockfile
 
 RUN apk add git
 


### PR DESCRIPTION
之前，每个镜像在构建的时候都只下载自己的组件所需要的依赖（例如组件A需要a, b包，组件B需要a, c包）。这固然减少了每个镜像下载依赖的大小（每个组件只下载自己所需要的依赖，A不会下载c，B不会下载a），但是构建系统时需要同时构建所有镜像，每个镜像所需要的依赖不一样，那么docker就会同时对每个组件下载自己的依赖，会同时产生大量网络请求（同时有组件A下载a, b，组件B下载a, c四个请求），如果此时用户的网络条件不好，或者使用了有资源限制的代理服务器，那么就可能下载出错。

pnpm有一个`fetch`子命令（ https://pnpm.io/cli/fetch ），它只需要lock文件（整个项目只有一个lock文件），运行此命令可以把lock文件中的所有依赖先全部下载下来。这样，预先下载好所有镜像后，后面的pnpm install过程就不需要发起任何网络请求了。

通过此功能，整个系统在构建的时候只需要下载一次依赖（整个系统的所有依赖，例子中的a, b, c），下载依赖后，各个镜像在后续就不会发起下载依赖的网络请求，提高了整个系统的构建速度。