### PR TITLE
fix(mis): 正确处理slurm.sh预期中的非0返回值

### DIFF
--- a/apps/mis-server/src/clusterops/slurm/account.ts
+++ b/apps/mis-server/src/clusterops/slurm/account.ts
@@ -12,6 +12,7 @@
 
 import { AccountOps } from "src/clusterops/api/account";
 import { SlurmClusterInfo } from "src/clusterops/slurm";
+import { handleSimpleResponse } from "src/clusterops/slurm/utils/slurm";
 
 export const slurmAccountOps = ({ executeSlurmScript }: SlurmClusterInfo): AccountOps => {
 
@@ -20,21 +21,15 @@ export const slurmAccountOps = ({ executeSlurmScript }: SlurmClusterInfo): Accou
       const { accountName, ownerId } = request;
       const result = await executeSlurmScript(["-c", accountName, "0", ownerId ], logger);
 
-      if (result.code === 6) {
-        return { code: "ALREADY_EXISTS" };
-      }
-      return { code: "OK" };
+      return handleSimpleResponse(result, { 6: "ALREADY_EXISTS" });
     },
 
     deleteAccount: async ({ request, logger }) => {
       const { accountName } = request;
       const result = await executeSlurmScript(["-a", accountName], logger);
 
-      if (result.code === 7) {
-        return { code: "NOT_FOUND" };
-      }
+      return handleSimpleResponse(result, { 7: "NOT_FOUND" });
 
-      return { code: "OK" };
     },
 
     blockAccount: async ({ request, logger }) => {
@@ -42,15 +37,7 @@ export const slurmAccountOps = ({ executeSlurmScript }: SlurmClusterInfo): Accou
 
       const result = await executeSlurmScript(["-b", accountName], logger);
 
-      if (result.code === 8) {
-        return { code: "ALREADY_BLOCKED" };
-      }
-
-      if (result.code === 7) {
-        return { code: "NOT_FOUND" };
-      }
-
-      return { code: "OK" };
+      return handleSimpleResponse(result, { 8: "ALREADY_BLOCKED", 7: "NOT_FOUND" });
     },
 
     unblockAccount: async ({ request, logger }) => {
@@ -58,15 +45,7 @@ export const slurmAccountOps = ({ executeSlurmScript }: SlurmClusterInfo): Accou
 
       const result = await executeSlurmScript(["-d", accountName], logger);
 
-      if (result.code === 9) {
-        return { code: "ALREADY_UNBLOCKED" };
-      }
-
-      if (result.code === 7) {
-        return { code: "NOT_FOUND" };
-      }
-
-      return { code: "OK" };
+      return handleSimpleResponse(result, { 9: "ALREADY_UNBLOCKED", 7: "NOT_FOUND" });
     },
   };
 };

--- a/apps/mis-server/src/clusterops/slurm/storage.ts
+++ b/apps/mis-server/src/clusterops/slurm/storage.ts
@@ -12,6 +12,7 @@
 
 import { ChangeStorageQuotaMode, StorageOps } from "src/clusterops/api/storage";
 import { SlurmClusterInfo } from "src/clusterops/slurm";
