### PR TITLE
fix(mis-server): 修复导入用户功能在获取集群中已有用户时，有账户没有用户的情况时报错的问题

### DIFF
--- a/apps/mis-server/src/utils/slurm.ts
+++ b/apps/mis-server/src/utils/slurm.ts
@@ -25,11 +25,14 @@ export function parseClusterUsers(dataStr: string): GetClusterUsersResponse {
   lines.push("");
 
   let i = 0;
-  while (i < lines.length) {
+  while (i < lines.length - 1) {
     const account = lines[i].trim();
     const accountIndex = obj.accounts.push({ accountName: account, users: [] as UserInAccount[], included: false });
     i++;
-    while (lines[i].trim() !== "") {
+    while (i < lines.length && lines[i].trim() !== "") {
+
+      if (lines[i].trim().startsWith("There is no user in account")) { break; }
+
       const [user, status] = lines[i].split(":").map((x) => x.trim());
       const userIndex = obj.users.findIndex((x) => x.userId === user);
       if (userIndex === -1) {
@@ -43,7 +46,7 @@ export function parseClusterUsers(dataStr: string): GetClusterUsersResponse {
           obj.accounts[accountIndex - 1].owner = user;
         }
       }
-      obj.accounts[accountIndex - 1].users.push({ userId:user, state:status });
+      obj.accounts[accountIndex - 1].users.push({ userId: user, state: status });
       i++;
     }
     i++;

--- a/apps/mis-server/src/utils/slurm.ts
+++ b/apps/mis-server/src/utils/slurm.ts
@@ -13,6 +13,8 @@
 import { ClusterAccountInfo, ClusterUserInfo,
   GetClusterUsersResponse, UserInAccount } from "@scow/protos/build/server/admin";
 
+// Parses slurm.sh output to GetClusterUsersResponse
+// Accounts with no user are not included
 export function parseClusterUsers(dataStr: string): GetClusterUsersResponse {
   const obj: GetClusterUsersResponse = {
     accounts:[] as ClusterAccountInfo[],
@@ -30,9 +32,10 @@ export function parseClusterUsers(dataStr: string): GetClusterUsersResponse {
     const accountIndex = obj.accounts.push({ accountName: account, users: [] as UserInAccount[], included: false });
     i++;
     while (i < lines.length && lines[i].trim() !== "") {
-
-      if (lines[i].trim().startsWith("There is no user in account")) { break; }
-
+      if (lines[i].trim().startsWith("There is no user in account")) {
+        obj.accounts.pop();
+        break;
+      }
       const [user, status] = lines[i].split(":").map((x) => x.trim());
       const userIndex = obj.users.findIndex((x) => x.userId === user);
       if (userIndex === -1) {

--- a/apps/mis-server/tests/admin/getClusterUsers.test.ts
+++ b/apps/mis-server/tests/admin/getClusterUsers.test.ts
@@ -13,7 +13,20 @@
 import { parseClusterUsers } from "src/utils/slurm";
 
 
-const dataStr = "a_user1\nuser1 : allowed!\nuser2 : blocked!\n\naccount2\nuser2:allowed!\nuser3:blocked!\n";
+const dataStr = `
+a_user1
+user1 : allowed!
+user2 : blocked!
+
+a_t2
+There is no user in account !
+account2
+user2:allowed!
+user3:blocked!
+
+a_t3
+There is no user in account !
+`;
 
 it("test whether the string from 'slurm.sh -l all' can be parsed successfully", async () => {
   const result = parseClusterUsers(dataStr);
@@ -26,14 +39,24 @@ it("test whether the string from 'slurm.sh -l all' can be parsed successfully", 
       included: false,
     },
     {
+      accountName: "a_t2",
+      users: [],
+      included: false,
+    },
+    {
       accountName: "account2",
       users: [{ userId: "user2", state: "allowed!" }, { userId: "user3", state: "blocked!" }],
       included: false,
     },
+    {
+      accountName: "a_t3",
+      users: [],
+      included: false,
+    },
   ],
-  users: [ 
-    { userId: "user1", userName: "user1", accounts: [ "a_user1" ], included: false }, 
-    { userId: "user2", userName: "user2", accounts: [ "a_user1", "account2" ], included: false }, 
+  users: [
+    { userId: "user1", userName: "user1", accounts: [ "a_user1" ], included: false },
+    { userId: "user2", userName: "user2", accounts: [ "a_user1", "account2" ], included: false },
     { userId: "user3", userName: "user3", accounts: [ "account2" ], included: false },
   ]});
 });

--- a/apps/mis-server/tests/admin/getClusterUsers.test.ts
+++ b/apps/mis-server/tests/admin/getClusterUsers.test.ts
@@ -39,18 +39,8 @@ it("test whether the string from 'slurm.sh -l all' can be parsed successfully", 
       included: false,
     },
     {
-      accountName: "a_t2",
-      users: [],
-      included: false,
-    },
-    {
       accountName: "account2",
       users: [{ userId: "user2", state: "allowed!" }, { userId: "user3", state: "blocked!" }],
-      included: false,
-    },
-    {
-      accountName: "a_t3",
-      users: [],
       included: false,
     },
   ],


### PR DESCRIPTION
导入用户功能需要首先获取集群中已有的用户，获取已有用户是通过`slurm.sh -l all`获取的。这个命令在发现一个没有用户的账户时会有以下输出，之前没有处理。修复后，获取已有用户账户时会忽略没有用户的账户。

```
a_t2
There is no user in account !
```