### PR TITLE
fix(mis-server): 修复当用户名有大写字符时，获取已有slurm用户信息时报错

### DIFF
--- a/apps/mis-server/src/services/admin.ts
+++ b/apps/mis-server/src/services/admin.ts
@@ -134,7 +134,9 @@ export const adminServiceServer = plugin((server) => {
         userId: { $in: result.users.map((x) => x.userId) },
       });
       includedUsers.forEach((user) => {
-        const u = result.users.find((x) => x.userId === user.userId)!;
+        // https://slurm.schedmd.com/sacctmgr.html#OPT_user
+        // slurm's username defaults to lower case
+        const u = result.users.find((x) => x.userId === user.userId.toLowerCase())!;
         u.included = true;
         u.userName = user.name;
       });

--- a/apps/mis-server/src/services/admin.ts
+++ b/apps/mis-server/src/services/admin.ts
@@ -136,7 +136,7 @@ export const adminServiceServer = plugin((server) => {
       includedUsers.forEach((user) => {
         // https://slurm.schedmd.com/sacctmgr.html#OPT_user
         // slurm's username defaults to lower case
-        const u = result.users.find((x) => x.userId === user.userId.toLowerCase())!;
+        const u = result.users.find((x) => x.userId.toLowerCase() === user.userId.toLowerCase())!;
         u.included = true;
         u.userName = user.name;
       });


### PR DESCRIPTION
根据slurm的文档（https://slurm.schedmd.com/sacctmgr.html#OPT_user ），默认情况下slurm的用户名为小写，创建用户时大写字符会被改成小写，但是SCOW数据库中存储的用户名没有这一变小写的步骤，又因为SQL查询where对比字符串也不考虑大小写（下图），而所以在获取slurm用户后，把slurm的所有用户名拿去数据库中查询数据库中已经存在的用户时，数据库返回的已有的用户的用户名为大小写都有，slurm用户为小写，匹配不上，就报错了。

![image](https://user-images.githubusercontent.com/8363856/210294396-5631b226-8805-40fc-b67d-25560b975eba.png)

这个PR在代码中在使用数据库中的用户查询slurm中对应的用户时忽略大小写以绕过这个问题。