### PR TITLE
ci: 增加demo集群的镜像

### DIFF
--- a/.github/workflows/test-build-publish.yaml
+++ b/.github/workflows/test-build-publish.yaml
@@ -95,7 +95,7 @@ jobs:
 
           - name: mis-web-demo
             file: mis-web
-            build_args: BASE_PATH=/demo/scow
+            build_args: BASE_PATH=/demo/scow/mis
 
           - name: portal-web-root
             file: portal-web

--- a/.github/workflows/test-build-publish.yaml
+++ b/.github/workflows/test-build-publish.yaml
@@ -93,6 +93,10 @@ jobs:
             file: mis-web
             build_args: BASE_PATH=/mis
 
+          - name: mis-web-demo
+            file: mis-web
+            build_args: BASE_PATH=/demo/scow
+
           - name: portal-web-root
             file: portal-web
             build_args: BASE_PATH=
@@ -100,6 +104,10 @@ jobs:
           - name: portal-web-portal
             file: portal-web
             build_args: BASE_PATH=/portal
+
+          - name: portal-web-demo
+            file: portal-web
+            build_args: BASE_PATH=/demo/scow
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
之后将会公开的demo集群部署在/demo/scow下，需要单独构建镜像。使用GitHub Actions自动构建demo集群所需要的镜像。