### PR TITLE
fix(portal): 以root身份查询已有交互式作业和连接到交互式作业

### DIFF
--- a/libs/ssh/src/ssh.ts
+++ b/libs/ssh/src/ssh.ts
@@ -203,6 +203,19 @@ export async function testRootUserSshLogin(host: string, keyPair: KeyPair, logge
 }
 
 /**
+ * Get a user's home directory
+ * @param ssh ssh object connected as any user
+ * @param username the username to be queried
+ * @param logger logger
+ * @returns the user's home directory
+ */
+export const getUserHomedir = async (ssh: NodeSSH, username: string, logger: Logger) => {
+  const resp = await loggedExec(ssh, logger, true, "eval", ["echo", `~${username}`]);
+
+  return resp.stdout.trim();
+};
+
+/**
  * Login as user by password and insert the host's public key to the user's authorized_keys to enable public key login
  *
  * @param address the address
@@ -217,8 +230,7 @@ export async function insertKeyAsUser(
 ) {
 
   await sshConnectByPassword(address, username, pwd, logger, async (ssh) => {
-    const homeDir = await loggedExec(ssh, logger, true, "eval", ["echo", `~${username}`]);
-    const userHomeDir = homeDir.stdout.trim();
+    const userHomeDir = await getUserHomedir(ssh, username, logger);
 
     const sftp = await ssh.requestSFTP();
     const stat = await sftpStat(sftp)(userHomeDir).catch(() => undefined);

--- a/libs/ssh/tests/ssh.test.ts
+++ b/libs/ssh/tests/ssh.test.ts
@@ -10,8 +10,9 @@
  * See the Mulan PSL v2 for more details.
  */
 
-import { executeAsUser, getEnvPrefix } from "src/ssh";
-import { connectToTestServerAsRoot, resetTestServerAsRoot, TestSshServer } from "tests/utils";
+import { executeAsUser, getEnvPrefix, getUserHomedir, sshConnectByPassword } from "src/ssh";
+import { connectToTestServerAsRoot, resetTestServerAsRoot,
+  rootUserId, target, TestSshServer, testUserId, testUserPassword } from "tests/utils";
 
 let testServer: TestSshServer;
 
@@ -24,15 +25,13 @@ afterEach(async () => {
 });
 
 
-const TEST_USER = "test";
-
 it.each([
-  [["whoami", [], {}], TEST_USER],
-  [["echo", ["$USER"], {}], TEST_USER],
-  [["echo", ["$USER $TEST", "$TEST"], { TEST: "1" }], `${TEST_USER} 1 1`],
+  [["whoami", [], {}], testUserId],
+  [["echo", ["$USER"], {}], testUserId],
+  [["echo", ["$USER $TEST", "$TEST"], { TEST: "1" }], `${testUserId} 1 1`],
 ] as const)("execute command as another user", async ([cmd, parameters, env], stdout) => {
 
-  const resp = await executeAsUser(testServer.ssh, TEST_USER, console, false, cmd, parameters, {
+  const resp = await executeAsUser(testServer.ssh, testUserId, console, false, cmd, parameters, {
     execOptions: { env },
   });
 
@@ -46,4 +45,15 @@ it.each([
   [{ test: "1", test2: "2\"" }, "test=1 test2='2\"' "],
 ])("gets correct env prefix", async (env, expected) => {
   expect(getEnvPrefix(env)).toBe(expected);
+});
+
+it.each([
+  [rootUserId, "/root"],
+  [testUserId, "/home/test"],
+])("get the homedir of user %p to %p", async (user, expected) => {
+  expect(await getUserHomedir(testServer.ssh, user, console)).toBe(expected);
+  await sshConnectByPassword(target, testUserId, testUserPassword, console, async (ssh) => {
+    expect(await getUserHomedir(ssh, user, console)).toBe(expected);
+  });
+
 });

--- a/libs/ssh/tests/utils.ts
+++ b/libs/ssh/tests/utils.ts
@@ -21,6 +21,8 @@ import { SFTPWrapper } from "ssh2";
 
 export const target = "localhost:22222";
 export const rootUserId = "root";
+export const testUserId = "test";
+export const testUserPassword = "1234";
 
 export interface TestSshServer {
   ssh: NodeSSH;
@@ -31,8 +33,6 @@ const SSH_PRIVATE_KEY_PATH = join(homedir(), ".ssh", "id_rsa");
 const SSH_PUBLIC_KEY_PATH = join(homedir(), ".ssh", "id_rsa.pub");
 
 export const rootKeyPair = getKeyPair(SSH_PRIVATE_KEY_PATH, SSH_PUBLIC_KEY_PATH);
-
-
 
 export const connectToTestServerAsRoot = async () => {
 


### PR DESCRIPTION
#384 后续。查询已有交互式作业和连接到交互式作业都需要浏览文件，之前都需要以用户身份登录SSH和SFTP。这个PR使这两个功能都可以以root身份连接到到SSH和SFTP，以避开加载用户shell配置文件的开销。