### PR TITLE
fix(mis-web): 管理系统使用下拉框设置用户的平台和租户角色

### DIFF
--- a/apps/mis-web/src/components/PlatformRoleSelector.tsx
+++ b/apps/mis-web/src/components/PlatformRoleSelector.tsx
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2022 Peking University and Peking University Institute for Computing and Digital Economy
+ * SCOW is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *          http://license.coscl.org.cn/MulanPSL2
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PSL v2 for more details.
+ */
+
+import { App, Select } from "antd";
+import { useState } from "react";
+import { api } from "src/apis";
+import { PlatformRole, PlatformRoleTexts } from "src/models/User";
+import { User } from "src/stores/UserStore";
+
+interface Props {
+  roles: PlatformRole[];
+  userId: string;
+  reload: () => void;
+  currentUser?: User;
+}
+
+export const PlatformRoleSelector: React.FC<Props> = ({ roles, userId, reload, currentUser }) => {
+  const { message } = App.useApp();
+
+  const [loading, setLoading] = useState(false);
+
+  return (
+    <Select
+      disabled={loading}
+      value={roles}
+      style={{ width: "100%" }}
+      options={Object.values(PlatformRole).map((x) => ({ label: PlatformRoleTexts[x], value: x }))}
+      onSelect={
+        async (value) => {
+          setLoading(true);
+          await api.setPlatformRole({ body:{
+            userId: userId,
+            roleType: value,
+          } })
+            .httpError(200, () => { message.error("用户已经是该角色"); })
+            .httpError(404, () => { message.error("用户不存在"); })
+            .httpError(403, () => { message.error("用户没有权限"); })
+            .then(() => {
+              message.success("设置成功");
+              setLoading(false);
+              reload();
+            });
+        }
+      }
+      onDeselect={
+        async (value) => {
+
+          if (currentUser && value === PlatformRole.PLATFORM_ADMIN && currentUser.identityId === userId) {
+            message.error("不能取消自己的平台管理员角色");
+            return;
+          }
+
+          setLoading(true);
+          await api.unsetPlatformRole({ body:{
+            userId: userId,
+            roleType: value,
+          } })
+            .httpError(200, () => { message.error("用户已经不是该角色"); })
+            .httpError(404, () => { message.error("用户不存在"); })
+            .httpError(403, () => { message.error("用户没有权限"); })
+            .then(() => {
+              message.success("设置成功");
+              setLoading(false);
+              reload();
+            });
+        }
+      }
+      mode="multiple"
+      placeholder="选择角色"
+    />
+  );
+};
+

--- a/apps/mis-web/src/components/TenantRoleSelector.tsx
+++ b/apps/mis-web/src/components/TenantRoleSelector.tsx
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2022 Peking University and Peking University Institute for Computing and Digital Economy
+ * SCOW is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *          http://license.coscl.org.cn/MulanPSL2
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PSL v2 for more details.
+ */
+
+import { App, Select } from "antd";
+import { useState } from "react";
+import { api } from "src/apis";
+import { TenantRole, TenantRoleTexts } from "src/models/User";
+import { User } from "src/stores/UserStore";
+
+interface Props {
+  roles: TenantRole[];
+  userId: string;
+  reload: () => void;
+  currentUser?: User;
+}
+
+export const TenantRoleSelector: React.FC<Props> = ({ roles, userId, reload, currentUser }) => {
+
+  const { message } = App.useApp();
+
+  const [loading, setLoading] = useState(false);
+
+  return (
+    <Select
+      disabled={loading}
+      value={roles}
+      style={{ width: "100%" }}
+      options={Object.values(TenantRole).map((x) => ({ label: TenantRoleTexts[x], value: x }))}
+      onSelect={
+        async (value) => {
+          setLoading(true);
+          await api.setTenantRole({ body:{
+            userId: userId,
+            roleType: value,
+          } })
+            .httpError(200, () => { message.error("用户已经是该角色"); })
+            .httpError(404, () => { message.error("用户不存在"); })
+            .httpError(403, () => { message.error("用户没有权限"); })
+            .then(() => {
+              message.success("设置成功");
+              setLoading(false);
+              reload();
+            });
+        }
+      }
+      onDeselect={
+        async (value) => {
+          if (currentUser && value === TenantRole.TENANT_ADMIN && currentUser.identityId === userId) {
+            message.error("不能取消自己的租户管理员角色");
+            return;
+          }
+
+          setLoading(true);
+          await api.unsetTenantRole({ body:{
+            userId: userId,
+            roleType: value,
+          } })
+            .httpError(200, () => { message.error("用户已经不是该角色"); })
+            .httpError(404, () => { message.error("用户不存在"); })
+            .httpError(403, () => { message.error("用户没有权限"); })
+            .then(() => {
+              message.success("设置成功");
+              setLoading(false);
+              reload();
+            });
+        }
+      }
+      mode="multiple"
+      placeholder="选择角色"
+    />
+  );
+};
+

