### PR TITLE
fix(web): 在localStorage中记住用户黑暗模式的设置

### DIFF
--- a/apps/mis-web/src/layouts/darkMode.tsx
+++ b/apps/mis-web/src/layouts/darkMode.tsx
@@ -11,11 +11,13 @@
  */
 
 import { FloatButton } from "antd";
+import dynamic from "next/dynamic";
 import Image from "next/image";
 import React, { PropsWithChildren, useEffect, useState } from "react";
 import moon from "src/components/icons/moon.svg";
 import sun from "src/components/icons/sun.svg";
 import sunMoon from "src/components/icons/sun-moon.svg";
+import { useLocalStorage } from "src/utils/hooks";
 
 const modes = ["system", "dark", "light"] as const;
 
@@ -28,14 +30,14 @@ const icons = {
 export type DarkMode = typeof modes[number];
 
 const DarkModeContext = React.createContext<{
-  mode: DarkMode;
-  dark: boolean;
-  setMode: (mode: DarkMode) => void;
-    }>(undefined!);
+   mode: DarkMode;
+   dark: boolean;
+   setMode: (mode: DarkMode) => void;
+     }>(undefined!);
 
 export const useDarkMode = () => React.useContext(DarkModeContext);
 
-export const DarkModeButton = () => {
+const DarkModeButtonInternal = () => {
   const { mode, setMode } = useDarkMode();
 
   const [icon, alt, label] = icons[mode];
@@ -50,9 +52,15 @@ export const DarkModeButton = () => {
   );
 };
 
+const DARK_MODE_KEY = "scow-dark-mode";
+
+// disable ssr for the button
+// for the image rendered in server and client is different
+export const DarkModeButton = dynamic(() => Promise.resolve(DarkModeButtonInternal), { ssr: false });
+
 export const DarkModeProvider = ({ children }: PropsWithChildren<{}>) => {
 
-  const [mode, setMode] = useState<DarkMode>("system");
+  const [mode, setMode] = useLocalStorage<DarkMode>(DARK_MODE_KEY, "system");
 
   const [dark, setDark] = useState(false);
 

--- a/apps/mis-web/src/utils/hooks.ts
+++ b/apps/mis-web/src/utils/hooks.ts
@@ -10,7 +10,7 @@
  * See the Mulan PSL v2 for more details.
  */
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 
 // https://stackoverflow.com/a/53180013
 
@@ -24,3 +24,43 @@ export const useDidUpdateEffect: typeof useEffect = (effect, deps) => {
       didMountRef.current = true;
   }, deps);
 };
+
+// https://usehooks.com/useLocalStorage/
+export function useLocalStorage<T>(key: string, initialValue: T) {
+  // State to store our value
+  // Pass initial state function to useState so logic is only executed once
+  const [storedValue, setStoredValue] = useState<T>(() => {
+    if (typeof window === "undefined") {
+      return initialValue;
+    }
+    try {
+      // Get from local storage by key
+      const item = window.localStorage.getItem(key);
+      // Parse stored json or if none return initialValue
+      return item ? JSON.parse(item) : initialValue;
+    } catch (error) {
+      // If error also return initialValue
+      console.log(error);
+      return initialValue;
+    }
+  });
+  // Return a wrapped version of useState's setter function that ...
+  // ... persists the new value to localStorage.
+  const setValue = (value: T | ((val: T) => T)) => {
+    try {
+      // Allow value to be a function so we have same API as useState
+      const valueToStore =
+        value instanceof Function ? value(storedValue) : value;
+      // Save state
+      setStoredValue(valueToStore);
+      // Save to local storage
+      if (typeof window !== "undefined") {
+        window.localStorage.setItem(key, JSON.stringify(valueToStore));
+      }
+    } catch (error) {
+      // A more advanced implementation would handle the error case
+      console.log(error);
+    }
+  };
+  return [storedValue, setValue] as const;
+}

