### PR TITLE
feat(lib-config): 在配置文件格式不正确抛出的错误信息中增加配置文件路径

### DIFF
--- a/libs/libconfig/src/validation.ts
+++ b/libs/libconfig/src/validation.ts
@@ -36,12 +36,14 @@ export const createAjv = () => addFormats(new Ajv({
 
 export function validateObject<TObj extends TSchema>(
   schema: TObj, object: any,
-): Static<TObj> {
+): Static<TObj> | Error {
 
   const ajv = createAjv();
   const ok = ajv.validate(schema, object);
 
-  if (!ok) { throw new Error("Invalid json. " + ajv.errorsText()); }
+  if (!ok) {
+    return new Error(ajv.errorsText());
+  }
 
   return object;
 }

--- a/libs/libconfig/tests/fileConfig.test.ts
+++ b/libs/libconfig/tests/fileConfig.test.ts
@@ -71,3 +71,13 @@ it("reports error if config not exist", async () => {
   expect(() => runTest([], "yml")).toThrow();
 });
 
+it("reports file path", async () => {
+
+  fs.writeFileSync(path.join(folderPath, configName + ".yaml"), exts.yaml({ loaded: false }));
+  try {
+    getConfigFromFile(Schema, configName, folderPath);
+    expect("").fail("should throw");
+  } catch (e: any) {
+    expect(e.message).toContain(path.join(folderPath, configName + ".yaml"));
+  }
+});

--- a/libs/libconfig/tests/global.d.ts
+++ b/libs/libconfig/tests/global.d.ts
@@ -10,27 +10,4 @@
  * See the Mulan PSL v2 for more details.
  */
 
-import { Type } from "@sinclair/typebox";
-import { validateObject } from "src/validation";
-
-const Schema = Type.Object({
-  propertyA: Type.Number(),
-});
-
-it.each([
-  [{ propertyA: 1 }, true],
-  [{ propertyA: 1, propertyB: 2 }, true],
-  [{ propertyA: "1" }, false],
-  [{ propertyB: 2 }, false],
-
-])("returns correct validation result", (data, expected) => {
-
-  const result = validateObject(Schema, data);
-
-  if (expected) {
-    expect(result).toEqual(data);
-  } else {
-    expect(result).toBeInstanceOf(Error);
-  }
-});
-
+import "jest-extended";


### PR DESCRIPTION
```
 Error: Error reading config file /home/ddadaal/Code/scow/libs/libconfig/tests/configFileTestundefined/test.yaml: data/loaded must be string
```