### PR TITLE
ci: 新增tag到发布工作流

### DIFF
--- a/.github/workflows/tag-release.yaml
+++ b/.github/workflows/tag-release.yaml
@@ -1,0 +1,26 @@
+name: Tag a release
+on:
+  push:
+    paths:
+      - package.json
+    branches:
+      - "master"
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  tag-if-needed:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+      - uses: fregante/setup-git-user@v1
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+
+      - name: Create tag if needed
+        run: node scripts/tag.mjs

--- a/.github/workflows/test-build-publish.yaml
+++ b/.github/workflows/test-build-publish.yaml
@@ -5,6 +5,8 @@ on:
   pull_request:
     branches: [master]
   push:
+    tags:
+      - "**"
     branches:
       - master
 

--- a/.github/workflows/test-build-publish.yaml
+++ b/.github/workflows/test-build-publish.yaml
@@ -10,9 +10,7 @@ on:
     branches:
       - master
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
+concurrency: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
 
 env:
   GITHUB_CR: ghcr.io

--- a/scripts/tag.mjs
+++ b/scripts/tag.mjs
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2022 Peking University and Peking University Institute for Computing and Digital Economy
+ * SCOW is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *          http://license.coscl.org.cn/MulanPSL2
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PSL v2 for more details.
+ */
+
+/**
+ * Compare the version of the current package.json with the version of the last commit
+ * If the version is changed, create a tag and push it to the remote repository
+ */
+
+import { execSync } from "child_process";
+import { readFileSync } from "fs";
+
+const exec = (cmd) => execSync(cmd, { stdio: "inherit", encoding: "utf-8" });
+
+const lastPackageJson = execSync("git --no-pager show HEAD^1:package.json", { encoding: "utf-8" });
+
+const lastVersion = JSON.parse(lastPackageJson).version;
+
+const currentVersion = JSON.parse(readFileSync("package.json", { encoding: "utf-8" })).version;
+
+if (lastVersion === currentVersion) {
+  console.log("App version is not changed. Ignored");
+  process.exit(0);
+}
+
+console.log("App version is changed from %s to %s", lastVersion, currentVersion);
+
+exec(`git tag -a v${currentVersion} -m 'Release v${currentVersion}'`);
+exec("git push --tags");
+
+

--- a/scripts/version.mjs
+++ b/scripts/version.mjs
@@ -29,10 +29,16 @@ const rootPackageJson = readPackageJson("./package.json");
 // read version from a app package
 const portalWebPackageJson = readPackageJson("./apps/portal-web/package.json");
 
-console.log("App version is %s", portalWebPackageJson.version);
-rootPackageJson.version = portalWebPackageJson.version;
+console.log("App version is %s. Root version is %s", portalWebPackageJson.version, rootPackageJson.version);
 
-// write back to root package.json
+if (portalWebPackageJson.version === rootPackageJson.version) {
+  console.log("App Version is not changed. Ignored.");
+  process.exit(0);
+}
+
+console.log("App Version is changed. Update root package.json version");
+
+rootPackageJson.version = portalWebPackageJson.version;
 fs.writeFileSync("./package.json", JSON.stringify(rootPackageJson, null, 2));
 
 


### PR DESCRIPTION
1. 当package.json中的版本变化时，触发tag-release.yml工作流，生成一个新版本的tag并推送到repo
2. 当有新的tag推送到仓库时，触发生成镜像并发布的工作流，构建带有版本号tag的镜像并推送