+import { throwIfNotReturn0 } from "src/clusterops/slurm/utils/slurm";
 
 export const slurmStorageOps = ({ executeSlurmScript }: SlurmClusterInfo): StorageOps => {
   return {
@@ -22,6 +23,8 @@ export const slurmStorageOps = ({ executeSlurmScript }: SlurmClusterInfo): Stora
       if (result.code === 2) {
         return { code: "NOT_FOUND" };
       }
+
+      throwIfNotReturn0(result);
 
       /**
        * format is
@@ -84,6 +87,8 @@ export const slurmStorageOps = ({ executeSlurmScript }: SlurmClusterInfo): Stora
       if (result.code === 4) {
         return { code: "NOT_FOUND" };
       }
+
+      throwIfNotReturn0(result);
 
       // TODO handle output format
       return { code: "OK", currentQuota: 10 };

--- a/apps/mis-server/src/clusterops/slurm/user.ts
+++ b/apps/mis-server/src/clusterops/slurm/user.ts
@@ -12,6 +12,7 @@
 
 import { UserOps } from "src/clusterops/api/user";
 import { SlurmClusterInfo } from "src/clusterops/slurm";
+import { handleSimpleResponse, throwIfNotReturn0 } from "src/clusterops/slurm/utils/slurm";
 
 export const slurmUserOps = ({ executeSlurmScript }: SlurmClusterInfo): UserOps => {
 
@@ -19,35 +20,35 @@ export const slurmUserOps = ({ executeSlurmScript }: SlurmClusterInfo): UserOps 
     addUserToAccount: async ({ request, logger }) => {
       const { accountName, userId } = request;
       const result = await executeSlurmScript(["-g", accountName, "0", userId], logger);
-      if (result.code === 3) {
-        return { code: "ALREADY_EXISTS" };
-      }
 
-      return { code: "OK" };
+      return handleSimpleResponse(result, { 3: "ALREADY_EXISTS" });
     },
     removeUser: async ({ request, logger }) => {
       const { accountName, userId } = request;
       const result = await executeSlurmScript(["-k", accountName, userId], logger);
-      if (result.code === 4) { return { code: "NOT_FOUND" }; }
-      return { code: "OK" };
+
+      return handleSimpleResponse(result, { 4: "NOT_FOUND" });
     },
 
     blockUserInAccount: async ({ request, logger }) => {
       const { accountName, userId } = request;
       const result = await executeSlurmScript(["-o", accountName, userId], logger);
-      if (result.code === 4) { return { code: "NOT_FOUND" }; }
-      return { code: "OK" };
+
+      return handleSimpleResponse(result, { 4: "NOT_FOUND" });
     },
 
     unblockUserInAccount: async ({ request, logger }) => {
       const { accountName, userId } = request;
       const result = await executeSlurmScript(["-r", accountName, userId], logger);
-      if (result.code === 4) { return { code: "NOT_FOUND" }; }
-      return { code: "OK" };
+
+      return handleSimpleResponse(result, { 4: "NOT_FOUND" });
     },
 
     getAllUsersInAccounts: async ({ logger }) => {
       const result = await executeSlurmScript(["-l", "all"], logger);
+
+      throwIfNotReturn0(result);
+
       return { result: result.stdout };
     },
 

--- a/libs/ssh/src/ssh.ts
+++ b/libs/ssh/src/ssh.ts
@@ -10,7 +10,7 @@
  * See the Mulan PSL v2 for more details.
  */
 
-import { NodeSSH, SSHExecCommandOptions } from "node-ssh";
+import { NodeSSH, SSHExecCommandOptions, SSHExecCommandResponse } from "node-ssh";
 import { join } from "path";
 import { quote } from "shell-quote";
 import type { Logger } from "ts-log";
@@ -135,6 +135,12 @@ export function constructCommand(cmd: string, parameters: readonly string[], env
   return envPrefix + command;
 }
 
+export class SSHExecError extends Error {
+  constructor(public response: SSHExecCommandResponse, options?: ErrorOptions) {
+    super("Error when executing command", options);
+  }
+}
+
 export async function loggedExec(ssh: NodeSSH, logger: Logger, throwIfFailed: boolean,
   cmd: string, parameters: string[], options?: SSHExecCommandOptions) {
 
@@ -147,7 +153,7 @@ export async function loggedExec(ssh: NodeSSH, logger: Logger, throwIfFailed: bo
   if (resp.code !== 0) {
     logger.error("Command %o failed. stdout %s, stderr %s", command, resp.stdout, resp.stderr);
     if (throwIfFailed) {
-      throw new Error("");
+      throw new SSHExecError(resp);
     }
   } else {
     logger.debug("Command %o completed. stdout %s, stderr %s", command, resp.stdout, resp.stderr);


### PR DESCRIPTION
之前，只要slurm.sh返回了0，那么整个调用函数就会throw，已经写好的针对一些预期中的非0返回值的逻辑无法执行（例如封锁已经封锁的账户，按现在的设计应该不报错）。这个PR修复了这个问题。