### PR TITLE
fix(mis): 管理系统支持SCOW数据库的用户信息是slurm数据库的子集

### DIFF
--- a/apps/mis-server/src/bl/block.ts
+++ b/apps/mis-server/src/bl/block.ts
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) 2022 Peking University and Peking University Institute for Computing and Digital Economy
+ * SCOW is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *          http://license.coscl.org.cn/MulanPSL2
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PSL v2 for more details.
+ */
+
+import { Logger } from "@ddadaal/tsgrpc-server";
+import { Account } from "src/entities/Account";
+import { UserAccount, UserStatus } from "src/entities/UserAccount";
+import { ClusterPlugin } from "src/plugins/clusters";
+
+/**
+ * Blocks the account in the slurm.
+ * If it is whitelisted, it doesn't block.
+ * Call flush after this.
+ *
+ * @returns Operation result
+**/
+export async function blockAccount(
+  account: Account, clusterPlugin: ClusterPlugin["clusters"], logger: Logger,
+): Promise<"AlreadyBlocked" | "Whitelisted" | "OK"> {
+
+  if (account.blocked) { return "AlreadyBlocked"; }
+
+  if (account.whitelist) {
+    return "Whitelisted";
+  }
+
+  await clusterPlugin.callOnAll(logger, async (ops) => {
+    const resp = await ops.account.blockAccount({
+      request: { accountName: account.accountName },
+      logger,
+    });
+    if (resp.code === "NOT_FOUND") {
+      throw new Error(`Account ${account.accountName} not found`);
+    }
+  });
+
+  account.blocked = true;
+  return "OK";
+}
+
+/**
+ * Unblocks the account in the slurm.
+ * If it is whitelisted, it doesn't block.
+ * Call flush after this.
+ *
+ * @returns Operation result
+**/
+export async function unblockAccount(
+  account: Account, clusterPlugin: ClusterPlugin["clusters"], logger: Logger,
+): Promise<"OK" | "ALREADY_UNBLOCKED"> {
+
+  if (!account.blocked) { return "ALREADY_UNBLOCKED"; }
+
+  await clusterPlugin.callOnAll(logger, async (ops) => {
+    const resp = await ops.account.unblockAccount({
+      request: { accountName: account.accountName },
+      logger,
+    });
+
+    if (resp.code === "NOT_FOUND") {
+      throw new Error(`Account ${account.accountName} not found`);
+    }
+  });
+
+  account.blocked = false;
+
+  return "OK";
+}
+
+/**
+ * User and account must be loaded.
+ * Call flush after this.
+ * */
+export async function blockUserInAccount(ua: UserAccount, clusterPlugin: ClusterPlugin, logger: Logger) {
+  if (ua.status === UserStatus.BLOCKED) {
+    return;
+  }
+
+  await clusterPlugin.clusters.callOnAll(logger, async (ops) => ops.user.blockUserInAccount({
+    request: {
+      accountName: ua.account.getProperty("accountName"),
+      userId: ua.user.getProperty("userId"),
+    },
+    logger,
+  }));
+
+  ua.status = UserStatus.BLOCKED;
+}
+
+/**
+ * User and account must be loaded.
+ * Call flush after this.
+ * */
+export async function unblockUserInAccount(ua: UserAccount, clusterPlugin: ClusterPlugin, logger: Logger) {
+  if (ua.status === UserStatus.UNBLOCKED) {
+    return;
+
+  }
+
+  await clusterPlugin.clusters.callOnAll(logger, async (ops) => ops.user.unblockUserInAccount({
+    request: {
+      accountName: ua.account.getProperty("accountName"),
+      userId: ua.user.getProperty("userId"),
+    },
+    logger,
+  }));
+
+  ua.status = UserStatus.UNBLOCKED;
+}
+

--- a/apps/mis-server/src/clusterops/api/account.ts
+++ b/apps/mis-server/src/clusterops/api/account.ts
@@ -35,18 +35,18 @@ export interface BlockAccountRequest {
 }
 
 /** NOT_FOUND: account is not found. */
