### PR TITLE
fix(dev): 启用tsc的declarationMap选项，整理libs下的tsconfig文件

### DIFF
--- a/dockerfiles/Dockerfile.auth
+++ b/dockerfiles/Dockerfile.auth
@@ -37,7 +37,9 @@ RUN pnpm i --offline --frozen-lockfile
 
 COPY --from=pruner /app/out/full/ .
 COPY tsconfig.json .eslintrc.json turbo.json ./
+COPY libs/tsconfig.json ./libs/
 COPY protos ./protos
+
 
 RUN pnpm build
 

--- a/dockerfiles/Dockerfile.docs
+++ b/dockerfiles/Dockerfile.docs
@@ -36,6 +36,7 @@ RUN pnpm i --offline --frozen-lockfile
 
 COPY --from=pruner /app/out/full/ .
 COPY tsconfig.json .eslintrc.json turbo.json ./
+COPY libs/tsconfig.json ./libs/
 COPY protos ./protos
 
 RUN pnpm build

--- a/dockerfiles/Dockerfile.mis-server
+++ b/dockerfiles/Dockerfile.mis-server
@@ -47,6 +47,7 @@ RUN pnpm i --offline --frozen-lockfile
 
 COPY --from=pruner /app/out/full/ .
 COPY tsconfig.json .eslintrc.json turbo.json buf.gen.yaml buf.work.yaml  ./
+COPY libs/tsconfig.json ./libs/
 COPY protos ./protos
 
 RUN pnpm build

--- a/dockerfiles/Dockerfile.mis-web
+++ b/dockerfiles/Dockerfile.mis-web
@@ -47,6 +47,7 @@ RUN pnpm i --offline --frozen-lockfile
 
 COPY --from=pruner /app/out/full/ .
 COPY tsconfig.json .eslintrc.json turbo.json buf.gen.yaml buf.work.yaml ./
+COPY libs/tsconfig.json ./libs/
 COPY protos ./protos
 
 ARG BASE_PATH=""

--- a/dockerfiles/Dockerfile.portal-server
+++ b/dockerfiles/Dockerfile.portal-server
@@ -46,6 +46,7 @@ RUN pnpm i --offline --frozen-lockfile
 
 COPY --from=pruner /app/out/full/ .
 COPY tsconfig.json .eslintrc.json turbo.json buf.gen.yaml buf.work.yaml ./
+COPY libs/tsconfig.json ./libs/
 COPY protos ./protos
 
 RUN pnpm build

--- a/dockerfiles/Dockerfile.portal-web
+++ b/dockerfiles/Dockerfile.portal-web
@@ -46,6 +46,7 @@ RUN pnpm i --offline --frozen-lockfile
 
 COPY --from=pruner /app/out/full/ .
 COPY tsconfig.json .eslintrc.json turbo.json buf.gen.yaml buf.work.yaml ./
+COPY libs/tsconfig.json ./libs/
 COPY protos ./protos
 
 ARG BASE_PATH=""

