### PR TITLE
fix(mis): 以root身份登录SSH，使用su命令以用户身份运行命令

### DIFF
--- a/apps/portal-server/src/clusterops/slurm/bl/queryJobInfo.ts
+++ b/apps/portal-server/src/clusterops/slurm/bl/queryJobInfo.ts
@@ -10,7 +10,7 @@
  * See the Mulan PSL v2 for more details.
  */
 
-import { loggedExec } from "@scow/lib-ssh";
+import { executeAsUser } from "@scow/lib-ssh";
 import { RunningJob } from "@scow/protos/build/common/job";
 import { NodeSSH } from "node-ssh";
 import { JobInfo } from "src/clusterops/api/job";
@@ -19,8 +19,8 @@ import { Logger } from "ts-log";
 
 const SEPARATOR = "__x__x__";
 
-export async function querySqueue(ssh: NodeSSH, logger: Logger, params: string[]) {
-  const result = await loggedExec(ssh, logger, true,
+export async function querySqueue(ssh: NodeSSH, userId: string, logger: Logger, params: string[]) {
+  const result = await executeAsUser(ssh, userId, logger, true,
     "squeue",
     [
       "-o",
@@ -68,12 +68,21 @@ function formatTime(time: Date, tz: string) {
   return applyOffset(dayjs(time), tz).format("YYYY-MM-DD[T]HH:mm:ss");
 }
 
-export async function querySacct(ssh: NodeSSH, logger: Logger, startTime?: Date, endTime?: Date) {
+/**
+ * Query sacct for running jobs
+ * @param ssh ssh object connected as root
+ * @param userId the user
+ * @param logger logger
+ * @param startTime start time
+ * @param endTime end time
+ * @returns
+ */
+export async function querySacct(ssh: NodeSSH, userId: string, logger: Logger, startTime?: Date, endTime?: Date) {
 
   // get the timezone of target machine
-  const { stdout: tz } = await loggedExec(ssh, logger, true, "date", ["+%:z"]);
+  const { stdout: tz } = await executeAsUser(ssh, userId, logger, true, "date", ["+%:z"]);
 
-  const result = await loggedExec(ssh, logger, true,
+  const result = await executeAsUser(ssh, userId, logger, true,
     "sacct",
     [
       "-X",

--- a/apps/portal-server/src/utils/ssh.ts
+++ b/apps/portal-server/src/utils/ssh.ts
@@ -12,14 +12,13 @@
 
 import { ServiceError } from "@ddadaal/tsgrpc-common";
 import { status } from "@grpc/grpc-js";
-import { loggedExec, sshConnect as libConnect, SshConnectError, testRootUserSshLogin } from "@scow/lib-ssh";
+import { sshConnect as libConnect, SshConnectError, testRootUserSshLogin } from "@scow/lib-ssh";
 import type { NodeSSH } from "node-ssh";
 import { clusters } from "src/config/clusters";
 import { rootKeyPair } from "src/config/env";
 import { scowErrorMetadata } from "src/utils/error";
 import { Logger } from "ts-log";
 
-export { loggedExec };
 
 export function getClusterLoginNode(cluster: string): string | undefined {
 
@@ -33,12 +32,12 @@ export async function sshConnect<T>(
 ): Promise<T> {
   return libConnect(address, username, rootKeyPair, logger, run).catch((e) => {
     if (e instanceof SshConnectError) {
-      throw new ServiceError({ 
+      throw new ServiceError({
         code: status.INTERNAL,
         metadata: scowErrorMetadata(SSH_ERROR_CODE),
       });
     }
-    throw e;    
+    throw e;
   });
 }
 

--- a/apps/portal-server/src/utils/turbovnc.ts
+++ b/apps/portal-server/src/utils/turbovnc.ts
@@ -10,10 +10,10 @@
  * See the Mulan PSL v2 for more details.
  */
 
+import { executeAsUser } from "@scow/lib-ssh";
 import { NodeSSH } from "node-ssh";
 import { join } from "path";
 import { portalConfig } from "src/config/portal";
-import { loggedExec } from "src/utils/ssh";
 import { Logger } from "ts-log";
 
 export const VNCSERVER_BIN_PATH = join(portalConfig.turboVNCPath, "bin", "vncserver");
@@ -62,8 +62,8 @@ export function parseDisplayId(stdout: string): number {
 
 const vncPasswdPath = join(portalConfig.turboVNCPath, "bin", "vncpasswd");
 
-export const refreshPassword = async (ssh: NodeSSH, logger: Logger, displayId: number) => {
-  const resp = await loggedExec(ssh, logger, true,
+export const refreshPassword = async (ssh: NodeSSH, userId: string, logger: Logger, displayId: number) => {
+  const resp = await executeAsUser(ssh, userId, logger, true,
     vncPasswdPath, ["-o", "-display", ":" + displayId]);
 
   return parseOtp(resp.stderr);

--- a/dev/ssh-server/Dockerfile
+++ b/dev/ssh-server/Dockerfile
@@ -12,7 +12,7 @@ FROM alpine:3.17
 
 ENV TZ Asia/Shanghai
 
-RUN apk add --no-cache openssh=9.1_p1-r1
+RUN apk add --no-cache openssh=9.1_p1-r1 sudo
 
 COPY ./entry.sh /entry.sh
 

--- a/libs/ssh/src/ssh.ts
+++ b/libs/ssh/src/ssh.ts
@@ -145,6 +145,26 @@ export async function loggedExec(ssh: NodeSSH, logger: Logger, throwIfFailed: bo
 }
 
 /**
+ * Execute a command as a user
+ *
+ * @param ssh ssh object connected as root
+ * @param user the user the command will execute as
+ * @param logger logger
+ * @param throwIfFailed throw if failed
+ * @param command the command
+ * @param parameters the parameters
+ * @param options exec options
+ */
+export async function executeAsUser(
+  ssh: NodeSSH, user: string, logger: Logger, throwIfFailed: boolean,
+  command: string, parameters: string[], options?: SSHExecCommandOptions,
+) {
+  const cmd = constructCommand(command, parameters);
+
+  return await loggedExec(ssh, logger, throwIfFailed, "su", ["-c", cmd, user], options);
+}
+
+/**
  * Check if the root user can log in to the host
  * If fails, return the error
  *

--- a/libs/ssh/src/ssh.ts
+++ b/libs/ssh/src/ssh.ts
@@ -193,7 +193,7 @@ export async function insertKeyAsUser(
 ) {
 
   await sshConnectByPassword(address, username, pwd, logger, async (ssh) => {
-    const homeDir = await ssh.execCommand(`eval echo ~${username}`);
+    const homeDir = await loggedExec(ssh, logger, true, "eval", ["echo", `~${username}`]);
     const userHomeDir = homeDir.stdout.trim();
 
     const sftp = await ssh.requestSFTP();

--- a/libs/ssh/src/ssh.ts
+++ b/libs/ssh/src/ssh.ts
@@ -107,6 +107,17 @@ export async function sshConnectByPassword<T>(
 }
 
 /**
+ * Calculate env prefix. Needed quotes in values are added
+ * e.g. { test: "123"; test1: "4\"56" } => "test=123 test1='4\"56' "
+ *
+ * @param env env objec
+ * @returns string to be added in front of the command
+ */
+export function getEnvPrefix(env: Record<string, string>) {
+  return Object.keys(env).map((x) => `${x}=${quote([env[x] ?? ""])} `).join("");
+}
+
+/**
  * Construct a command with env prefixes.
  * Some OpenSSH servers don't accept envs
  * This is a workaround by combining the envs to the command
@@ -119,7 +130,7 @@ export function constructCommand(cmd: string, parameters: readonly string[], env
 
   const command = cmd + (parameters.length > 0 ? (" " + quote(parameters)) : "");
 
-  const envPrefix = env ? Object.keys(env).map((x) => `${x}=${quote([env[x] ?? ""])} `).join("") : "";
+  const envPrefix = env ? getEnvPrefix(env) : "";
 
   return envPrefix + command;
 }
@@ -157,11 +168,18 @@ export async function loggedExec(ssh: NodeSSH, logger: Logger, throwIfFailed: bo
  */
 export async function executeAsUser(
   ssh: NodeSSH, user: string, logger: Logger, throwIfFailed: boolean,
-  command: string, parameters: string[], options?: SSHExecCommandOptions,
+  command: string, parameters: readonly string[], options?: SSHExecCommandOptions,
 ) {
-  const cmd = constructCommand(command, parameters);
 
-  return await loggedExec(ssh, logger, throwIfFailed, "su", ["-c", cmd, user], options);
+  const env = options?.execOptions?.env;
+  const envOption = env ? `--preserve-env=${Object.keys(env).join(",")}` : "";
+
+  return await loggedExec(ssh, logger, throwIfFailed,
+    "sudo", [
+      envOption,
+      "-u", user,
+      "-s", command, ...parameters,
+    ], options);
 }
 
 /**

--- a/libs/ssh/tests/ssh.test.ts
+++ b/libs/ssh/tests/ssh.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2022 Peking University and Peking University Institute for Computing and Digital Economy
+ * SCOW is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *          http://license.coscl.org.cn/MulanPSL2
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PSL v2 for more details.
+ */
+
+import { executeAsUser } from "src/ssh";
+import { connectToTestServerAsRoot, resetTestServerAsRoot, TestSshServer } from "tests/utils";
+
+let testServer: TestSshServer;
+
+beforeEach(async () => {
+  testServer = await connectToTestServerAsRoot();
+});
+
+afterEach(async () => {
+  await resetTestServerAsRoot(testServer);
+});
+
+
+it("execute command as another user", async () => {
+
+  const resp = await executeAsUser(testServer.ssh, "test", console, false, "whoami", [], {});
+
+  expect(resp.stdout).toBe("test");
+
+});
+

--- a/libs/ssh/tests/sshKey.test.ts
+++ b/libs/ssh/tests/sshKey.test.ts
@@ -15,9 +15,9 @@ import { insertKeyAsRoot } from "src/key";
 import { sftpExists, sftpReadFile, sftpStat, sshRmrf } from "src/sftp";
 import { insertKeyAsUser, sshConnect } from "src/ssh";
 
-import { connectToTestServerAsRoot, createTestItems, resetTestServerAsRoot, rootKeyPair, TestSshServer } from "./utils";
+import { connectToTestServerAsRoot,
+  createTestItems, resetTestServerAsRoot, rootKeyPair, target, TestSshServer } from "./utils";
 
-const target = "localhost:22222";
 let serverSsh: TestSshServer;
 const randomPostfix = String(Math.ceil(Math.random() * 1000 + 1));
 const testUser = "testNewUser" + randomPostfix;

--- a/libs/ssh/tests/utils.ts
+++ b/libs/ssh/tests/utils.ts
@@ -19,7 +19,7 @@ import { sftpWriteFile, sshRmrf } from "src/sftp";
 import { sshRawConnect } from "src/ssh";
 import { SFTPWrapper } from "ssh2";
 
-const target = "localhost:22222";
+export const target = "localhost:22222";
 export const rootUserId = "root";
 
 export interface TestSshServer {


### PR DESCRIPTION
当前，系统所有以用户身份进行的操作（比如查询作业、提交作业等）都需要使用SSH连接以用户身份连接到登录节点后运行命令来操作，且每次执行命令的时候都会开一个新shell，开启新shell的时候会执行shell的配置脚本（比如.bashrc）。如果用户的配置文件中增加了运行时间较长的脚本，那么执行这些命令的时候，系统的反应将会非常慢。

这个PR将以用户身份执行命令的方法改成了**以root身份登录SSH，使用sudo -u 用户 -c 命令 命令行参数**。这样执行命令的时候是开的root用户的shell，而root用户的配置文件一般是比较简单的，这样就绕过了执行用户的配置脚本以用户身份执行命令。

此次PR修改了除了创建交互式作业之外的所有以用户身份执行命令的地方。创建交互式作业部分代码比较复杂，同时涉及到SFTP和SSH，修改后会提高代码复杂度，并且创建交互式作业的过程慢一点可以理解，故没有修改。

受到影响的功能（均在门户系统，管理系统之前只有获取运行中作业调用了slurm指令，但是那是以root身份运行的）

- 查询运行中作业
- 查询交互式作业（仍然需要通过SFTP查询文件，仍然可能有速度慢的问题）
- 获取用户的所有账户
- 提交作业
- 取消作业
- 查询所有作业
- 获取所有桌面
- 连接到桌面
- 关闭桌面
