### PR TITLE
fix(portal-server): 解决VNC桌面和应用启动时displayId大于等于10后，解析displayId不正确的问题。

### DIFF
--- a/apps/portal-server/src/utils/turbovnc.ts
+++ b/apps/portal-server/src/utils/turbovnc.ts
@@ -44,6 +44,7 @@ export function parseOtp(stderr: string): string {
 export function parseDisplayId(stdout: string): number {
 
   // Desktop 'TurboVNC: t001:2 (2001213077)' started on display t001:2
+  // Desktop 'TurboVNC: cn1:21 (demo_admin)' started on display cn1:21
   const regex = /^Desktop '.*' started on display .*:(\d+)$/;
 
   const lines = stdout.split("\n");
@@ -52,7 +53,7 @@ export function parseDisplayId(stdout: string): number {
     const matches = line.match(regex);
     if (!matches) { continue; }
 
-    return +matches[1][0];
+    return +matches[1];
   }
 
   // logger.error("Error parsing display id from %s", stdout);

--- a/apps/portal-server/tests/utils/parseVncOutput.test.ts
+++ b/apps/portal-server/tests/utils/parseVncOutput.test.ts
@@ -12,7 +12,7 @@
 
 import { parseDisplayId, parseListOutput, parseOtp } from "src/utils/turbovnc";
 
-const startOutput = `
+const startOutput1 = `
 Desktop 'TurboVNC: login01:1 (2001213077)' started on display login01:1
 
 One-Time Password authentication enabled.  Generating initial OTP ...
@@ -24,15 +24,29 @@ Starting applications specified in ./xstartup
 Log file is /nfs/2001213077/.vnc/login01:1.log
 `;
 
+const startOutput2 = `
+Desktop 'TurboVNC: cn1:21 (demo_admin)' started on display cn1:21
+
+One-Time Password authentication enabled.  Generating initial OTP ...
+Full control one-time password: 17486286
+Run '/opt/TurboVNC/bin/vncpasswd -o' from within the TurboVNC session or
+    '/opt/TurboVNC/bin/vncpasswd -o -display :21' from within this shell
+    to generate additional OTPs
+Starting applications specified in ./xstartup
+Log file is ./vnc.log
+
+`;
+
 it.each([
-  [startOutput, 1],
+  [startOutput1, 1],
+  [startOutput2, 21],
 ])("parses display id from output", async (output, expected) => {
   expect(parseDisplayId(output)).toBe(expected);
 });
 
 it.each([
   ["Full control one-time password: 32582749", "32582749"],
-  [startOutput, "67159149"],
+  [startOutput1, "67159149"],
 ])("parses OTP from output", async (output, expected) => {
   expect(parseOtp(output)).toBe(expected);
 });
@@ -43,10 +57,11 @@ TurboVNC sessions:
 X DISPLAY #     PROCESS ID      NOVNC PROCESS ID
 :1\t\t21468
 :2\t\t22284
+:21\t\t22222
 `;
 
 it.each([
-  [listOutput, [1, 2]],
+  [listOutput, [1, 2, 21]],
 ])("parses list", (output, expected) => {
   expect(parseListOutput(output)).toIncludeSameMembers(expected);
 });


### PR DESCRIPTION
之前如果启动桌面或者桌面类应用时displayId大于等于10，那么解析出来的displayId只包括第一个数字对应的数字。比如displayId是21，但是解析出来只能解析出2。这个PR解决了这个问题