--- a/apps/portal-web/src/layouts/darkMode.tsx
+++ b/apps/portal-web/src/layouts/darkMode.tsx
@@ -11,11 +11,13 @@
  */
 
 import { FloatButton } from "antd";
+import dynamic from "next/dynamic";
 import Image from "next/image";
 import React, { PropsWithChildren, useEffect, useState } from "react";
 import moon from "src/components/icons/moon.svg";
 import sun from "src/components/icons/sun.svg";
 import sunMoon from "src/components/icons/sun-moon.svg";
+import { useLocalStorage } from "src/utils/hooks";
 
 const modes = ["system", "dark", "light"] as const;
 
@@ -28,14 +30,14 @@ const icons = {
 export type DarkMode = typeof modes[number];
 
 const DarkModeContext = React.createContext<{
-  mode: DarkMode;
-  dark: boolean;
-  setMode: (mode: DarkMode) => void;
-    }>(undefined!);
+    mode: DarkMode;
+    dark: boolean;
+    setMode: (mode: DarkMode) => void;
+      }>(undefined!);
 
 export const useDarkMode = () => React.useContext(DarkModeContext);
 
-export const DarkModeButton = () => {
+const DarkModeButtonInternal = () => {
   const { mode, setMode } = useDarkMode();
 
   const [icon, alt, label] = icons[mode];
@@ -50,9 +52,15 @@ export const DarkModeButton = () => {
   );
 };
 
+const DARK_MODE_KEY = "scow-dark-mode";
+
+// disable ssr for the button
+// for the image rendered in server and client is different
+export const DarkModeButton = dynamic(() => Promise.resolve(DarkModeButtonInternal), { ssr: false });
+
 export const DarkModeProvider = ({ children }: PropsWithChildren<{}>) => {
 
-  const [mode, setMode] = useState<DarkMode>("system");
+  const [mode, setMode] = useLocalStorage<DarkMode>(DARK_MODE_KEY, "system");
 
   const [dark, setDark] = useState(false);
 

--- a/apps/portal-web/src/utils/hooks.ts
+++ b/apps/portal-web/src/utils/hooks.ts
@@ -10,7 +10,7 @@
  * See the Mulan PSL v2 for more details.
  */
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 
 // https://stackoverflow.com/a/53180013
 
@@ -24,3 +24,44 @@ export const useDidUpdateEffect: typeof useEffect = (effect, deps) => {
       didMountRef.current = true;
   }, deps);
 };
+
+
+// https://usehooks.com/useLocalStorage/
+export function useLocalStorage<T>(key: string, initialValue: T) {
+  // State to store our value
+  // Pass initial state function to useState so logic is only executed once
+  const [storedValue, setStoredValue] = useState<T>(() => {
+    if (typeof window === "undefined") {
+      return initialValue;
+    }
+    try {
+      // Get from local storage by key
+      const item = window.localStorage.getItem(key);
+      // Parse stored json or if none return initialValue
+      return item ? JSON.parse(item) : initialValue;
+    } catch (error) {
+      // If error also return initialValue
+      console.log(error);
+      return initialValue;
+    }
+  });
+  // Return a wrapped version of useState's setter function that ...
+  // ... persists the new value to localStorage.
+  const setValue = (value: T | ((val: T) => T)) => {
+    try {
+      // Allow value to be a function so we have same API as useState
+      const valueToStore =
+        value instanceof Function ? value(storedValue) : value;
+      // Save state
+      setStoredValue(valueToStore);
+      // Save to local storage
+      if (typeof window !== "undefined") {
+        window.localStorage.setItem(key, JSON.stringify(valueToStore));
+      }
+    } catch (error) {
+      // A more advanced implementation would handle the error case
+      console.log(error);
+    }
+  };
+  return [storedValue, setValue] as const;
+}


### PR DESCRIPTION
在localStorage中增加一个`scow-dark-mode`的设置，记住用户黑暗模式的设置，这样用户刷新或者切换到门户/管理系统时黑暗模式设置不会重置为系统。