--- a/apps/mis-web/src/pageComponents/admin/AllUsersTable.tsx
+++ b/apps/mis-web/src/pageComponents/admin/AllUsersTable.tsx
@@ -10,7 +10,6 @@
  * See the Mulan PSL v2 for more details.
  */
 
-import { ExclamationCircleOutlined } from "@ant-design/icons";
 import { formatDateTime } from "@scow/lib-web/build/utils/datetime";
 import { PlatformUserInfo } from "@scow/protos/build/server/user";
 import { App, Divider, Space, Table } from "antd";
@@ -18,8 +17,7 @@ import React, { useCallback, useState } from "react";
 import { useAsync } from "react-async";
 import { api } from "src/apis";
 import { ChangePasswordModalLink } from "src/components/ChangePasswordModal";
-import { DisabledA } from "src/components/DisabledA";
-import { PlatformRole } from "src/models/User";
+import { PlatformRoleSelector } from "src/components/PlatformRoleSelector";
 import { GetAllUsersSchema } from "src/pages/api/admin/getAllUsers";
 import { User } from "src/stores/UserStore";
 
@@ -74,7 +72,7 @@ const UserInfoTable: React.FC<UserInfoTableProps> = ({
   data, pageInfo, setPageInfo, isLoading, reload, user,
 }) => {
 
-  const { modal, message } = App.useApp();
+  const { message } = App.useApp();
 
   return (
     <>
@@ -99,123 +97,10 @@ const UserInfoTable: React.FC<UserInfoTableProps> = ({
           render={(time: string) => formatDateTime(time)}
         />
         <Table.Column<PlatformUserInfo>
-          dataIndex="platformRoles"
-          title="平台管理员"
+          dataIndex="roles"
+          title="平台角色"
           render={(_, r) => (
-            r.platformRoles.includes(PlatformRole.PLATFORM_ADMIN)
-              ? (
-                <Space size="middle">
-                  是
-                  <DisabledA
-                    disabled={r.userId === user.identityId}
-                    message="不能取消自己的平台管理员权限"
-                    onClick={() => {
-                      modal.confirm({
-                        title: "确认取消管理员权限",
-                        icon: <ExclamationCircleOutlined />,
-                        content: `确认要移除用户${r.name}（ID: ${r.userId}）的平台管理员权限？`,
-                        onOk: async () => {
-                          await api.unsetPlatformRole({ body: {
-                            userId: r.userId,
-                            roleType: PlatformRole.PLATFORM_ADMIN,
-                          } })
-                            .then(() => {
-                              message.success("操作成功！");
-                              reload();
-                            });
-                        },
-                      });
-                    }}
-                  >
-                    取消
-                  </DisabledA>
-                </Space>
-              ) : (
-                <Space size="middle">
-                  否
-                  <a
-                    onClick={() => {
-                      modal.confirm({
-                        title: "确认设置为平台管理员",
-                        icon: <ExclamationCircleOutlined />,
-                        content: `确认要设置用户${r.name}（ID: ${r.userId}）为平台管理员？`,
-                        onOk: async () => {
-                          await api.setPlatformRole({ body: {
-                            userId: r.userId,
-                            roleType: PlatformRole.PLATFORM_ADMIN,
-                          } })
-                            .then(() => {
-                              message.success("操作成功！");
-                              reload();
-                            });
-                        },
-                      });
-                    }}
-                  >
-                    设置
-                  </a>
-                </Space>
-              )
-
-          )}
-        />
-        <Table.Column<PlatformUserInfo>
-          dataIndex="platformRoles"
-          title="平台财务人员"
-          render={(_, r) => (
-            r.platformRoles.includes(PlatformRole.PLATFORM_FINANCE)
-              ? (
-                <Space size="middle">
-                  是
-                  <a
-                    onClick={() => {
-                      modal.confirm({
-                        title: "确认取消财务人员权限",
-                        icon: <ExclamationCircleOutlined />,
-                        content: `确认要取消用户${r.name}（ID: ${r.userId}）的财务人员权限？`,
-                        onOk: async () => {
-                          await api.unsetPlatformRole({ body: {
-                            userId: r.userId,
-                            roleType: PlatformRole.PLATFORM_FINANCE,
-                          } })
-                            .then(() => {
-                              message.success("操作成功！");
-                              reload();
-                            });
-                        },
-                      });
-                    }}
-                  >
-                    取消
-                  </a>
-                </Space>
-              ) : (
-                <Space size="middle">
-                  否
-                  <a
-                    onClick={() => {
-                      modal.confirm({
-                        title: "确认设置为平台财务人员",
-                        icon: <ExclamationCircleOutlined />,
-                        content: `确认要设置用户${r.name}（ID: ${r.userId}）为平台财务人员？`,
-                        onOk: async () => {
-                          await api.setPlatformRole({ body: {
-                            userId: r.userId,
-                            roleType: PlatformRole.PLATFORM_FINANCE,
-                          } })
-                            .then(() => {
-                              message.success("操作成功！");
-                              reload();
-                            });
-                        },
-                      });
-                    }}
-                  >
-                    设置
-                  </a>
-                </Space>
-              )
-
+            <PlatformRoleSelector reload={reload} roles={r.platformRoles} userId={r.userId} currentUser={user} />
           )}
         />
 

--- a/apps/mis-web/src/pageComponents/init/InitUsersAndAccountsTable.tsx
+++ b/apps/mis-web/src/pageComponents/init/InitUsersAndAccountsTable.tsx
@@ -13,143 +13,20 @@
 import { FormLayout } from "@scow/lib-web/build/layouts/FormLayout";
 import { Account } from "@scow/protos/build/server/account";
 import { AccountAffiliation, User } from "@scow/protos/build/server/user";
-import { App, Select, Table, Tabs, Typography } from "antd";
-import { useEffect, useState } from "react";
+import { Table, Tabs, Typography } from "antd";
+import { useEffect } from "react";
 import { useAsync } from "react-async";
 import { api } from "src/apis";
 import { Centered } from "src/components/layouts";
-import { PlatformRole, PlatformRoleTexts, TenantRole, TenantRoleTexts, UserRole, UserRoleTexts } from "src/models/User";
+import { PlatformRoleSelector } from "src/components/PlatformRoleSelector";
+import { TenantRoleSelector } from "src/components/TenantRoleSelector";
+import { UserRole, UserRoleTexts } from "src/models/User";
 
 interface DataTableProps<T> {
   data: T[] | undefined;
   loading: boolean;
   reload: () => void;
 }
-
-interface PlatformRoleSelectorProps {
-  role: PlatformRole[];
-  userId: string;
-  reload: () => void;
-}
-
-const platformRoleToLabeledValue = (role: PlatformRole) => ({ label: PlatformRoleTexts[role], value: role });
-
-const PlatformRoleSelector: React.FC<PlatformRoleSelectorProps> = ({ role, userId, reload }) => {
-  const { message } = App.useApp();
-
-  const [loading, setLoading] = useState(false);
-
-  return (
-    <Select
-      disabled={loading}
-      value={role}
-      style={{ width: "100%" }}
-      options={Object.values(PlatformRole).map(platformRoleToLabeledValue)}
-      onSelect={
-        async (value) => {
-          setLoading(true);
-          await api.setPlatformRole({ body:{
-            userId: userId,
-            roleType: value,
-          } })
-            .httpError(200, () => { message.error("用户已经是该角色"); })
-            .httpError(404, () => { message.error("用户不存在"); })
-            .httpError(403, () => { message.error("用户没有权限"); })
-            .then(() => {
-              message.success("设置成功");
-              setLoading(false);
-              reload();
-            });
-        }
-      }
-      onDeselect={
-        async (value) => {
-          setLoading(true);
-          await api.unsetPlatformRole({ body:{
-            userId: userId,
-            roleType: value,
-          } })
-            .httpError(200, () => { message.error("用户已经不是该角色"); })
-            .httpError(404, () => { message.error("用户不存在"); })
-            .httpError(403, () => { message.error("用户没有权限"); })
-            .then(() => {
-              message.success("设置成功");
-              setLoading(false);
-              reload();
-            });
-        }
-      }
-      mode="multiple"
-      placeholder="Please select"
-    />
-  );
-};
-
-
-interface TenantRoleSelectorProps {
-  role: TenantRole[];
-  userId: string;
-  reload: () => void;
-}
-
-const tenantRoleToLabeledValue = (role: TenantRole) => ({ label: TenantRoleTexts[role], value: role });
-
-const TenantRoleSelector: React.FC<TenantRoleSelectorProps> = ({ role, userId, reload }) => {
-
-  const { message } = App.useApp();
-
-  const [loading, setLoading] = useState(false);
-
-  console.log(TenantRole);
-
-  return (
-    <Select
-      disabled={loading}
-      value={role}
-      style={{ width: "100%" }}
-      options={Object.values(TenantRole).map(tenantRoleToLabeledValue)}
-      onSelect={
-        async (value) => {
-          console.log(value);
-          setLoading(true);
-          await api.setTenantRole({ body:{
-            userId: userId,
-            roleType: value,
-          } })
-            .httpError(200, () => { message.error("用户已经是该角色"); })
-            .httpError(404, () => { message.error("用户不存在"); })
-            .httpError(403, () => { message.error("用户没有权限"); })
-            .then(() => {
-              message.success("设置成功");
-              setLoading(false);
-              reload();
-            });
-        }
-      }
-      onDeselect={
-        async (value) => {
-          console.log(value);
-          setLoading(true);
-          await api.unsetTenantRole({ body:{
-            userId: userId,
-            roleType: value,
-          } })
-            .httpError(200, () => { message.error("用户已经不是该角色"); })
-            .httpError(404, () => { message.error("用户不存在"); })
-            .httpError(403, () => { message.error("用户没有权限"); })
-            .then(() => {
-              message.success("设置成功");
-              setLoading(false);
-              reload();
-            });
-        }
-      }
-      mode="multiple"
-      placeholder="Please select"
-    />
-  );
-};
-
 
 const UserTable: React.FC<DataTableProps<User>> = ({ data, loading, reload }) => {
   return (
@@ -167,7 +44,7 @@ const UserTable: React.FC<DataTableProps<User>> = ({ data, loading, reload }) =>
         title="平台角色"
         width={200}
         render={(_, r) => (
-          <PlatformRoleSelector role={r.platformRoles} userId={r.userId} reload={reload} />
+          <PlatformRoleSelector roles={r.platformRoles} userId={r.userId} reload={reload} />
         )}
       />
       <Table.Column<User>
@@ -175,7 +52,7 @@ const UserTable: React.FC<DataTableProps<User>> = ({ data, loading, reload }) =>
         title="租户角色"
         width={200}
         render={(_, r) => (
-          <TenantRoleSelector role={r.tenantRoles} userId={r.userId} reload={reload} />
+          <TenantRoleSelector roles={r.tenantRoles} userId={r.userId} reload={reload} />
         )}
       />
       <Table.Column

--- a/apps/mis-web/src/pageComponents/tenant/AdminUserTable.tsx
+++ b/apps/mis-web/src/pageComponents/tenant/AdminUserTable.tsx
@@ -10,15 +10,14 @@
  * See the Mulan PSL v2 for more details.
  */
 
-import { ExclamationCircleOutlined } from "@ant-design/icons";
 import { compareDateTime, formatDateTime } from "@scow/lib-web/build/utils/datetime";
 import { App, Button, Divider, Form, Input, Space, Table } from "antd";
 import React, { useMemo, useState } from "react";
 import { api } from "src/apis";
 import { ChangePasswordModalLink } from "src/components/ChangePasswordModal";
-import { DisabledA } from "src/components/DisabledA";
 import { FilterFormContainer } from "src/components/FilterFormContainer";
-import { FullUserInfo, TenantRole } from "src/models/User";
+import { TenantRoleSelector } from "src/components/TenantRoleSelector";
+import { FullUserInfo } from "src/models/User";
 import { GetTenantUsersSchema } from "src/pages/api/admin/getTenantUsers";
 import { User } from "src/stores/UserStore";
 
@@ -38,7 +37,7 @@ export const AdminUserTable: React.FC<Props> = ({
   data, isLoading, reload, user,
 }) => {
 
-  const { message, modal } = App.useApp();
+  const { message } = App.useApp();
 
   const [form] = Form.useForm<FilterForm>();
 
@@ -97,118 +96,9 @@ export const AdminUserTable: React.FC<Props> = ({
         />
         <Table.Column<FullUserInfo>
           dataIndex="tenantRoles"
-          title="租户管理员"
+          title="租户角色"
           render={(_, r) => (
-            r.tenantRoles.includes(TenantRole.TENANT_ADMIN) ? (
-              <Space size="middle">
-                是
-                <DisabledA
-                  disabled={r.id === user.identityId}
-                  message="不能取消自己的租户管理员权限"
-                  onClick={async () => {
-                    modal.confirm({
-                      title: "确定取消租户管理员权限",
-                      icon: <ExclamationCircleOutlined />,
-                      content: `确定要移除用户${r.name}（ID: ${r.id}）的租户管理员权限？`,
-                      onOk: async () => {
-                        await api.unsetTenantRole({ body: {
-                          userId : r.id,
-                          roleType: TenantRole.TENANT_ADMIN,
-                        } })
-                          .then(() => {
-                            message.success("操作成功！");
-                            reload();
-                          });
-                      },
-                    });
-                  }}
-                >
-                  取消
-                </DisabledA>
-              </Space>
-            ) : (
-              <Space size="middle">
-                否
-                <a
-                  onClick={() => {
-                    modal.confirm({
-                      title: "确定设置为租户管理员",
-                      icon: <ExclamationCircleOutlined />,
-                      content: `确定要设置用户${r.name}（ID: ${r.id}）为租户管理员？`,
-                      onOk: async () => {
-                        await api.setTenantRole({ body: {
-                          userId : r.id,
-                          roleType: TenantRole.TENANT_ADMIN,
-                        } })
-                          .then(() => {
-                            message.success("操作成功！");
-                            reload();
-                          });
-                      },
-                    });
-                  }}
-                >
-                  设置
-                </a>
-              </Space>
-            )
-          )}
-        />
-        <Table.Column<FullUserInfo>
-          dataIndex="tenantRoles"
-          title="租户财务人员"
-          render={(_, r) => (
-            r.tenantRoles.includes(TenantRole.TENANT_FINANCE) ? (
-              <Space size="middle">
-                是
-                <a
-                  onClick={() => {
-                    modal.confirm({
-                      title: "确定取消租户财务人员权限",
-                      icon: <ExclamationCircleOutlined />,
-                      content: `确定要移除用户${r.name}（ID: ${r.id}）的财务人员权限？`,
-                      onOk: async () => {
-                        await api.unsetTenantRole({ body: {
-                          userId : r.id,
-                          roleType: TenantRole.TENANT_FINANCE,
-                        } })
-                          .then(() => {
-                            message.success("操作成功！");
-                            reload();
-                          });
-                      },
-                    });
-                  }}
-                >
-                  取消
-                </a>
-              </Space>
-            ) : (
-              <Space size="middle">
-                否
-                <a
-                  onClick={() => {
-                    modal.confirm({
-                      title: "确定设置为租户财务人员",
-                      icon: <ExclamationCircleOutlined />,
-                      content: `确定要设置用户${r.name}（ID: ${r.id}）为租户财务人员？`,
-                      onOk: async () => {
-                        await api.setTenantRole({ body: {
-                          userId : r.id,
-                          roleType: TenantRole.TENANT_FINANCE,
-                        } })
-                          .then(() => {
-                            message.success("操作成功！");
-                            reload();
-                          });
-                      },
-                    });
-                  }}
-                >
-                  设置
-                </a>
-              </Space>
-            )
+            <TenantRoleSelector reload={reload} roles={r.tenantRoles} userId={r.id} currentUser={user} />
           )}
         />
         <Table.Column<FullUserInfo>


### PR DESCRIPTION
管理系统平台管理员管理所有用户和租户管理员管理租户用户功能中，使用下拉框选择用户的角色，和系统初始化时选择用户角色UI相同。

![image](https://user-images.githubusercontent.com/8363856/210211952-b0f32e7a-8033-40fb-af32-98e7a507118f.png)

![image](https://user-images.githubusercontent.com/8363856/210211972-2b744d1b-258c-4329-9915-9bc716086d9a.png)

同时：

- 去掉多余的console.log
- 修改两个Selector组件中prop不规范命名：表示多个角色的prop原来为单数role，现在修改为复数roles