### PR TITLE
feat(mis-server): 允许自定义slurm.sh连接数据库的用户名和数据库名

### DIFF
--- a/apps/mis-server/src/clusterops/slurm/utils/slurm.ts
+++ b/apps/mis-server/src/clusterops/slurm/utils/slurm.ts
@@ -34,11 +34,13 @@ export const executeSlurmScript = async (
   const partitionsParam = partitions.map((x) => "\"" + x + "\"").join(" ");
 
   const result = await executeScript(slurmMisConfig, slurmMisConfig.scriptPath, params, {
-    MYSQL_PASSWORD: slurmMisConfig.dbPassword,
     BASE_PARTITIONS: partitionsParam,
     CLUSTER_NAME: slurmMisConfig.clusterName,
     DB_HOST: slurmMisConfig.dbHost,
     DB_PORT: String(slurmMisConfig.dbPort),
+    DB_USER: slurmMisConfig.dbUser,
+    DB_PASSWORD: slurmMisConfig.dbPassword,
+    SLURM_ACCT_DB_NAME: slurmMisConfig.slurmAcctDbName,
   }, logger);
 
   return result;

--- a/deploy/local/config-example/clusters/hpc01.yaml
+++ b/deploy/local/config-example/clusters/hpc01.yaml
@@ -60,8 +60,19 @@ slurm:
     # 不填写为下面的默认值
     # dbPort: 3306
 
-    # slurmdbd的数据库root用户的密码
+    # slurm数据库的用户名
+    # 参考slurmdbd.conf的StorageUser配置
+    # 不填写为下面的默认值
+    # dbUser: root
+
+    # slurmdbd的数据库用户的密码
+    # 参考slurmdbd.conf的StoragePass配置
     dbPassword: password
+
+    # slurm accounting数据库的数据库名
+    # 参考slurmdbd.conf的StorageLoc配置
+    # 不填写为下面的默认值
+    # slurmAcctDbName: "slurm_acct_db"
 
     # 这个集群在slurm中的集群名字
     clusterName: pkuhpc

--- a/docs/docs/deploy/SCOW/mis/schedulers/slurm.md
+++ b/docs/docs/deploy/SCOW/mis/schedulers/slurm.md
@@ -28,21 +28,33 @@ slurm:
   mis:
     # 部署slurm.sh的机器的地址
     managerUrl: haha
-    # slurm.sh在机器中的绝对地址,每次系统启动时，会自动将slurm.sh文件复制到scriptPath指定路径上
+    # slurm.sh在机器中的绝对地址
     scriptPath: /test/slurm.sh
 
-    # 部署slurm.sh的机器通过什么地址访问slurm的mysql数据库
+    # 部署slurm.sh的机器通过什么地址访问slurm的数据库
     # 不填写为下面的默认值
     # dbHost: localhost
 
-    # 部署slurm.sh的机器通过什么端口访问slurm的mysql数据库
+    # 部署slurm.sh的机器通过什么端口访问slurm的数据库
     # 不填写为下面的默认值
     # dbPort: 3306
 
-    # slurmdbd的数据库密码
+    # slurm数据库的用户名
+    # 参考slurmdbd.conf的StorageUser配置
+    # 不填写为下面的默认值
+    # dbUser: root
+
+    # slurmdbd的数据库用户的密码
+    # 参考slurmdbd.conf的StoragePass配置
     dbPassword: password
-    # slurm中这个集群的集群名
-    clusterName: hpc01
+
+    # slurm accounting数据库的数据库名
+    # 参考slurmdbd.conf的StorageLoc配置
+    # 不填写为下面的默认值
+    # slurmAcctDbName: "slurm_acct_db"
+
+    # 这个集群在slurm中的集群名字
+    clusterName: pkuhpc
 ```
 
 ## 导入已有用户信息

--- a/libs/config/src/mis.ts
+++ b/libs/config/src/mis.ts
@@ -18,7 +18,9 @@ export const SlurmMisConfigSchema = Type.Object({
   managerUrl: Type.String({ description: "slurm manager节点的URL" }),
   dbHost: Type.String({ description: "slurmdbd的数据库地址", default: "localhost" }),
   dbPort: Type.Integer({ description: "slurmdbd的数据库端口", default: 3306 }),
+  dbUser: Type.String({ description: "slurmdbd的数据库的用户名", default: "root" }),
   dbPassword: Type.String({ description: "slurmdbd的数据库密码" }),
+  slurmAcctDbName: Type.String({ description: "slurm accounting database的数据库名", default: "slurm_acct_db" }),
   clusterName: Type.String({ description: "这个集群在slurm中的集群名字" }),
   scriptPath: Type.String({ description: "slurm.sh绝对路径" }),
 }, { description: "slurm的MIS配置" });


### PR DESCRIPTION
增加集群配置文件中的`slurm.mis.dbUser`和`slurm.mis.slurmAcctDbName`配置，用于指定slurm accouting数据库的用户名和数据库名。