--- a/libs/auth/tsconfig.json
+++ b/libs/auth/tsconfig.json
@@ -1,8 +1,7 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../tsconfig.json",
   "compilerOptions": {
     "outDir": "build",
-    "declaration": true,
     "baseUrl": "./",
     "paths": {
       "src/*": [

--- a/libs/config/tsconfig.json
+++ b/libs/config/tsconfig.json
@@ -1,8 +1,7 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../tsconfig.json",
   "compilerOptions": {
     "outDir": "build",
-    "declaration": true,
     "baseUrl": "./",
     "paths": {
       "src/*": [

--- a/libs/decimal/tsconfig.json
+++ b/libs/decimal/tsconfig.json
@@ -1,8 +1,7 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../tsconfig.json",
   "compilerOptions": {
     "outDir": "build",
-    "declaration": true
   },
   "include": [
     "src/**/*.ts",

--- a/libs/decimal/tsconfig.json
+++ b/libs/decimal/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "outDir": "build",
+    "outDir": "build"
   },
   "include": [
     "src/**/*.ts",

--- a/libs/libconfig/tsconfig.json
+++ b/libs/libconfig/tsconfig.json
@@ -1,8 +1,7 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../tsconfig.json",
   "compilerOptions": {
     "outDir": "build",
-    "declaration": true,
     "baseUrl": "./",
     "paths": {
       "src/*": [

--- a/libs/protos/tsconfig.json
+++ b/libs/protos/tsconfig.json
@@ -1,8 +1,7 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../tsconfig.json",
   "compilerOptions": {
     "outDir": "build",
-    "declaration": true,
     "baseUrl": "./",
   },
   "include": [

--- a/libs/protos/tsconfig.json
+++ b/libs/protos/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "outDir": "build",
-    "baseUrl": "./",
+    "baseUrl": "./"
   },
   "include": [
     "generated/**/*.ts"

--- a/libs/ssh/tsconfig.json
+++ b/libs/ssh/tsconfig.json
@@ -1,8 +1,7 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../tsconfig.json",
   "compilerOptions": {
     "outDir": "build",
-    "declaration": true,
     "baseUrl": "./",
     "paths": {
       "src/*": [

--- a/libs/tsconfig.json
+++ b/libs/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true
+  }
+}

--- a/libs/utils/tsconfig.json
+++ b/libs/utils/tsconfig.json
@@ -1,8 +1,7 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../tsconfig.json",
   "compilerOptions": {
     "outDir": "build",
-    "declaration": true,
     "baseUrl": "./",
     "paths": {
       "src/*": [

--- a/libs/web/src/layouts/base/header/components.tsx
+++ b/libs/web/src/layouts/base/header/components.tsx
@@ -41,7 +41,7 @@ interface JumpToAnotherLinkProps {
 }
 
 export const JumpToAnotherLink = ({ user, link, icon, linkText }: JumpToAnotherLinkProps) => {
-  if (!linkText) { return undefined; }
+  if (!link) { return undefined; }
 
   return (
 

--- a/libs/web/src/layouts/base/header/components.tsx
+++ b/libs/web/src/layouts/base/header/components.tsx
@@ -40,8 +40,8 @@ interface JumpToAnotherLinkProps {
   linkText: string;
 }
 
-export const JumpToAnotherLink = ({ user, link, icon, linkText }: JumpToAnotherLinkProps) => {
-  if (!link) { return undefined; }
+export const JumpToAnotherLink: React.FC<JumpToAnotherLinkProps> = ({ user, link, icon, linkText }) => {
+  if (!link) { return null; }
 
   return (
 

--- a/libs/web/src/layouts/icon.tsx
+++ b/libs/web/src/layouts/icon.tsx
@@ -21,7 +21,7 @@ interface Props {
 export function NavIcon({ src, alt }: Props) {
   return (
     <AntdIcon
-      component={({ width, height, style, className, fill }) => (
+      component={({ width, height, style, className, fill }: any) => (
         <Image
           src={src}
           alt={alt}

--- a/libs/web/src/utils/throttle.ts
+++ b/libs/web/src/utils/throttle.ts
@@ -15,7 +15,7 @@ export function throttle<T extends(...args: any[]) => any>(fn: T, wait = 500):
   // 上一次执行 fn 的时间
   let previous = 0;
   // 将 throttle 处理结果当作函数返回
-  return function(...args: any[]) {
+  return function(this: any, ...args: any[]) {
     // 获取当前时间，转换成时间戳，单位毫秒
     const now = +new Date();
     // 将当前时间和上一次执行函数的时间进行对比

--- a/libs/web/tsconfig.json
+++ b/libs/web/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../tsconfig.json",
   "compilerOptions": {
     "target": "ESNext",
     "lib": [
@@ -7,13 +8,6 @@
       "esnext"
     ],
     "outDir": "build",
-    "allowJs": true,
-    "skipLibCheck": true,
-    "declaration": true,
-    "moduleResolution": "node",
-    "resolveJsonModule": true,
-    "esModuleInterop": true,
-    "isolatedModules": true,
     "jsx": "react-jsx",
     "baseUrl": ".",
     "paths": {
@@ -29,7 +23,6 @@
     "node_modules"
   ],
   "include": [
-    "next-env.d.ts",
     "**/*.ts",
     "**/*.tsx",
   ]

--- a/libs/web/tsconfig.json
+++ b/libs/web/tsconfig.json
@@ -9,6 +9,7 @@
     ],
     "outDir": "build",
     "jsx": "react-jsx",
+    "module": "ESNext",
     "baseUrl": ".",
     "paths": {
       "src/*": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,6 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "resolveJsonModule": true,
-    "isolatedModules": true,
-    "declarationMap": true
+    "isolatedModules": true
   },
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,18 +1,18 @@
 {
-    "compilerOptions": {
-      "target": "ESNext",
-      "allowJs": true,
-      "skipLibCheck": true,
-      "strict": true,
-      "forceConsistentCasingInFileNames": true,
-      "experimentalDecorators": true,
-      "emitDecoratorMetadata": true,
-      "noImplicitAny": false,
-      "esModuleInterop": true,
-      "module": "commonjs",
-      "moduleResolution": "node",
-      "resolveJsonModule": true,
-      "isolatedModules": true,
-    }
-  }
-  
+  "compilerOptions": {
+    "target": "ESNext",
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "noImplicitAny": false,
+    "esModuleInterop": true,
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "declarationMap": true
+  },
+}


### PR DESCRIPTION
现在在VSCode中按住ctrl再点击引用能够正确跳转到源码了，之前只能跳转到生成的.d.ts文件。

![动画](https://user-images.githubusercontent.com/8363856/209601797-98dcf3f0-c29c-4266-9a28-246a0fd38fd5.gif)

原理是tsconfig的declarationMap选项（https://www.typescriptlang.org/tsconfig#declarationMap）。

这个选项将会在build目录下创建一些.ts.map文件，生产时并不需要，所以同时修改了copyDist.mjs脚本，把map中的.ts和.ts.map文件删掉，以减小最终镜像的大小

另外还在libs下放了一个公共的tsconfig.json，开启了declaration和declarationMap选项。