### PR TITLE
fix(portal/apps): proxy中location的正则表达式识别错误

### DIFF
--- a/apps/gateway/nginx.conf
+++ b/apps/gateway/nginx.conf
@@ -27,20 +27,20 @@ server {
     include includes/websocket;
   }
 
-  location ~ ^${BASE_PATH}/rproxy/(?<node>.*)/(?<port>\d+)(?<rest>.*)$ {
+  location ~ ^${BASE_PATH}/rproxy/(?<node>[\d|\.]*)/(?<port>\d+)(?<rest>.*)$ {
     proxy_pass http://$node:$port$rest$is_args$args;
 
     include includes/headers;
     include includes/websocket;
   }
-  location ~ ^${BASE_PATH}/proxy/(?<node>.*)/(?<port>\d+)(?<rest>.*)$ {
+  location ~ ^${BASE_PATH}/proxy/(?<node>[\d|\.]*)/(?<port>\d+)(?<rest>.*)$ {
     proxy_pass http://$node:$port${BASE_PATH}/proxy/$node/$port$rest$is_args$args;
 
     include includes/headers;
     include includes/websocket;
   }
 
-  location ~ ^${BASE_PATH}/wsproxy/(?<node>.*)/(?<port>\d+)(?<rest>.*)$ {
+  location ~ ^${BASE_PATH}/wsproxy/(?<node>[\d|\.]*)/(?<port>\d+)(?<rest>.*)$ {
     proxy_pass http://$node:$port$rest$is_args$args;
 
     proxy_read_timeout 600;


### PR DESCRIPTION
之前的正则表达式会将rest中以数字开头的识别为port，导致整个转发失败。