### PR TITLE
enhancement(mis): 导入用户和账户时显示已经存在的用户和账户

### DIFF
--- a/apps/mis-server/src/services/admin.ts
+++ b/apps/mis-server/src/services/admin.ts
@@ -109,18 +109,24 @@ export const adminServiceServer = plugin((server) => {
 
       const result = parseClusterUsers(reply.result);
 
-      await Promise.all(result.accounts.map(async (account) => {
-        if (await em.findOne(Account, { accountName: account.accountName })) {
-          account.included = true;
-        }
-      }));
-      
-      await Promise.all(result.users.map(async (user) => {
-        if (await em.findOne(User, { userId: user.userId })) {
-          user.included = true;
-        }
-      }));
+      const includedAccounts = await em.find(Account, { 
+        accountName: { $in: result.accounts.map((x) => (x.accountName)) },
+      });
+      includedAccounts.map((account) => {
+        const a = result.accounts.find((x) => (x.accountName === account.accountName));
+        a!.included = true;
+        a!.owner = "该账户已导入";
+      });
 
+      const includedUsers = await em.find(User, {
+        userId: { $in: result.users.map((x) => (x.userId)) },
+      });
+      includedUsers.map((user) => {
+        const u = result.users.find((x) => (x.userId === user.userId));
+        u!.included = true;
+        u!.userName = user.name;
+      });
+      
       return [result];
     },
 

--- a/apps/mis-server/src/services/admin.ts
+++ b/apps/mis-server/src/services/admin.ts
@@ -110,21 +110,21 @@ export const adminServiceServer = plugin((server) => {
       const result = parseClusterUsers(reply.result);
 
       const includedAccounts = await em.find(Account, { 
-        accountName: { $in: result.accounts.map((x) => (x.accountName)) },
+        accountName: { $in: result.accounts.map((x) => x.accountName) },
       });
-      includedAccounts.map((account) => {
-        const a = result.accounts.find((x) => (x.accountName === account.accountName));
-        a!.included = true;
-        a!.owner = "该账户已导入";
+      includedAccounts.forEach((account) => {
+        const a = result.accounts.find((x) => x.accountName === account.accountName)!;
+        a.included = true;
+        a.owner = "该账户已导入";
       });
 
       const includedUsers = await em.find(User, {
-        userId: { $in: result.users.map((x) => (x.userId)) },
+        userId: { $in: result.users.map((x) => x.userId) },
       });
-      includedUsers.map((user) => {
-        const u = result.users.find((x) => (x.userId === user.userId));
-        u!.included = true;
-        u!.userName = user.name;
+      includedUsers.forEach((user) => {
+        const u = result.users.find((x) => x.userId === user.userId)!;
+        u.included = true;
+        u.userName = user.name;
       });
       
       return [result];

--- a/apps/mis-server/src/utils/slurm.ts
+++ b/apps/mis-server/src/utils/slurm.ts
@@ -14,13 +14,13 @@ export function parseClusterUsers(dataStr: string): GetClusterUsersReply {
   let i = 0;
   while (i < lines.length) {
     const account = lines[i].trim();
-    const accountIndex = obj.accounts.push({ accountName: account, users: [] as UserInAccount[] });
+    const accountIndex = obj.accounts.push({ accountName: account, users: [] as UserInAccount[], included: false });
     i++;
     while (lines[i].trim() !== "") {
       const [user, status] = lines[i].split(":").map((x) => x.trim());
       const userIndex = obj.users.findIndex((x) => x.userId === user);
       if (userIndex === -1) {
-        obj.users.push({ userId: user, userName: user, accounts: [account]});
+        obj.users.push({ userId: user, userName: user, accounts: [account], included: false });
       }
       else {
         obj.users[userIndex].accounts.push(account);

--- a/apps/mis-server/tests/admin/getClusterUsers.test.ts
+++ b/apps/mis-server/tests/admin/getClusterUsers.test.ts
@@ -11,15 +11,17 @@ it("test whether the string from 'slurm.sh -l all' can be parsed successfully", 
       accountName: "a_user1",
       users: [{ userId: "user1", state: "allowed!" }, { userId: "user2", state: "blocked!" }],
       owner: "user1",
+      included: false,
     },
     {
       accountName: "account2",
       users: [{ userId: "user2", state: "allowed!" }, { userId: "user3", state: "blocked!" }],
+      included: false,
     },
   ],
   users: [ 
-    { userId: "user1", userName: "user1", accounts: [ "a_user1" ]}, 
-    { userId: "user2", userName: "user2", accounts: [ "a_user1", "account2" ]}, 
-    { userId: "user3", userName: "user3", accounts: [ "account2" ]},
+    { userId: "user1", userName: "user1", accounts: [ "a_user1" ], included: false }, 
+    { userId: "user2", userName: "user2", accounts: [ "a_user1", "account2" ], included: false }, 
+    { userId: "user3", userName: "user3", accounts: [ "account2" ], included: false },
   ]});
 });

--- a/apps/mis-web/src/apis/api.mock.ts
+++ b/apps/mis-web/src/apis/api.mock.ts
@@ -205,7 +205,7 @@ export const mockApi: MockApi<typeof api> = {
         {
           accountName: "a_user4",
           users: [{ userId: "user4", state: "allowed!" }],
-          owner: "user4",
+          owner: "该账户已导入",
           included: true,
         },
       ],

--- a/apps/mis-web/src/apis/api.mock.ts
+++ b/apps/mis-web/src/apis/api.mock.ts
@@ -195,16 +195,25 @@ export const mockApi: MockApi<typeof api> = {
           accountName: "a_user1",
           users: [{ userId: "user1", state: "allowed!" }, { userId: "user2", state: "allowed!" }],
           owner: "user1",
+          included: false,
         },
         {
           accountName: "account2",
           users: [{ userId: "user2", state: "allowed!" }, { userId: "user3", state: "allowed!" }],
+          included: false,
+        },
+        {
+          accountName: "a_user4",
+          users: [{ userId: "user4", state: "allowed!" }],
+          owner: "user4",
+          included: true,
         },
       ],
       users: [ 
-        { userId: "user1", userName: "user1", accounts: [ "a_user1" ]}, 
-        { userId: "user2", userName: "user2", accounts: [ "a_user1", "account2" ]}, 
-        { userId: "user3", userName: "user3", accounts: [ "account2" ]},
+        { userId: "user1", userName: "user1", accounts: [ "a_user1" ], included: false }, 
+        { userId: "user2", userName: "user2", accounts: [ "a_user1", "account2" ], included: false }, 
+        { userId: "user3", userName: "user3", accounts: [ "account2" ], included: false },
+        { userId: "user4", userName: "user4", accounts: [ "a_user4" ], included: true },
       ],
     });
   },

--- a/apps/mis-web/src/pageComponents/admin/ImportUsersTable.tsx
+++ b/apps/mis-web/src/pageComponents/admin/ImportUsersTable.tsx
@@ -1,6 +1,6 @@
 import { Button, Checkbox, Form, Input, message, Select, Table, Tabs, Tooltip } from "antd";
 import Router from "next/router";
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useAsync } from "react-async";
 import { api } from "src/apis";
 import { SingleClusterSelector } from "src/components/ClusterSelector";
@@ -34,42 +34,27 @@ export const ImportUsersTable: React.FC = () => {
 
   const [loading, setLoading] = useState(false);
 
-  const [selectedUsers, setSelectedUsers] = useState<React.Key[]>([0, 1]);
-  const [selectedAccounts, setSelectedAccounts] = useState<React.Key[]>([]);
-
-  const promiseFn = useCallback(async () => {
-    const result = await api.getClusterUsers({ query: {
+  const promiseFn = useCallback(async () => {    
+    return await api.getClusterUsers({ query: {
       cluster: cluster.id,
     } });
-
-    const users: React.Key[] = [];
-    const accounts: React.Key[] = [];
-
-    result.users.forEach((user) => {
-      if (!user.included) {
-        users.push(user.userId);
-      }
-    });
-    result.accounts.forEach((account) => {
-      if (!account.included) {
-        accounts.push(account.accountName);
-      }
-    });
-
-    setSelectedUsers(users);
-    setSelectedAccounts(accounts);
-
-    return result;
   }, [cluster]);
-
+  
   const { data, isLoading, reload } = useAsync({ promiseFn });
-
+  
   useEffect(() => {
     form.setFieldsValue({
       data: data,
       whitelist: true,
     });
   }, [data]);
+  
+  const selectedUsers = useMemo(() => data?.users.filter(
+    (x) => (!x.included)).map((x) => (x.userId)), [data],
+  );
+  const selectedAccounts = useMemo(() => data?.accounts.filter(
+    (x) => (!x.included)).map((x) => (x.accountName)), [data],
+  );
 
   return (
     <div>

--- a/apps/mis-web/src/pages/api/admin/importUsers.ts
+++ b/apps/mis-web/src/pages/api/admin/importUsers.ts
@@ -2,7 +2,7 @@ import { route } from "@ddadaal/next-typed-api-routes-runtime";
 import { asyncClientCall } from "@ddadaal/tsgrpc-client";
 import { Status } from "@grpc/grpc-js/build/src/constants";
 import { authenticate } from "src/auth/server";
-import { AdminServiceClient, GetClusterUsersReply } from "src/generated/server/admin";
+import { AdminServiceClient, ImportUsersData } from "src/generated/server/admin";
 import { PlatformRole } from "src/models/User";
 import { getClient } from "src/utils/client";
 import { queryIfInitialized } from "src/utils/init";
@@ -12,7 +12,7 @@ export interface ImportUsersSchema {
   method: "POST";
 
   body: {
-    data: GetClusterUsersReply;
+    data: ImportUsersData;
     whitelist: boolean;
   }
 

--- a/protos/server/admin.proto
+++ b/protos/server/admin.proto
@@ -30,8 +30,20 @@ message QueryStorageQuotaRequest {
 message QueryStorageQuotaReply { uint64 current_quota = 1; }
 
 message ImportUsersData {
-  repeated ClusterAccountInfo accounts = 1;
-  repeated ClusterUserInfo users = 2;
+  message AccountInfo {
+    string account_name = 1;
+    repeated UserInAccount users = 2;
+    string owner = 3;
+  }
+
+  message UserInfo {
+    string user_id = 1;
+    string user_name = 2;
+    repeated string accounts = 3;
+  }
+
+  repeated AccountInfo accounts = 1;
+  repeated UserInfo users = 2;
 }
 
 message ImportUsersRequest {
@@ -55,12 +67,14 @@ message ClusterAccountInfo {
   string account_name = 1;
   repeated UserInAccount users = 2;
   optional string owner = 3;
+  bool included = 4;
 }
 
 message ClusterUserInfo {
   string user_id = 1;
   string user_name = 2;
   repeated string accounts = 3;
+  bool included = 4;
 }
 
 message GetClusterUsersRequest {


### PR DESCRIPTION
在导入用户的表格中, 用checkbox显示已经在scow系统中的用户和账户, 使用者不能操作checkbox, 系统默认导入所有不存在scow中的用户和账户.

持久化入数据库的逻辑不变, 也就是说后端假设新导入的用户和账户与原来scow中存在的用户与账户没有任何依赖关系.

![image](https://user-images.githubusercontent.com/98016770/202891052-83369be8-c46a-403c-a9ae-258af0266faa.png)
![image](https://user-images.githubusercontent.com/98016770/202891064-24aef914-d156-4b20-a458-b8450b91da63.png)