-export type BlockAccountReply =
-  | { code: "NOT_FOUND"}
-  | { code: "OK", executed: boolean };
+export type BlockAccountReply = {
+  code: "OK" | "NOT_FOUND" | "ALREADY_BLOCKED";
+};
 
 export interface UnblockAccountRequest {
   accountName: string;
 }
 
 /** NOT_FOUND: account is not found. */
-export type UnblockAccountReply =
-  | { code: "NOT_FOUND"}
-  | { code: "OK"; executed: boolean };
+export type UnblockAccountReply = {
+  code: "OK" | "NOT_FOUND" | "ALREADY_UNBLOCKED"
+};
 
 export interface AccountOps {
   deleteAccount(req: Request<DeleteAccountRequest>): Promise<DeleteAccountReply>;

--- a/apps/mis-server/src/clusterops/api/user.ts
+++ b/apps/mis-server/src/clusterops/api/user.ts
@@ -34,15 +34,19 @@ export interface RemoveUserRequest {
 }
 
 /** NOT_FOUND: user is not found. */
-export interface RemoveUserReply {}
+export interface RemoveUserReply {
+  code: "OK" | "NOT_FOUND";
+}
 
-export interface AddUserRequest {
+export interface AddUserToAccountRequest {
   userId: string;
   accountName: string;
 }
 
 /** ALREADY_EXISTS: User already exists. */
-export interface AddUserReply {}
+export interface AddUserToAccountReply {
+  code: "OK" | "ALREADY_EXISTS"
+}
 
 export interface GetAllUsersInAccountsRequest {}
 
@@ -51,7 +55,7 @@ export interface GetAllUsersInAccountsReply {
 }
 
 export interface UserOps {
-  addUser(req: Request<AddUserRequest>): Promise<AddUserReply>;
+  addUserToAccount(req: Request<AddUserToAccountRequest>): Promise<AddUserToAccountReply>;
   removeUser(req: Request<RemoveUserRequest>): Promise<RemoveUserReply>;
   blockUserInAccount(req: Request<BlockUserInAccountRequest>): Promise<BlockUserInAccountReply>;
   unblockUserInAccount(req: Request<UnblockUserInAccountRequest>): Promise<UnblockUserInAccountReply>;

--- a/apps/mis-server/src/clusterops/slurm/account.ts
+++ b/apps/mis-server/src/clusterops/slurm/account.ts
@@ -43,14 +43,14 @@ export const slurmAccountOps = ({ executeSlurmScript }: SlurmClusterInfo): Accou
       const result = await executeSlurmScript(["-b", accountName], logger);
 
       if (result.code === 8) {
-        return { code: "OK", executed: false };
+        return { code: "ALREADY_BLOCKED" };
       }
 
       if (result.code === 7) {
         return { code: "NOT_FOUND" };
       }
 
-      return { code: "OK", executed: true };
+      return { code: "OK" };
     },
 
     unblockAccount: async ({ request, logger }) => {
@@ -59,14 +59,14 @@ export const slurmAccountOps = ({ executeSlurmScript }: SlurmClusterInfo): Accou
       const result = await executeSlurmScript(["-d", accountName], logger);
 
       if (result.code === 9) {
-        return { code: "OK", executed: false };
+        return { code: "ALREADY_UNBLOCKED" };
       }
 
       if (result.code === 7) {
         return { code: "NOT_FOUND" };
       }
 
-      return { code: "OK", executed: true };
+      return { code: "OK" };
     },
   };
 };

