### PR TITLE
chore: 统一镜像结构

### DIFF
--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "rimraf build && tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
     "dev": "nodemon --watch src -e ts --exec \"npx dotenv -e env/.env.dev -- npx ts-node -r tsconfig-paths/register src/index.ts\"",
+    "serve": "node build/index.js",
     "test": "jest"
   },
   "keywords": [],

--- a/apps/mis-server/src/plugins/orm.ts
+++ b/apps/mis-server/src/plugins/orm.ts
@@ -1,11 +1,14 @@
 import { plugin } from "@ddadaal/tsgrpc-server";
 import { MikroORM, Options } from "@mikro-orm/core";
 import { MySqlDriver } from "@mikro-orm/mysql";
+import { join } from "path";
 import { config } from "src/config/env";
 import { misConfig } from "src/config/mis";
 import { DatabaseSeeder } from "src/seeders/DatabaseSeeder";
 
 import { entities } from "../entities";
+
+const distPath = process.env.NODE_ENV === "production" ? "build" : "src";
 
 export const ormConfigs = {
   host: misConfig.db.host,
@@ -17,13 +20,13 @@ export const ormConfigs = {
   forceUndefined: true,
   runMigrations: true,
   migrations: {
-    path: "./src/migrations",
+    path: join(distPath, "migrations"),
     pattern: /^[\w-]+\d+\.(j|t)s$/,
   },
   entities,
   debug: misConfig.db.debug,
   seeder: {
-    path: "./src/seeders",
+    path: join(distPath, "seenders"),
   },
 } as Options<MySqlDriver>;
 

--- a/dockerfiles/Dockerfile.auth
+++ b/dockerfiles/Dockerfile.auth
@@ -47,10 +47,10 @@ WORKDIR /app/apps/auth
 COPY apps/auth/public ./public
 COPY --from=builder /app/apps/auth/package.json .
 COPY --from=builder /app/apps/auth/node_modules/ ./node_modules
-COPY --from=builder /app/apps/auth/build ./src
+COPY --from=builder /app/apps/auth/build ./build
 
 ENV NODE_ENV production
 
 EXPOSE 5000
 
-ENTRYPOINT [ "node", "src/index.js" ]
+CMD ["npm", "run", "serve"]

--- a/dockerfiles/Dockerfile.mis-server
+++ b/dockerfiles/Dockerfile.mis-server
@@ -70,11 +70,11 @@ WORKDIR /app/apps/mis-server
 COPY --from=builder /app/apps/mis-server/package.json .
 COPY --from=builder /app/apps/mis-server/node_modules/ ./node_modules
 COPY --from=builder /app/apps/mis-server/scripts/ ./scripts
-COPY --from=builder /app/apps/mis-server/build/ ./src
+COPY --from=builder /app/apps/mis-server/build/ ./build
 
 ENV NODE_ENV production
 
-ENTRYPOINT [ "node", "src/index.js" ]
+CMD ["npm", "run", "serve"]
 
 
 

--- a/dockerfiles/Dockerfile.portal-server
+++ b/dockerfiles/Dockerfile.portal-server
@@ -63,12 +63,12 @@ COPY --from=builder /app/libs/config/build/ ./build
 WORKDIR /app/apps/portal-server
 COPY --from=builder /app/apps/portal-server/package.json .
 COPY --from=builder /app/apps/portal-server/node_modules/ ./node_modules
-COPY --from=builder /app/apps/portal-server/build/ ./src
 COPY --from=builder /app/apps/portal-server/assets ./assets
+COPY --from=builder /app/apps/portal-server/build/ ./build
 
 ENV NODE_ENV production
 
-ENTRYPOINT [ "node", "src/index.js" ]
+CMD ["npm", "run", "serve"]
 
 
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "build": "pnpm run -r build",
     "build:libs": "pnpm --filter \"./libs/**\" run build",
-    "build:containers": "docker compose --env-file dev/.env.build -f dev/docker-compose.build.yml build",
+    "build:images": "docker compose --env-file dev/.env.build -f dev/docker-compose.build.yml build",
     "prepareDev": "pnpm build:libs && pnpm run -r prepareDev",
     "prune": "pnpm clean --yes && pnpm bootstrap --ci -- --production",
     "devenv": "docker compose --env-file dev/.env.dev -f dev/docker-compose.dev.yml up -d",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "devenv": "docker compose --env-file dev/.env.dev -f dev/docker-compose.dev.yml up -d",
     "devenv:stop": "docker compose --env-file dev/.env.dev -f dev/docker-compose.dev.yml down",
     "test": "pnpm run -r test",
-    "test:ci": "pnpm run -r test --ci --coverage",
+    "test:ci": "pnpm run -r test --ci --coverage --runInBand",
     "prepare": "node -e \"try { require('husky').install() } catch (e) {if (e.code !== 'MODULE_NOT_FOUND') throw e}\"",
     "lint": "eslint --cache --ext .tsx,.ts .",
     "cm": "cz"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "devenv": "docker compose --env-file dev/.env.dev -f dev/docker-compose.dev.yml up -d",
     "devenv:stop": "docker compose --env-file dev/.env.dev -f dev/docker-compose.dev.yml down",
     "test": "pnpm run -r test",
-    "test:ci": "pnpm run -r test --ci --coverage --runInBand",
+    "test:ci": "pnpm run -r test --ci --coverage",
     "prepare": "node -e \"try { require('husky').install() } catch (e) {if (e.code !== 'MODULE_NOT_FOUND') throw e}\"",
     "lint": "eslint --cache --ext .tsx,.ts .",
     "cm": "cz"


### PR DESCRIPTION
之前五个node镜像中，有的镜像的项目代码在`src`中，有的在`build`中；有的使用ENTRYPOINT作为dockerfile的启动语句，有的使用CMD。这个PR统一了这些区别。

1. 所有镜像中的项目代码均存放在`build`中
2. 所有Dockerfile均使用`CMD ["npm", "run", "serve"]`作为容器的启动语句

同时还修改了根目录下的build:containers命令改成了build:images