### PR TITLE
fix(mis): 修复查看充值记录的bug和调整租户充值文本

### DIFF
--- a/apps/mis-server/src/services/charging.ts
+++ b/apps/mis-server/src/services/charging.ts
@@ -147,8 +147,7 @@ export const chargingServiceServer = plugin((server) => {
       const { tenantName, accountName, endTime, startTime } = ensureNotUndefined(request, ["startTime", "endTime"]);
 
       const records = await em.find(PayRecord, {
-        time: { $gte: startTime, $lte: endTime },
-        ...accountName !== undefined ? { accountName } : {},
+        time: { $gte: startTime, $lte: endTime }, accountName,
         ...tenantName !== undefined ? { tenantName } : {},
       }, { orderBy: { time: QueryOrder.DESC } });
 

--- a/apps/mis-server/tests/charging/charging.test.ts
+++ b/apps/mis-server/tests/charging/charging.test.ts
@@ -241,7 +241,7 @@ it("returns payment records", async () => {
     amount: request1.amount,
   } as Partial<PaymentRecord>);
 
-  expect(reply1.total).toBe(numberToMoney(10));
+  expect(reply1.total).toStrictEqual(numberToMoney(10));
 
   // not set accountName, set tenantName
   const reply2 = await asyncClientCall(client, "getPaymentRecords", {
@@ -260,7 +260,7 @@ it("returns payment records", async () => {
     amount: request2.amount,
   } as Partial<PaymentRecord>);
 
-  expect(reply2.total).toBe(numberToMoney(20));
+  expect(reply2.total).toStrictEqual(numberToMoney(20));
 
   // not set accountName, not set tenantName
   const reply3 = await asyncClientCall(client, "getPaymentRecords", {
@@ -278,6 +278,6 @@ it("returns payment records", async () => {
     amount: request2.amount,
   } as Partial<PaymentRecord>);
 
-  expect(reply3.total).toBe(numberToMoney(20));
+  expect(reply3.total).toStrictEqual(numberToMoney(20));
 
 });

--- a/apps/mis-server/tests/charging/charging.test.ts
+++ b/apps/mis-server/tests/charging/charging.test.ts
@@ -194,11 +194,11 @@ it("returns payment records", async () => {
 
   const request1: PayRequest = {
     accountName: account.accountName,
+    tenantName: account.tenant.getProperty("name"),
     amount: amount1,
     comment: "comment",
     operatorId: "tester",
     ipAddress: "127.0.0.1",
-    tenantName: account.tenant.getProperty("name"),
     type: "test",
   };
 
@@ -219,6 +219,8 @@ it("returns payment records", async () => {
   await asyncClientCall(client, "pay", request2);
 
   await reloadEntity(em, account);
+  await reloadEntity(em, account.tenant.getEntity());
+  
   expect(account.balance.toNumber()).toBe(10);
   expect(account.tenant.getProperty("balance").toNumber()).toBe(20);
 

--- a/apps/mis-server/tests/charging/charging.test.ts
+++ b/apps/mis-server/tests/charging/charging.test.ts
@@ -189,11 +189,12 @@ it("concurrently charges", async () => {
 
 
 it("returns payment records", async () => {
-  const amount = numberToMoney(10);
+  const amount1 = numberToMoney(10);
+  const amount2 = numberToMoney(20);
 
-  const request: PayRequest = {
+  const request1: PayRequest = {
     accountName: account.accountName,
-    amount: amount,
+    amount: amount1,
     comment: "comment",
     operatorId: "tester",
     ipAddress: "127.0.0.1",
@@ -201,27 +202,80 @@ it("returns payment records", async () => {
     type: "test",
   };
 
+  const request2: PayRequest = {
+    tenantName: account.tenant.getProperty("name"),
+    amount: amount2,
+    comment: "comment",
+    operatorId: "tester",
+    ipAddress: "127.0.0.1",
+    type: "test",
+  };
+
   const startTime = new Date();
 
   const client = new ChargingServiceClient(server.serverAddress, ChannelCredentials.createInsecure());
 
-  await asyncClientCall(client, "pay", request);
+  await asyncClientCall(client, "pay", request1);
+  await asyncClientCall(client, "pay", request2);
 
   await reloadEntity(em, account);
   expect(account.balance.toNumber()).toBe(10);
+  expect(account.tenant.getProperty("balance").toNumber()).toBe(20);
 
-  const reply = await asyncClientCall(client, "getPaymentRecords", {
+  // set accountName
+  const reply1 = await asyncClientCall(client, "getPaymentRecords", {
     accountName: account.accountName,
+    tenantName: account.tenant.getProperty("name"),
     startTime: startTime.toISOString(),
     endTime: new Date().toISOString(),
   });
 
-  expect(reply.results).toHaveLength(1);
+  expect(reply1.results).toHaveLength(1);
 
-  expect(reply.results[0]).toMatchObject({
-    accountName: request.accountName,
-    comment: request.comment,
-    ipAddress: request.ipAddress,
-    amount: request.amount,
+  expect(reply1.results[0]).toMatchObject({
+    accountName: request1.accountName,
+    comment: request1.comment,
+    ipAddress: request1.ipAddress,
+    amount: request1.amount,
   } as Partial<PaymentRecord>);
+
+  expect(reply1.total).toBe(numberToMoney(10));
+
+  // not set accountName, set tenantName
+  const reply2 = await asyncClientCall(client, "getPaymentRecords", {
+    tenantName: account.tenant.getProperty("name"),
+    startTime: startTime.toISOString(),
+    endTime: new Date().toISOString(),
+  });
+
+  expect(reply2.results).toHaveLength(1);
+
+  expect(reply2.results[0]).toMatchObject({
+    tenantName: request2.tenantName,
+    accountName: request2.accountName,
+    comment: request2.comment,
+    ipAddress: request2.ipAddress,
+    amount: request2.amount,
+  } as Partial<PaymentRecord>);
+
+  expect(reply2.total).toBe(numberToMoney(20));
+
+  // not set accountName, not set tenantName
+  const reply3 = await asyncClientCall(client, "getPaymentRecords", {
+    startTime: startTime.toISOString(),
+    endTime: new Date().toISOString(),
+  });
+
+  expect(reply3.results).toHaveLength(1);
+
+  expect(reply3.results[0]).toMatchObject({
+    tenantName: request2.tenantName,
+    accountName: request2.accountName,
+    comment: request2.comment,
+    ipAddress: request2.ipAddress,
+    amount: request2.amount,
+  } as Partial<PaymentRecord>);
+
+  expect(reply3.total).toBe(numberToMoney(20));
+
 });

--- a/apps/mis-web/src/layouts/routes.tsx
+++ b/apps/mis-web/src/layouts/routes.tsx
@@ -72,7 +72,7 @@ export const platformAdminRoutes: (platformRoles: PlatformRole[]) => NavItemProp
           children: [
             {
               Icon: PlusSquareOutlined,
-              text: "账户充值",
+              text: "租户充值",
               path: "/admin/finance/pay",
             },
             {

--- a/apps/mis-web/src/pageComponents/finance/PaymentTable.tsx
+++ b/apps/mis-web/src/pageComponents/finance/PaymentTable.tsx
@@ -83,7 +83,7 @@ export const PaymentTable: React.FC<Props> = ({
                 )
               : (
                 <Form.Item label="账户" name="accountName">
-                  <Input />
+                  <Input placeholder="不输入账户时显示租户充值记录" />
                 </Form.Item>
               )
           }

--- a/apps/mis-web/src/pages/api/finance/payments.ts
+++ b/apps/mis-web/src/pages/api/finance/payments.ts
@@ -21,7 +21,7 @@ import { getClient } from "src/utils/client";
 
 export interface PaymentInfo {
   index: number;
-  accountName: string;
+  accountName?: string;
   time: string;
   type: string;
   amount: number;
@@ -86,7 +86,7 @@ export default route<GetPaymentsSchema>("GetPaymentsSchema", async (req, res) =>
 
   const returnAuditInfo = user.tenantRoles.includes(TenantRole.TENANT_FINANCE);
 
-  const accounts = reply.results.filter((x) => x.accountName !== undefined).map((x) => {
+  const records = reply.results.map((x) => {
     const obj = ensureNotUndefined(x, ["time", "amount"]);
 
     return {
@@ -103,8 +103,8 @@ export default route<GetPaymentsSchema>("GetPaymentsSchema", async (req, res) =>
 
   return {
     200: {
-      results: accounts,
-      total: accounts.reduce((prev, curr) => prev + curr.amount, 0),
+      results: records,
+      total: moneyToNumber(reply.total),
     },
   };
 });

--- a/apps/mis-web/src/pages/api/finance/payments.ts
+++ b/apps/mis-web/src/pages/api/finance/payments.ts
@@ -104,7 +104,7 @@ export default route<GetPaymentsSchema>("GetPaymentsSchema", async (req, res) =>
   return {
     200: {
       results: accounts,
-      total: moneyToNumber(reply.total),
+      total: accounts.reduce((prev, curr) => prev.amount + curr.amount, 0),
     },
   };
 });

--- a/apps/mis-web/src/pages/api/finance/payments.ts
+++ b/apps/mis-web/src/pages/api/finance/payments.ts
@@ -104,7 +104,7 @@ export default route<GetPaymentsSchema>("GetPaymentsSchema", async (req, res) =>
   return {
     200: {
       results: accounts,
-      total: accounts.reduce((prev, curr) => prev.amount + curr.amount, 0),
+      total: accounts.reduce((prev, curr) => prev + curr.amount, 0),
     },
   };
 });

--- a/apps/mis-web/src/pages/api/finance/payments.ts
+++ b/apps/mis-web/src/pages/api/finance/payments.ts
@@ -86,7 +86,7 @@ export default route<GetPaymentsSchema>("GetPaymentsSchema", async (req, res) =>
 
   const returnAuditInfo = user.tenantRoles.includes(TenantRole.TENANT_FINANCE);
 
-  const accounts = reply.results.map((x) => {
+  const accounts = reply.results.filter((x) => x.accountName !== undefined).map((x) => {
     const obj = ensureNotUndefined(x, ["time", "amount"]);
 
     return {

--- a/protos/server/charging.proto
+++ b/protos/server/charging.proto
@@ -94,8 +94,8 @@ message PaymentRecord {
 }
 
 // If account_name is set, return records of the account, ignoring tenant_name.
-// If account_name is not set and tenant_name is set, return records of the
-// tenant. If none is set, return all
+// If account_name is not set and tenant_name is set, return records of this tenant.
+// If none is set, return records of all tenants.
 message GetPaymentRecordsRequest {
   google.protobuf.Timestamp start_time = 1;
   google.protobuf.Timestamp end_time = 2;


### PR DESCRIPTION
- 调整租户充值文本
- 修复查看充值记录的bug。在默认不指定账户的情况下后端会返回`accountName`为空的充值记录，在api层处理时遇到问题。