### PR TITLE
fix: 修复某些开发环境中ldaptest容器openfiles bug

### DIFF
--- a/dev/docker-compose.dev.yml
+++ b/dev/docker-compose.dev.yml
@@ -42,6 +42,10 @@ services:
       - 389:389
     volumes:
       - ldap:/var/lib/ldap
+    ulimits:
+      nofile:
+        soft: 10240
+        hard: 10240
 
 networks:
   default:

--- a/dev/ldap/Dockerfile
+++ b/dev/ldap/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7
 WORKDIR /ldap
 COPY dev/ldap/provider.sh .
 
-RUN ./provider.sh docker
+RUN ulimit -n 10240;./provider.sh docker
 
 VOLUME [ "/var/lib/ldap" ]
 


### PR DESCRIPTION
在openeuler下，centos7容器的默认open files值是1073741816，在build阶段安装glibc的时候，以及启动容器的时候会报错，需要把open files改小