### PR TITLE
fix(portal-server): 连接VNC类应用时，以用户身份SSH连接到计算节点

### DIFF
--- a/apps/portal-server/src/clusterops/slurm/app.ts
+++ b/apps/portal-server/src/clusterops/slurm/app.ts
@@ -324,7 +324,10 @@ export const slurmAppOps = (cluster: string): AppOps => {
               if (displayId) {
                 // the server is run at the compute node
                 // login to the compute node and refresh the password
-                return await sshConnect(host, "root", logger, async (computeNodeSsh) => {
+
+                // connect as user so that
+                // the service node doesn't need to be able to connect to compute nodes with public key
+                return await sshConnect(host, userId, logger, async (computeNodeSsh) => {
                   const password = await refreshPassword(computeNodeSsh, userId, logger, displayId!);
                   return {
                     code: "OK",


### PR DESCRIPTION
#384 把连接VNC类应用时，连接到计算节点的用户名也改成了root，但是SCOW事实上没有要求服务节点也能免密登录到计算节点。这个PR把连接到计算节点的用户名改回了用户名。