### PR TITLE
fix(web): 修复base path不为/的时候，header中门户和管理系统的Link指向不正确的问题

### DIFF
--- a/apps/mis-web/src/layouts/base/header/index.tsx
+++ b/apps/mis-web/src/layouts/base/header/index.tsx
@@ -1,6 +1,5 @@
 import { ArrowRightOutlined, MenuFoldOutlined, MenuUnfoldOutlined } from "@ant-design/icons";
 import { Space, Typography } from "antd";
-import Link from "next/link";
 import { join } from "path";
 import React from "react";
 import { antdBreakpoints } from "src/layouts/base/constants";
@@ -91,18 +90,13 @@ export const Header: React.FC<Props> = ({
       {
         publicConfig.PORTAL_URL ? (
           <HeaderItem>
-            <Link
-              href={
-                user
-                  ? join(publicConfig.PORTAL_URL, "/api/auth/callback?token=" + user.token)
-                  : publicConfig.PORTAL_URL
-              }
-              legacyBehavior
+            {/* Cannot use Link because links adds BASE_PATH, but MIS_URL already contains it */}
+            <Typography.Link href={user
+              ? join(publicConfig.PORTAL_URL, "/api/auth/callback?token=" + user.token)
+              : publicConfig.PORTAL_URL}
             >
-              <Typography.Link>
-                <ArrowRightOutlined /> 门户
-              </Typography.Link>
-            </Link>
+              <ArrowRightOutlined /> 门户
+            </Typography.Link>
           </HeaderItem>
         ) : undefined
       }

--- a/apps/portal-web/src/layouts/base/header/index.tsx
+++ b/apps/portal-web/src/layouts/base/header/index.tsx
@@ -1,6 +1,5 @@
 import { ArrowRightOutlined, MenuFoldOutlined, MenuUnfoldOutlined } from "@ant-design/icons";
 import { Space, Typography } from "antd";
-import Link from "next/link";
 import { join } from "path";
 import React from "react";
 import { antdBreakpoints } from "src/layouts/base/constants";
@@ -91,18 +90,13 @@ export const Header: React.FC<Props> = ({
       {
         publicConfig.MIS_URL ? (
           <HeaderItem>
-            <Link
-              href={
-                user
-                  ? join(publicConfig.MIS_URL, "/api/auth/callback?token=" + user.token)
-                  : publicConfig.MIS_URL
-              }
-              legacyBehavior
+            {/* Cannot use Link because links adds BASE_PATH, but MIS_URL already contains it */}
+            <Typography.Link href={user
+              ? join(publicConfig.MIS_URL, "/api/auth/callback?token=" + user.token)
+              : publicConfig.MIS_URL}
             >
-              <Typography.Link>
-                <ArrowRightOutlined /> 管理系统
-              </Typography.Link>
-            </Link>
+              <ArrowRightOutlined /> 管理系统
+            </Typography.Link>
           </HeaderItem>
         ) : undefined
       }


### PR DESCRIPTION
例如base path是`/demo/scow`，管理系统部署在`/mis`下，那么之前门户系统header中的跳转到管理系统的link的href实际上是`/demo/scow/demo/scow/mis`。这是因为之前使用Link组件，而Link组件将会在已经有了base path的MIS_URL变量的基础上再加一个base path。这个PR修复了这个问题。