### PR TITLE
chore: 更新changesets工作流

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,9 @@
   "access": "public",
   "baseBranch": "master",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": [],
+  "privatePackages": {
+    "version": true,
+    "tag": true
+  }
 }

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,7 +2,16 @@
   "$schema": "https://unpkg.com/@changesets/config@2.3.0/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
-  "fixed": [],
+  "fixed": [
+    [
+      "@scow/auth",
+      "@scow/gateway",
+      "@scow/mis-server",
+      "@scow/mis-web",
+      "@scow/portal-server",
+      "@scow/portal-web"
+    ]
+  ],
   "linked": [],
   "access": "public",
   "baseBranch": "master",

--- a/.github/workflows/test-build-publish.yaml
+++ b/.github/workflows/test-build-publish.yaml
@@ -79,7 +79,9 @@ jobs:
         uses: changesets/action@v1
         if: github.ref == 'refs/heads/master'
         with:
-          publish: pnpm publish:ci
+          version: pnpm ci:version
+          publish: pnpm ci:publish
+          createGithubReleases: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/apps/gateway/package.json
+++ b/apps/gateway/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@scow/gateway",
+  "private": true,
+  "version": "0.1.0"
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "scow",
   "private": true,
+  "version": "0.1.0",
   "scripts": {
     "build": "turbo run build",
     "build:libs": "turbo run build --filter \"./libs/**\"",
@@ -16,7 +17,8 @@
     "lint": "turbo run lint:ts lint:protos",
     "lint:ts": "eslint --cache --ext .tsx,.ts .",
     "lint:protos": "buf lint",
-    "publish:ci": "pnpm publish -r"
+    "ci:version": "node scripts/version.mjs",
+    "ci:publish": "pnpm publish -r"
   },
   "devDependencies": {
     "turbo": "1.7.0",

--- a/scripts/version.mjs
+++ b/scripts/version.mjs
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2022 Peking University and Peking University Institute for Computing and Digital Economy
+ * SCOW is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *          http://license.coscl.org.cn/MulanPSL2
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PSL v2 for more details.
+ */
+
+/**
+ * Execute pnpm changeset version to bump package versions, and bump root package.json version
+ */
+
+import { execSync } from "child_process";
+import fs from "fs";
+
+const exec = (cmd) => execSync(cmd, { stdio: "inherit" });
+
+exec("pnpm changeset version");
+
+// update root package version
+const readPackageJson = (path) => JSON.parse(fs.readFileSync(path, { encoding: "utf8" }));
+
+const rootPackageJson = readPackageJson("./package.json");
+
+// read version from a app package
+const portalWebPackageJson = readPackageJson("./apps/portal-web/package.json");
+
+console.log("App version is %s", portalWebPackageJson.version);
+rootPackageJson.version = portalWebPackageJson.version;
+
+// write back to root package.json
+fs.writeFileSync("./package.json", JSON.stringify(rootPackageJson, null, 2));
+
+


### PR DESCRIPTION
- 使用changesets管理gateway项目
- 将apps下的所有包的版本关联起来，并增加一个`ci:version`脚本，使得提高任何一个apps下的版本将会同时提高apps下所有包以及根包的版本