### PR TITLE
feat(portal-web): 更新登录节点桌面UI设计

### DIFF
--- a/apps/portal-web/src/pageComponents/desktop/DesktopTable.tsx
+++ b/apps/portal-web/src/pageComponents/desktop/DesktopTable.tsx
@@ -1,5 +1,5 @@
 import { PlusOutlined } from "@ant-design/icons";
-import { Form, Table } from "antd";
+import { Button, Form, Table } from "antd";
 import { ColumnsType } from "antd/es/table";
 import { useRouter } from "next/router";
 import React, { useCallback } from "react";
@@ -8,7 +8,6 @@ import { api } from "src/apis";
 import { SingleClusterSelector } from "src/components/ClusterSelector";
 import { FilterFormContainer } from "src/components/FilterFormContainer";
 import { ModalButton } from "src/components/ModalLink";
-import { PageTitle } from "src/components/PageTitle";
 import { DesktopTableActions } from "src/pageComponents/desktop/DesktopTableActions";
 import { NewDesktopTableModal } from "src/pageComponents/desktop/NewDesktopTableModal";
 import { publicConfig } from "src/utils/config";
@@ -17,7 +16,6 @@ import { queryToString } from "src/utils/querystring";
 const NewDesktopTableModalButton = ModalButton(NewDesktopTableModal, { type: "primary", icon: <PlusOutlined /> });
 
 interface Props {
-
 }
 
 export type DesktopItem = {
@@ -66,11 +64,6 @@ export const DesktopTable: React.FC<Props> = () => {
   ];
   return (
     <div>
-      <PageTitle titleText="登录节点上的桌面">
-        <NewDesktopTableModalButton reload={reload}>
-        新建桌面
-        </NewDesktopTableModalButton>
-      </PageTitle>
       <FilterFormContainer>
         <Form layout="inline">
           <Form.Item label="集群">
@@ -80,6 +73,16 @@ export const DesktopTable: React.FC<Props> = () => {
                 router.push({ query: { cluster: x.id } });
               }}
             />
+          </Form.Item>
+          <Form.Item>
+            <Button onClick={reload} loading={isLoading}>
+              刷新
+            </Button>
+          </Form.Item>
+          <Form.Item>
+            <NewDesktopTableModalButton reload={reload} cluster={cluster}>
+              新建桌面
+            </NewDesktopTableModalButton>
           </Form.Item>
         </Form>
       </FilterFormContainer>

--- a/apps/portal-web/src/pageComponents/desktop/NewDesktopTableModal.tsx
+++ b/apps/portal-web/src/pageComponents/desktop/NewDesktopTableModal.tsx
@@ -1,7 +1,6 @@
 import { Form, Modal, Select } from "antd";
 import React, { useState } from "react";
 import { api } from "src/apis";
-import { SingleClusterSelector } from "src/components/ClusterSelector";
 import { Cluster, publicConfig } from "src/utils/config";
 import { openDesktop } from "src/utils/vnc";
 
@@ -9,18 +8,18 @@ export interface Props {
   open: boolean;
   onClose: () => void;
   reload: () => void;
+  cluster: Cluster;
 }
 
-interface ClusterInfo {
-  cluster: Cluster;
+interface FormInfo {
   wm: string;
 }
 
 
-export const NewDesktopTableModal: React.FC<Props> = ({ open, onClose, reload }) => {
+export const NewDesktopTableModal: React.FC<Props> = ({ open, onClose, reload, cluster }) => {
   const defaultWm = publicConfig.LOGIN_DESKTOP_WMS[0];
 
-  const [form] = Form.useForm<ClusterInfo>();
+  const [form] = Form.useForm<FormInfo>();
   const [submitting, setSubmitting] = useState(false);
 
   const onOk = async () => {
@@ -30,7 +29,7 @@ export const NewDesktopTableModal: React.FC<Props> = ({ open, onClose, reload })
     setSubmitting(true);
 
     // Create new desktop
-    await api.createDesktop({ body: { cluster: values.cluster.id, wm: values.wm } })
+    await api.createDesktop({ body: { cluster: cluster.id, wm: values.wm } })
       .httpError(409, (e) => {
         const { code } = e;
         if (code === "TOO_MANY_DESKTOPS") {
@@ -59,24 +58,12 @@ export const NewDesktopTableModal: React.FC<Props> = ({ open, onClose, reload })
       confirmLoading={submitting}
       onCancel={onClose}
     >
-      <Form form={form} initialValues={{ cluster: publicConfig.CLUSTERS[0], wm: defaultWm.wm }} onFinish={onOk}>
-        <Form.Item
-          label="集群"
-          name="cluster"
-          rules={[
-            {
-              required: true,
-            },
-          ]}
-        >
-          <SingleClusterSelector />
-        </Form.Item>
+      <Form form={form} initialValues={{ wm: defaultWm.wm }} onFinish={onOk}>
         <Form.Item label="桌面" name="wm" required>
           <Select
             options={publicConfig.LOGIN_DESKTOP_WMS.map(({ name, wm }) =>
               ({ label: name, value: wm }))}
           />
-
         </Form.Item>
       </Form>
     </Modal>

--- a/apps/portal-web/src/pages/desktop/index.tsx
+++ b/apps/portal-web/src/pages/desktop/index.tsx
@@ -1,6 +1,7 @@
 import { NextPage } from "next";
 import { requireAuth } from "src/auth/requireAuth";
 import { NotFoundPage } from "src/components/errorPages/NotFoundPage";
+import { PageTitle } from "src/components/PageTitle";
 import { DesktopTable } from "src/pageComponents/desktop/DesktopTable";
 import { publicConfig } from "src/utils/config";
 import { Head } from "src/utils/head";
@@ -14,6 +15,7 @@ export const DesktopIndexPage: NextPage = requireAuth(() => true)(() => {
   return (
     <div>
       <Head title="桌面" />
+      <PageTitle titleText="登录节点上的桌面" />
       <DesktopTable />
     </div>
   );


### PR DESCRIPTION
1. 增加刷新按钮
2. 将创建桌面放到搜索区域中

![image](https://user-images.githubusercontent.com/8363856/203507333-ce674b6a-a5e6-44ad-8776-621e6cc491c2.png)

3. 创建桌面时默认使用选中的集群，不单独选择集群
![image](https://user-images.githubusercontent.com/8363856/203507466-12c6f974-fd54-479a-a372-b43048ed99e0.png)