--- a/apps/mis-server/src/clusterops/slurm/user.ts
+++ b/apps/mis-server/src/clusterops/slurm/user.ts
@@ -16,7 +16,7 @@ import { SlurmClusterInfo } from "src/clusterops/slurm";
 export const slurmUserOps = ({ executeSlurmScript }: SlurmClusterInfo): UserOps => {
 
   return {
-    addUser: async ({ request, logger }) => {
+    addUserToAccount: async ({ request, logger }) => {
       const { accountName, userId } = request;
       const result = await executeSlurmScript(["-g", accountName, "0", userId], logger);
       if (result.code === 3) {

--- a/apps/mis-server/src/entities/Account.ts
+++ b/apps/mis-server/src/entities/Account.ts
@@ -10,7 +10,6 @@
  * See the Mulan PSL v2 for more details.
  */
 
-import { Logger } from "@ddadaal/tsgrpc-server";
 import { Collection, Entity,
   IdentifiedReference, ManyToOne, OneToMany, OneToOne, PrimaryKey, Property,
 } from "@mikro-orm/core";
@@ -18,7 +17,6 @@ import { Decimal } from "@scow/lib-decimal";
 import { AccountWhitelist } from "src/entities/AccountWhitelist";
 import { Tenant } from "src/entities/Tenant";
 import { UserAccount } from "src/entities/UserAccount";
-import { ClusterPlugin } from "src/plugins/clusters";
 import { DECIMAL_DEFAULT_RAW, DecimalType } from "src/utils/decimal";
 import { EntityOrRef, toRef } from "src/utils/orm";
 
@@ -49,47 +47,6 @@ export class Account {
 
   @Property({ type: DecimalType, defaultRaw: DECIMAL_DEFAULT_RAW })
     balance: Decimal = new Decimal(0);
-
-  /**
-   * Blocks the account in the slurm.
-   * If it is whitelisted, it doesn't block.
-   * Call flush after this.
-   *
-   * @returns Operation result
-  **/
-  async block(clusterPlugin: ClusterPlugin["clusters"], logger: Logger):
-   Promise<"AlreadyBlocked" | "Whitelisted" | "OK"> {
-
-    if (this.blocked) { return "AlreadyBlocked"; }
-
-    if (this.whitelist) {
-      return "Whitelisted";
-    }
-
-    await clusterPlugin.callOnAll(logger, async (ops) => ops.account.blockAccount({
-      request: { accountName: this.accountName },
-      logger,
-    }));
-
-
-    this.blocked = true;
-    return "OK";
-  }
-
-  /**
-     * Call flush after this.
-     * */
-  async unblock(clusterPlugin: ClusterPlugin["clusters"], logger: Logger) {
-
-    if (!this.blocked) { return; }
-
-    await clusterPlugin.callOnAll(logger, async (ops) => ops.account.unblockAccount({
-      request: { accountName: this.accountName },
-      logger,
-    }));
-
-    this.blocked = false;
-  }
 
   constructor(init: {
     accountName: string;

--- a/apps/mis-server/src/entities/UserAccount.ts
+++ b/apps/mis-server/src/entities/UserAccount.ts
@@ -10,13 +10,11 @@
  * See the Mulan PSL v2 for more details.
  */
 
-import { Logger } from "@ddadaal/tsgrpc-server";
 import { Entity, IdentifiedReference,
   ManyToOne, PrimaryKey, Property } from "@mikro-orm/core";
 import { Decimal } from "@scow/lib-decimal";
 import { Account } from "src/entities/Account";
 import { User } from "src/entities/User";
-import { ClusterPlugin } from "src/plugins/clusters";
 import { DecimalType } from "src/utils/decimal";
 import { EntityOrRef, toRef } from "src/utils/orm";
 
@@ -44,71 +42,6 @@ export class UserAccount {
 
   @Property({ columnType: "varchar(10)", comment: Object.values(UserStatus).join(", ") })
     status: UserStatus;
-
-  async addJobCharge(charge: Decimal, clusterPlugin: ClusterPlugin, logger: Logger) {
-    if (this.usedJobCharge && this.jobChargeLimit) {
-      this.usedJobCharge = this.usedJobCharge.plus(charge);
-      if (this.usedJobCharge.gt(this.jobChargeLimit)) {
-        await this.block(clusterPlugin, logger);
-      } else {
-        await this.unblock(clusterPlugin, logger);
-      }
-    }
-  }
-
-  async setJobCharge(charge: Decimal, clusterPlugin: ClusterPlugin, logger: Logger) {
-    this.jobChargeLimit = charge;
-    if (!this.usedJobCharge) {
-      this.usedJobCharge = new Decimal(0);
-    } else {
-      if (this.jobChargeLimit.lt(this.usedJobCharge)) {
-        await this.block(clusterPlugin, logger);
-      } else {
-        await this.unblock(clusterPlugin, logger);
-      }
-    }
-  }
-
-  /**
-   * User and account must be loaded.
-   * Call flush after this.
-   * */
-  async block(clusterPlugin: ClusterPlugin, logger: Logger) {
-    if (this.status === UserStatus.BLOCKED) {
-      return;
-    }
-
-    await clusterPlugin.clusters.callOnAll(logger, async (ops) => ops.user.blockUserInAccount({
-      request: {
-        accountName: this.account.getProperty("accountName"),
-        userId: this.user.getProperty("userId"),
-      },
-      logger,
-    }));
-
-    this.status = UserStatus.BLOCKED;
-  }
-
-  /**
-   * User and account must be loaded.
-   * Call flush after this.
-   * */
-  async unblock(clusterPlugin: ClusterPlugin, logger: Logger) {
-    if (this.status === UserStatus.UNBLOCKED) {
-      return;
-
-    }
-
-    await clusterPlugin.clusters.callOnAll(logger, async (ops) => ops.user.unblockUserInAccount({
-      request: {
-        accountName: this.account.getProperty("accountName"),
-        userId: this.user.getProperty("userId"),
-      },
-      logger,
-    }));
-
-    this.status = UserStatus.UNBLOCKED;
-  }
 
   @Property({ columnType: "varchar(10)", comment: Object.values(UserRole).join(", ") })
     role: UserRole;

--- a/apps/mis-server/src/services/jobChargeLimit.ts
+++ b/apps/mis-server/src/services/jobChargeLimit.ts
@@ -17,6 +17,7 @@ import { LockMode } from "@mikro-orm/core";
 import { Decimal } from "@scow/lib-decimal";
 import { moneyToNumber } from "@scow/lib-decimal/build/convertion";
 import { JobChargeLimitServiceServer, JobChargeLimitServiceService } from "@scow/protos/build/server/job_charge_limit";
+import { setJobCharge } from "src/bl/charging";
 import { UserAccount } from "src/entities/UserAccount";
 
 export const jobChargeLimitServer = plugin((server) => {
@@ -77,7 +78,7 @@ export const jobChargeLimitServer = plugin((server) => {
           };
         }
 
-        await userAccount.setJobCharge(new Decimal(moneyToNumber(limit)), server.ext, logger);
+        await setJobCharge(userAccount, new Decimal(moneyToNumber(limit)), server.ext, logger);
 
         logger.info("Set %s job charge limit to user %s account %s. Current used %s",
           userAccount.jobChargeLimit!.toFixed(2),

--- a/apps/mis-server/src/tasks/fetch.ts
+++ b/apps/mis-server/src/tasks/fetch.ts
@@ -15,7 +15,7 @@ import { MikroORM, QueryOrder } from "@mikro-orm/core";
 import { MariaDbDriver } from "@mikro-orm/mariadb";
 import { SqlEntityManager } from "@mikro-orm/mysql";
 import { parsePlaceholder } from "@scow/lib-config";
-import { charge } from "src/bl/charging";
+import { addJobCharge, charge } from "src/bl/charging";
 import { clusterNameToScowClusterId } from "src/config/clusters";
 import { misConfig } from "src/config/mis";
 import { Account } from "src/entities/Account";
@@ -199,7 +199,7 @@ export async function fetchJobs(
                 target: ua.account.$.tenant.getEntity(),
               }, em, logger, clusterPlugin);
 
-              await ua.addJobCharge(x.tenantPrice, clusterPlugin, logger);
+              await addJobCharge(ua, x.tenantPrice, clusterPlugin, logger);
             }
           }));
 

--- a/apps/mis-server/tests/admin/jobChargeLimit.test.ts
+++ b/apps/mis-server/tests/admin/jobChargeLimit.test.ts
@@ -17,6 +17,7 @@ import { SqlEntityManager } from "@mikro-orm/mysql";
 import { Decimal, decimalToMoney } from "@scow/lib-decimal";
 import { JobChargeLimitServiceClient } from "@scow/protos/build/server/job_charge_limit";
 import { createServer } from "src/app";
+import { addJobCharge } from "src/bl/charging";
 import { UserAccount, UserStatus } from "src/entities/UserAccount";
 import { reloadEntity } from "src/utils/orm";
 import { InitialData, insertInitialData } from "tests/data/data";
@@ -119,7 +120,7 @@ it("adds job charge", async () => {
 
   const charge = new Decimal(20.4);
 
-  await ua.addJobCharge(charge, server.ext, server.logger);
+  await addJobCharge(ua, charge, server.ext, server.logger);
 
   expectDecimalEqual(ua.usedJobCharge, charge);
   expectDecimalEqual(ua.jobChargeLimit, limit);
@@ -135,7 +136,7 @@ it("blocks user if used > limit", async () => {
   expectDecimalEqual(ua.jobChargeLimit, limit);
 
   const charge = new Decimal(120.4);
-  await ua.addJobCharge(charge, server.ext, server.logger);
+  await addJobCharge(ua, charge, server.ext, server.logger);
 
   expectDecimalEqual(ua.usedJobCharge, charge);
   expectDecimalEqual(ua.jobChargeLimit, limit);
@@ -167,7 +168,7 @@ it("unblocks user if limit >= used is positive", async () => {
 
   const charge = new Decimal(-20.4);
 
-  await ua.addJobCharge(charge, server.ext, server.logger);
+  await addJobCharge(ua, charge, server.ext, server.logger);
 
   expectDecimalEqual(ua.jobChargeLimit, limit);
   expectDecimalEqual(ua.usedJobCharge, new Decimal(99.6));
@@ -175,7 +176,7 @@ it("unblocks user if limit >= used is positive", async () => {
 });
 
 it("does nothing if no limit", async () => { const charge = new Decimal(120.4);
-  await ua.addJobCharge(charge, server.ext, server.logger);
+  await addJobCharge(ua, charge, server.ext, server.logger);
 
   expect(ua.jobChargeLimit).toBeUndefined();
   expect(ua.usedJobCharge).toBeUndefined();

--- a/apps/mis-server/tests/job/fetchJobs.test.ts
+++ b/apps/mis-server/tests/job/fetchJobs.test.ts
@@ -15,6 +15,7 @@ import { Server } from "@ddadaal/tsgrpc-server";
 import { MySqlDriver, SqlEntityManager } from "@mikro-orm/mysql";
 import { Decimal } from "@scow/lib-decimal";
 import { createServer } from "src/app";
+import { setJobCharge } from "src/bl/charging";
 import { clusterNameToScowClusterId } from "src/config/clusters";
 import { JobInfo } from "src/entities/JobInfo";
 import { OriginalJob } from "src/entities/OriginalJob";
@@ -67,7 +68,7 @@ it("fetches the data", async () => {
 
   // set job charge limit of user b in account b
 
-  await data.uaBB.setJobCharge(new Decimal(0.01), server.ext, server.logger);
+  await setJobCharge(data.uaBB, new Decimal(0.01), server.ext, server.logger);
   await initialEm.flush();
 
   await fetchJobs(server.ext.orm.em.fork(), server.logger, server.ext, server.ext);


### PR DESCRIPTION
目前SCOW管理系统假设了SCOW数据库中的用户信息和slurm用户信息完全一致，但是这个限制是没有必要的，只要求SCOW用户信息是slurm数据库的子集就可以了。这样也可以支持导入部分用户信息。

涉及到多集群操作的时候，某个集群出现以下情况，整个操作不报错：

- SCOW中不存在用户，slurm中存在用户，创建这个用户时
- SCOW中存在用户 ，slurm中不存在用户，删除这个用户时
- SCOW中把用户加入账户，slurm中已有这个用户账户关系
- SCOW中把用户从账户中去除，slurm中这个用户不在账户中
- SCOW中创建账户 ，slurm中已存在账户（注意，如果创建账户的时候发现账户已存在，还需要单独做一步把拥有者加入账户中，因为slurm中的账户可能没有SCOW的拥有者。账户中的已有的用户可以不管，因为这属于上面提到的第三种情况）

这个PR还重构了部分管理系统的业务逻辑，把业务逻辑从entity实体类定义中移到了专门的文件中，并整理了部分内部API定义。