### PR TITLE
fix(build): 修改默认构建的镜像的TAG为master

### DIFF
--- a/deploy/config-example.py
+++ b/deploy/config-example.py
@@ -16,6 +16,7 @@
 # COMMON.BASE_PATH: 整个系统的部署根路径。以/开头，不要以/结尾，如果是根路径写"/"
 # COMMON.IMAGE_BASE: 镜像仓库地址，据实际情况填写
 # COMMON.IMAGE_TAG: 镜像tag，据实际情况填写
+# 如果您的镜像是本地构建的，IMAGE_BASE和IMAGE_TAG必须和构建时.env.build中的值保持一致。
 COMMON = {
   "PORT": 80,
   "BASE_PATH": "/",

--- a/dev/.env.build
+++ b/dev/.env.build
@@ -1,2 +1,2 @@
 IMAGE_BASE=ghcr.io/pkuhpc/scow
-TAG=latest
+TAG=master


### PR DESCRIPTION
config.py中的COMMON.IMAGE_BASE和IMAGE_TAG需要和构建时的dev/.dev.build中指定的IMAGE_BASE和IMAGE_TAG对应。我发现目前默认的构建时的tag为latest，但是默认的config.py中为master，不匹配。

Fixes #325 