### PR TITLE
fix(docs): 首页标题去掉Hello from SCOW，改为SCOW

### DIFF
--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -43,7 +43,7 @@ export default function Home(): JSX.Element {
   const { siteConfig } = useDocusaurusContext();
   return (
     <Layout
-      title={`Hello from ${siteConfig.title}`}
+      title={``}
       description="Description will go into a meta tag in <head />">
       <HomepageHeader />
       <main>

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -40,10 +40,8 @@ function HomepageHeader() {
 }
 
 export default function Home(): JSX.Element {
-  const { siteConfig } = useDocusaurusContext();
   return (
     <Layout
-      title={``}
       description="Description will go into a meta tag in <head />">
       <HomepageHeader />
       <main>


### PR DESCRIPTION
去掉Hello from SCOW