### PR TITLE
fix(portal-server): 以用户身份提交作业

### DIFF
--- a/apps/portal-server/src/clusterops/slurm/job.ts
+++ b/apps/portal-server/src/clusterops/slurm/job.ts
@@ -10,7 +10,7 @@
  * See the Mulan PSL v2 for more details.
  */
 
-import { executeAsUser, sftpExists, sftpReaddir, sftpReadFile, sftpWriteFile } from "@scow/lib-ssh";
+import { executeAsUser, loggedExec, sftpExists, sftpReaddir, sftpReadFile, sftpWriteFile } from "@scow/lib-ssh";
 import { join } from "path";
 import { JobOps, JobTemplate } from "src/clusterops/api/job";
 import { querySacct, querySqueue } from "src/clusterops/slurm/bl/queryJobInfo";
@@ -56,7 +56,7 @@ export const slurmJobOps = (cluster: string): JobOps => {
     submitJob: async (request, logger) => {
       const { jobInfo, userId, saveAsTemplate } = request;
 
-      return await sshConnect(host, "root", logger, async (ssh) => {
+      return await sshConnect(host, userId, logger, async (ssh) => {
 
         const dir = jobInfo.workingDirectory;
 
@@ -68,7 +68,7 @@ export const slurmJobOps = (cluster: string): JobOps => {
         await ssh.mkdir(dir, undefined, sftp);
 
         // use sbatch to allocate the script. pass the script into sbatch in stdin
-        const { code, stderr, stdout } = await executeAsUser(ssh, userId, logger, false,
+        const { code, stderr, stdout } = await loggedExec(ssh, logger, false,
           "sbatch", [],
           { stdin: script },
         );


### PR DESCRIPTION
#384 为了提高需要SSH运行命令的功能的加载数据的速度，将很多需要以用户身份运行命令的功能改成以root身份运行命令，其中包括提交作业。但是以root身份提交作业可能会让slurm无法正确获知目前真正的用户，从而错误的设置一些作业的属性（比如stdout输出目录）。这个PR将提交作业重新改成以用户身份登录SSH后提交作业。这可能会降低shell配置文件复杂的用户提交作业的速度，但是提交作业本来就不需要速度快，这个修改可以接受。