### PR TITLE
fix(web): 修改小屏幕下header宽度溢出问题

### DIFF
--- a/apps/mis-web/src/layouts/base/header/UserIndicator.tsx
+++ b/apps/mis-web/src/layouts/base/header/UserIndicator.tsx
@@ -16,6 +16,7 @@ import Link from "next/link";
 import React from "react";
 import { ClickableA } from "src/components/ClickableA";
 import { UserInfo } from "src/models/User";
+import { antdBreakpoints } from "src/styles/constants";
 import styled from "styled-components";
 
 interface Props {
@@ -25,6 +26,12 @@ interface Props {
 
 const Container = styled.div`
   white-space: nowrap;
+`;
+
+const HiddenOnSmallScreen = styled.span`
+  @media (max-width: ${antdBreakpoints.md}px) {
+    display: none;
+  }
 `;
 
 export const UserIndicator: React.FC<Props> = ({
@@ -39,6 +46,7 @@ export const UserIndicator: React.FC<Props> = ({
             trigger={["click"]}
             menu={{
               items: [
+                { key: "username", disabled: true, label: `用户姓名：${user.name}` },
                 { key: "userid", disabled: true, label: `用户ID：${user.identityId}` },
                 { key: "profileLink", label: <Link href="/profile">个人信息</Link> },
                 { key: "logout", onClick: logout, label: "退出登录" },
@@ -47,7 +55,9 @@ export const UserIndicator: React.FC<Props> = ({
           >
             <ClickableA>
               <UserOutlined />
-              {user.name}
+              <HiddenOnSmallScreen>
+                {user.name}
+              </HiddenOnSmallScreen>
               <DownOutlined />
             </ClickableA>
           </Dropdown>

--- a/apps/mis-web/src/layouts/base/header/index.tsx
+++ b/apps/mis-web/src/layouts/base/header/index.tsx
@@ -10,7 +10,7 @@
  * See the Mulan PSL v2 for more details.
  */
 
-import { ArrowRightOutlined, MenuFoldOutlined, MenuUnfoldOutlined } from "@ant-design/icons";
+import { DesktopOutlined, MenuFoldOutlined, MenuUnfoldOutlined } from "@ant-design/icons";
 import { Space, Typography } from "antd";
 import { join } from "path";
 import React from "react";
@@ -42,7 +42,13 @@ const HeaderItem = styled.div`
   padding: 0 16px;
   /* justify-content: center; */
   height: 100%;
+
+  @media (max-width: ${antdBreakpoints.md}px) {
+    padding-right: 4px;
+  }
+
 `;
+
 
 const MenuPart = styled(HeaderItem)`
   flex: 1;
@@ -59,6 +65,12 @@ const MenuPartPlaceholder = styled.div`
 const IndicatorPart = styled(HeaderItem)`
   justify-self: flex-end;
   flex-wrap: nowrap;
+`;
+
+const HiddenOnSmallScreen = styled.span`
+  @media (max-width: ${antdBreakpoints.md}px) {
+    display: none;
+  }
 `;
 
 interface Props {
@@ -107,7 +119,10 @@ export const Header: React.FC<Props> = ({
               ? join(publicConfig.PORTAL_URL, "/api/auth/callback?token=" + user.token)
               : publicConfig.PORTAL_URL}
             >
-              <ArrowRightOutlined /> 门户
+              <DesktopOutlined style={{ paddingRight: 2 }} />
+              <HiddenOnSmallScreen>
+                 门户
+              </HiddenOnSmallScreen>
             </Typography.Link>
           </HeaderItem>
         ) : undefined

--- a/apps/portal-web/src/layouts/base/header/UserIndicator.tsx
+++ b/apps/portal-web/src/layouts/base/header/UserIndicator.tsx
@@ -16,6 +16,7 @@ import Link from "next/link";
 import React from "react";
 import { ClickableA } from "src/components/ClickableA";
 import { UserInfo } from "src/models/User";
+import { antdBreakpoints } from "src/styles/constants";
 import styled from "styled-components";
 
 interface Props {
@@ -25,6 +26,13 @@ interface Props {
 
 const Container = styled.div`
   white-space: nowrap;
+`;
+
+const HiddenOnSmallScreen = styled.span`
+  @media (max-width: ${antdBreakpoints.md}px) {
+    display: none;
+  }
+
 `;
 
 export const UserIndicator: React.FC<Props> = ({
@@ -47,7 +55,9 @@ export const UserIndicator: React.FC<Props> = ({
           >
             <ClickableA>
               <UserOutlined />
-              {user.identityId}
+              <HiddenOnSmallScreen>
+                {user.identityId}
+              </HiddenOnSmallScreen>
               <DownOutlined />
             </ClickableA>
           </Dropdown>

--- a/apps/portal-web/src/layouts/base/header/index.tsx
+++ b/apps/portal-web/src/layouts/base/header/index.tsx
@@ -10,7 +10,7 @@
  * See the Mulan PSL v2 for more details.
  */
 
-import { ArrowRightOutlined, MenuFoldOutlined, MenuUnfoldOutlined } from "@ant-design/icons";
+import { DatabaseOutlined, MenuFoldOutlined, MenuUnfoldOutlined } from "@ant-design/icons";
 import { Space, Typography } from "antd";
 import { join } from "path";
 import React from "react";
@@ -42,6 +42,11 @@ const HeaderItem = styled.div`
   padding: 0 16px;
   /* justify-content: center; */
   height: 100%;
+
+  @media (max-width: ${antdBreakpoints.md}px) {
+    padding-right: 4px;
+  }
+
 `;
 
 const MenuPart = styled(HeaderItem)`
@@ -54,6 +59,13 @@ const MenuPartPlaceholder = styled.div`
   @media (min-width: ${antdBreakpoints.md}px) {
     display: none;
   }
+`;
+
+const HiddenOnSmallScreen = styled.span`
+  @media (max-width: ${antdBreakpoints.md}px) {
+    display: none;
+  }
+
 `;
 
 const IndicatorPart = styled(HeaderItem)`
@@ -107,7 +119,10 @@ export const Header: React.FC<Props> = ({
               ? join(publicConfig.MIS_URL, "/api/auth/callback?token=" + user.token)
               : publicConfig.MIS_URL}
             >
-              <ArrowRightOutlined /> 管理系统
+              <DatabaseOutlined />
+              <HiddenOnSmallScreen>
+                管理系统
+              </HiddenOnSmallScreen>
             </Typography.Link>
           </HeaderItem>
         ) : undefined


### PR DESCRIPTION
这是之前的：

![image](https://user-images.githubusercontent.com/8363856/205535625-7b150744-0cfb-4f08-a791-af7c4f98d8db.png)

这是现在的：

![image](https://user-images.githubusercontent.com/8363856/205535657-76cb040f-3eb1-4157-97e1-b9b4b71c9922.png)

具体修改：

- 在md宽度以下隐藏跳转到门户或者管理系统的文本
- 在md宽度以下，header图标之间的padding改为4px（md宽度以上为16px）
- 修改门户的图标为DesktopOutlined，管理系统的图标为DatabaseOutlined
- 管理系统用户下拉框中增加用户姓名的显示（因为小屏幕下用户姓名被隐藏，没有地方可以显示用户姓名）（门户系统没有用户姓名）