### PR TITLE
fix(web): 作业查询UI优化

### DIFF
--- a/apps/mis-web/src/pageComponents/job/HistoryJobTable.tsx
+++ b/apps/mis-web/src/pageComponents/job/HistoryJobTable.tsx
@@ -15,7 +15,7 @@ import { defaultPresets, formatDateTime } from "@scow/lib-web/build/utils/dateti
 import { useDidUpdateEffect } from "@scow/lib-web/build/utils/hooks";
 import { Money } from "@scow/protos/build/common/money";
 import { JobInfo } from "@scow/protos/build/server/job";
-import { App, Button, DatePicker, Divider, Form, Input, InputNumber, Select, Table } from "antd";
+import { App, Button, DatePicker, Divider, Form, Input, InputNumber, Select, Space, Table } from "antd";
 import dayjs from "dayjs";
 import React, { useCallback, useRef, useState } from "react";
 import { useAsync } from "react-async";
@@ -60,7 +60,7 @@ export const JobTable: React.FC<Props> = ({
   const [query, setQuery] = useState<FilterForm>(() => {
     const now = dayjs();
     return {
-      jobEndTime: [now.subtract(1, "week"), now],
+      jobEndTime: [now.subtract(1, "week").startOf("day"), now.endOf("day")],
       jobId: undefined,
       clusters: Object.values(publicConfig.CLUSTERS),
       accountName: typeof accountNames === "string" ? accountNames : undefined,
@@ -95,7 +95,7 @@ export const JobTable: React.FC<Props> = ({
     });
   }, [pageInfo, query]);
 
-  const { data, isLoading } = useAsync({ promiseFn });
+  const { data, isLoading, reload } = useAsync({ promiseFn });
 
   return (
     <div>
@@ -112,9 +112,10 @@ export const JobTable: React.FC<Props> = ({
         >
           <FilterFormTabs
             button={(
-              <Form.Item>
+              <Space>
                 <Button type="primary" htmlType="submit">搜索</Button>
-              </Form.Item>
+                <Button onClick={reload} loading={isLoading}>刷新</Button>
+              </Space>
             )}
             onChange={(a) => rangeSearch.current = a === "range"}
             tabs={[

--- a/apps/mis-web/src/pageComponents/job/RunningJobTable.tsx
+++ b/apps/mis-web/src/pageComponents/job/RunningJobTable.tsx
@@ -108,7 +108,7 @@ export const RunningJobQueryTable: React.FC<Props> = ({
             button={(
               <Space>
                 <Button type="primary" htmlType="submit">搜索</Button>
-                <Button onClick={reload} disabled={isLoading}>刷新</Button>
+                <Button onClick={reload} loading={isLoading}>刷新</Button>
               </Space>
             )}
             tabs={[

--- a/apps/portal-web/src/pageComponents/job/AllJobsTable.tsx
+++ b/apps/portal-web/src/pageComponents/job/AllJobsTable.tsx
@@ -45,7 +45,7 @@ export const AllJobQueryTable: React.FC<Props> = ({
   const [query, setQuery] = useState<FilterForm>(() => {
     const now = dayjs();
     return {
-      time: [now.subtract(1, "week"), now],
+      time: [now.subtract(1, "week").startOf("day"), now.endOf("day")],
       jobId: undefined,
       cluster: defaultClusterStore.cluster,
     };
@@ -102,6 +102,9 @@ export const AllJobQueryTable: React.FC<Props> = ({
           </Form.Item>
           <Form.Item>
             <Button type="primary" htmlType="submit">搜索</Button>
+          </Form.Item>
+          <Form.Item>
+            <Button loading={isLoading} onClick={reload}>刷新</Button>
           </Form.Item>
         </Form>
       </FilterFormContainer>

--- a/apps/portal-web/src/pageComponents/job/RunningJobTable.tsx
+++ b/apps/portal-web/src/pageComponents/job/RunningJobTable.tsx
@@ -93,6 +93,9 @@ export const RunningJobQueryTable: React.FC<Props> = ({
           <Form.Item>
             <Button type="primary" htmlType="submit">搜索</Button>
           </Form.Item>
+          <Form.Item>
+            <Button loading={isLoading} onClick={reload}>刷新</Button>
+          </Form.Item>
         </Form>
       </FilterFormContainer>
       <RunningJobInfoTable


### PR DESCRIPTION
管理系统和门户系统的作业查询功能优化：

- 查询历史作业的默认时间修改为一周前的一天的第一秒至当天的最后一秒
- 所有查询作业增加刷新按钮

![image](https://user-images.githubusercontent.com/8363856/210477722-d98c4ad2-50df-429d-80a9-ab936f1e1641.png)
