### PR TITLE
fix(portal-web): 修复从metadata中判断是否为SCOW业务逻辑错误的逻辑

### DIFF
--- a/apps/portal-web/src/utils/route.ts
+++ b/apps/portal-web/src/utils/route.ts
@@ -20,8 +20,9 @@ export const route: typeof rawRoute = (schemaName, handler) => {
       return response.catch((e) => {
         if (!(e.metadata instanceof Metadata)) { throw e; }
 
-        const SCOW_ERROR = e.metadata.get("IS_SCOW_ERROR");
-        if (!SCOW_ERROR) { throw e; }
+        const SCOW_ERROR = (e.metadata as Metadata).get("IS_SCOW_ERROR");
+        if (SCOW_ERROR.length === 0) { throw e; }
+
         const code = e.metadata.get("SCOW_ERROR_CODE")[0].toString();
         return { 500: { code } };
       });


### PR DESCRIPTION
https://github.com/PKUHPC/SCOW/commit/00481d45e39d2ce794cdafcdc097d755103ecf61 这个commit新引入了一种通过metadata传递SCOW业务错误代码的方式，但是在前端判断是否为SCOW业务逻辑的代码有问题。Metadata.get返回的一定为数组，一定为真值，于是前端会把所有grpc错误都认为为SCOW业务逻辑错误。这个PR修复了这个问题。