### PR TITLE
ci: CI步骤增加代码格式检查

### DIFF
--- a/.github/workflows/lint-pr-content.yaml
+++ b/.github/workflows/lint-pr-content.yaml
@@ -1,4 +1,4 @@
-name: Lint PR
+name: Lint PR Title and Content
 on:
   pull_request_target:
     types:
@@ -8,6 +8,7 @@ on:
       - synchronize
 
 jobs:
+
   lint-title:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test-build-publish.yaml
+++ b/.github/workflows/test-build-publish.yaml
@@ -28,6 +28,12 @@ jobs:
           node-version: 18.x
           cache: pnpm
 
+      - name: Install dependencies
+        run: pnpm i --frozen-lockfile
+
+      - name: Lint code
+        run: pnpm lint
+
       - name: Generate SSH key pairs for test
         run: ssh-keygen -t rsa -q -f "$HOME/.ssh/id_rsa" -N ""
 
@@ -36,9 +42,6 @@ jobs:
 
       - name: Check running containers
         run: docker ps
-
-      - name: Install dependencies
-        run: pnpm i --frozen-lockfile
 
       - name: Prepare dev libs and code
         run: pnpm prepareDev

--- a/apps/portal-server/tests/file/exists.test.ts
+++ b/apps/portal-server/tests/file/exists.test.ts
@@ -1,3 +1,15 @@
+/**
+ * Copyright (c) 2022 Peking University and Peking University Institute for Computing and Digital Economy
+ * SCOW is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *          http://license.coscl.org.cn/MulanPSL2
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PSL v2 for more details.
+ */
+
 import { asyncUnaryCall } from "@ddadaal/tsgrpc-client";
 import { Server } from "@ddadaal/tsgrpc-server";
 import { credentials } from "@grpc/grpc-js";

--- a/apps/portal-web/src/pageComponents/filemanager/FileManager.tsx
+++ b/apps/portal-web/src/pageComponents/filemanager/FileManager.tsx
@@ -179,7 +179,7 @@ export const FileManager: React.FC<Props> = ({ cluster, path, urlPrefix }) => {
           modal.error({
             title: `文件${file.name}${operationText}出错`,
             content: error,
-          })
+          });
         })
         .then(() => {
           setOperation((o) => o ? { ...operation, completed: o.completed.concat(file) } : undefined);
@@ -189,14 +189,14 @@ export const FileManager: React.FC<Props> = ({ cluster, path, urlPrefix }) => {
         });
     };
     
-    let successfulCount:number = 0;
-    let abandonCount:number = 0;
+    let successfulCount: number = 0;
+    let abandonCount: number = 0;
     const allCount = operation.selected.length;
     try {
       for (const x of operation.selected) {
         const exists = await api.fileExist({ query: { cluster, path: join(path, x.name) } });
         if (exists.result) {
-          await new Promise<void>(async (res) =>{
+          await new Promise<void>(async (res) => {
             modal.confirm({
               title: "文件/目录已存在",
               content: `文件/目录${x.name}已存在，是否覆盖？`,
@@ -211,20 +211,20 @@ export const FileManager: React.FC<Props> = ({ cluster, path, urlPrefix }) => {
               },
               onCancel: async () => { abandonCount++; res(); },
             });
-          })
+          });
         } else {
           await pasteFile(x, join(operation.originalPath, x.name), join(path, x.name));
           successfulCount++;
         }
       }
       message.success(
-        `${operationText}成功！总计${allCount}项文件/目录，其中成功${successfulCount}项，放弃${abandonCount}项`
+        `${operationText}成功！总计${allCount}项文件/目录，其中成功${successfulCount}项，放弃${abandonCount}项`,
       );
     } catch (e) {
       console.error(e);
       message.error(
-        `${operationText}错误！总计${allCount}项文件/目录，其中成功${successfulCount}项，放弃${abandonCount}项`+
-        `失败${allCount - successfulCount - abandonCount}项`
+        `${operationText}错误！总计${allCount}项文件/目录，其中成功${successfulCount}项，放弃${abandonCount}项` +
+        `失败${allCount - successfulCount - abandonCount}项`,
       );
     } finally {
       resetSelectedAndOperation();

--- a/apps/portal-web/src/pages/api/file/fileExist.ts
+++ b/apps/portal-web/src/pages/api/file/fileExist.ts
@@ -1,3 +1,15 @@
+/**
+ * Copyright (c) 2022 Peking University and Peking University Institute for Computing and Digital Economy
+ * SCOW is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *          http://license.coscl.org.cn/MulanPSL2
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PSL v2 for more details.
+ */
+
 import { asyncUnaryCall } from "@ddadaal/tsgrpc-client";
 import { status } from "@grpc/grpc-js";
 import { authenticate } from "src/auth/server";

--- a/apps/portal-web/src/pages/api/file/getFileType.ts
+++ b/apps/portal-web/src/pages/api/file/getFileType.ts
@@ -1,3 +1,15 @@
+/**
+ * Copyright (c) 2022 Peking University and Peking University Institute for Computing and Digital Economy
+ * SCOW is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *          http://license.coscl.org.cn/MulanPSL2
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PSL v2 for more details.
+ */
+
 import { asyncUnaryCall } from "@ddadaal/tsgrpc-client";
 import { status } from "@grpc/grpc-js";
 import { authenticate } from "src/auth/server";


### PR DESCRIPTION
#327 没有lint代码就提交了，后面发现是因为之前只在commit的时候使用git的pre-commit hook使用eslint检查代码风格，但是这个步骤可能会被人跳过。这次在CI的时候检查代码风格，这样就绕不过了。同时修复 #327 的代码格式问题。