### PR TITLE
fix(web): 修复一些UI细节问题

### DIFF
--- a/apps/mis-web/src/layouts/base/BaseLayout.tsx
+++ b/apps/mis-web/src/layouts/base/BaseLayout.tsx
@@ -26,7 +26,6 @@ const ContentPart = styled.div`
   flex: 1;
   flex-direction: column;
   width: 100%;
-  overflow-x: scroll;
 `;
 
 const Content = styled(Layout.Content)`

--- a/apps/mis-web/src/layouts/base/SideNav/index.tsx
+++ b/apps/mis-web/src/layouts/base/SideNav/index.tsx
@@ -39,7 +39,6 @@ const StyledSider = styled(Sider)`
     overflow: auto;
   }
 
-
   .ant-menu-item:first-child {
     margin-top: 0px;
   }
@@ -47,6 +46,12 @@ const StyledSider = styled(Sider)`
   .ant-menu {
     min-height: 100%;
     border-right: 0;
+  }
+`;
+
+const Container = styled.div`
+  .ant-layout-sider {
+    background: initial;
   }
 `;
 
@@ -90,7 +95,7 @@ export const SideNav: React.FC<Props> = ({
     return null;
   }
   return (
-    <>
+    <Container>
       <BodyMask
         onClick={() => setCollapsed(true)}
         sidebarShown={!collapsed}
@@ -117,7 +122,7 @@ export const SideNav: React.FC<Props> = ({
         >
         </Menu>
       </StyledSider>
-    </>
+    </Container>
   );
 };
 

--- a/apps/mis-web/src/layouts/base/SideNav/index.tsx
+++ b/apps/mis-web/src/layouts/base/SideNav/index.tsx
@@ -28,7 +28,6 @@ const StyledSider = styled(Sider)`
 
   @media (max-width: ${antdBreakpoints[breakpoint]}px ) {
     position: absolute !important;
-    height: 100%;
     z-index: 1000;
 
     body, html {
@@ -38,6 +37,8 @@ const StyledSider = styled(Sider)`
 
     overflow: auto;
   }
+
+  height: 100%;
 
   .ant-menu-item:first-child {
     margin-top: 0px;

--- a/apps/mis-web/src/utils/head.tsx
+++ b/apps/mis-web/src/utils/head.tsx
@@ -7,7 +7,7 @@ type Props = React.PropsWithChildren<{
 export const Head: React.FC<Props> = ({ title, children }) => {
   return (
     <NextHead>
-      <title>{title} - scow</title>
+      <title>{`${title} - scow`}</title>
       {children}
     </NextHead>
   );

--- a/apps/portal-web/src/layouts/base/BaseLayout.tsx
+++ b/apps/portal-web/src/layouts/base/BaseLayout.tsx
@@ -26,7 +26,6 @@ const ContentPart = styled.div`
   flex: 1;
   flex-direction: column;
   width: 100%;
-  overflow-x: scroll;
 `;
 
 const Content = styled(Layout.Content)`

--- a/apps/portal-web/src/layouts/base/SideNav/index.tsx
+++ b/apps/portal-web/src/layouts/base/SideNav/index.tsx
@@ -28,7 +28,7 @@ const StyledSider = styled(Sider)`
 
   @media (max-width: ${antdBreakpoints[breakpoint]}px ) {
     position: absolute !important;
-    height: 100%;
+    min-height: 100%;
     z-index: 1000;
 
     body, html {
@@ -38,6 +38,8 @@ const StyledSider = styled(Sider)`
 
     overflow: auto;
   }
+
+  height: 100%;
 
   .ant-menu-item:first-child {
     margin-top: 0px;

--- a/apps/portal-web/src/layouts/base/SideNav/index.tsx
+++ b/apps/portal-web/src/layouts/base/SideNav/index.tsx
@@ -39,7 +39,6 @@ const StyledSider = styled(Sider)`
     overflow: auto;
   }
 
-
   .ant-menu-item:first-child {
     margin-top: 0px;
   }
@@ -48,8 +47,12 @@ const StyledSider = styled(Sider)`
     min-height: 100%;
     border-right: 0;
   }
+`;
 
-
+const Container = styled.div`
+  .ant-layout-sider {
+    background: initial;
+  }
 `;
 
 function getAllParentKeys(routes: NavItemProps[]): string[] {
@@ -92,7 +95,7 @@ export const SideNav: React.FC<Props> = ({
     return null;
   }
   return (
-    <>
+    <Container>
       <BodyMask
         onClick={() => setCollapsed(true)}
         sidebarShown={!collapsed}
@@ -119,7 +122,7 @@ export const SideNav: React.FC<Props> = ({
         >
         </Menu>
       </StyledSider>
-    </>
+    </Container>
   );
 };
 

--- a/apps/portal-web/src/pageComponents/dashboard/CustomizableLogoAndText.tsx
+++ b/apps/portal-web/src/pageComponents/dashboard/CustomizableLogoAndText.tsx
@@ -45,6 +45,7 @@ export const CustomizableLogoAndText: React.FC<Props> = ({ hostname }) => {
           src={join(process.env.NEXT_PUBLIC_BASE_PATH || "", "/api/logo")}
           style={{
             objectFit: "contain",
+            maxWidth: "100%",
           }}
         />
       </Logo>

--- a/apps/portal-web/src/pageComponents/shell/Shell.tsx
+++ b/apps/portal-web/src/pageComponents/shell/Shell.tsx
@@ -2,6 +2,7 @@ import { join } from "path";
 import { useEffect, useRef } from "react";
 import { io } from "socket.io-client";
 import { User } from "src/stores/UserStore";
+import { debounce } from "src/utils/debounce";
 import styled from "styled-components";
 import { Terminal } from "xterm";
 import { FitAddon } from "xterm-addon-fit";
@@ -10,9 +11,9 @@ const TerminalContainer = styled.div`
   background-color: black;
   flex: 1;
 
-  // https://github.com/xtermjs/xterm.js/issues/3564#issuecomment-1034107272
+  width: 100%;
+
   .xterm-viewport {
-    width: initial !important;
     overflow-y: hidden;
   }
 `;
@@ -52,10 +53,10 @@ export const Shell: React.FC<Props> = ({ user, cluster, path }) => {
         `${path ? "path " + path : "home path"} ***\r\n`,
       );
 
-      const resizeObserver = new ResizeObserver(() => {
+      const resizeObserver = new ResizeObserver(debounce(() => {
         fitAddon.fit();
         socket.emit("resize", { cols: term.cols, rows: term.rows });
-      });
+      }));
 
       resizeObserver.observe(container.current);
 

--- a/apps/portal-web/src/pageComponents/shell/Shell.tsx
+++ b/apps/portal-web/src/pageComponents/shell/Shell.tsx
@@ -13,6 +13,7 @@ const TerminalContainer = styled.div`
   // https://github.com/xtermjs/xterm.js/issues/3564#issuecomment-1034107272
   .xterm-viewport {
     width: initial !important;
+    overflow-y: hidden;
   }
 `;
 
@@ -30,7 +31,10 @@ export const Shell: React.FC<Props> = ({ user, cluster, path }) => {
   useEffect(() => {
     if (container.current) {
 
-      const term = new Terminal({ cursorBlink: true });
+      const term = new Terminal({
+        cursorBlink: true,
+        scrollback: 0,
+      });
 
       const payload = {
         cluster,

--- a/apps/portal-web/src/pageComponents/shell/Shell.tsx
+++ b/apps/portal-web/src/pageComponents/shell/Shell.tsx
@@ -12,10 +12,6 @@ const TerminalContainer = styled.div`
   flex: 1;
 
   width: 100%;
-
-  .xterm-viewport {
-    overflow-y: hidden;
-  }
 `;
 
 interface Props {
@@ -34,7 +30,6 @@ export const Shell: React.FC<Props> = ({ user, cluster, path }) => {
 
       const term = new Terminal({
         cursorBlink: true,
-        scrollback: 0,
       });
 
       const payload = {

--- a/apps/portal-web/src/pages/shell/[cluster]/[[...path]].tsx
+++ b/apps/portal-web/src/pages/shell/[cluster]/[[...path]].tsx
@@ -11,7 +11,7 @@ import { Head } from "src/utils/head";
 import styled from "styled-components";
 
 const Container = styled.div`
-  position: absolute;
+  position: fixed;
   left: 0;
   top: 0;
   height: 100%;

--- a/apps/portal-web/src/utils/head.tsx
+++ b/apps/portal-web/src/utils/head.tsx
@@ -7,7 +7,7 @@ type Props = React.PropsWithChildren<{
 export const Head: React.FC<Props> = ({ title, children }) => {
   return (
     <NextHead>
-      <title>{title} - scow</title>
+      <title>{`${title} - scow`}</title>
       {children}
     </NextHead>
   );


### PR DESCRIPTION
1. 去除内容一直出现的底部的滚动条，只有宽度过宽会出现滚动条
1. 修复Shell无法正常全屏的问题
3. Shell可以正常放大缩小 
4. 门户主页logo最大宽度为设备宽度

![image](https://user-images.githubusercontent.com/8363856/203725025-3e9e0bb4-4fe5-4392-91ed-5e2cee666b4a.png)

5. 去除侧边栏滑出时的底色（见下图，现在已经没有了）

![image](https://user-images.githubusercontent.com/8363856/203725262-2da931c1-2f2a-4407-b14b-8ebc97bdde5e.png)

6. 修复title标签有多个组件的报错