### PR TITLE
fix(portal-server): 使用xterm-256color创建shell

### DIFF
--- a/apps/portal-server/src/services/shell.ts
+++ b/apps/portal-server/src/services/shell.ts
@@ -115,7 +115,7 @@ export const shellServiceServer = plugin((server) => {
               channel,
             ),
           ]).finally(() => { call.end(); channel.end(); });
-        }, { cols, rows });
+        }, { cols, rows, term: "xterm-256color" });
       });
 
 


### PR DESCRIPTION
在通过ssh创建shell的时候，默认使用的终端为`vt100`，只支持16色，所以有的时候颜色显示不全。现在把使用的终端程序改成`xterm-256color`，能够显示更多颜色。

![image](https://user-images.githubusercontent.com/8363856/205793913-9ebc83fa-0ed0-48bb-93b4-036a1e9e7603.png)
