### PR TITLE
feat: 配置日志输出选项

### DIFF
--- a/.changeset/curly-beds-drive.md
+++ b/.changeset/curly-beds-drive.md
@@ -1,0 +1,8 @@
+---
+"@scow/portal-server": minor
+"@scow/mis-server": minor
+"@scow/auth": minor
+"@scow/docs": minor
+---
+
+增加配置日志输出选项功能

--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -36,7 +36,8 @@
     "fastify-plugin": "4.5.0",
     "ioredis": "5.3.1",
     "ldapjs": "2.3.3",
-    "nanoid": "4.0.1"
+    "nanoid": "4.0.1",
+    "pino-pretty": "9.2.0"
   },
   "devDependencies": {
     "@types/asn1": "0.2.0",

--- a/apps/auth/src/app.ts
+++ b/apps/auth/src/app.ts
@@ -33,7 +33,12 @@ const ValidationError = createError("BAD_REQUEST", "Errors occurred when validat
 export function buildApp(pluginOverrides?: PluginOverrides) {
 
   const server = fastify({
-    logger: { level: config.LOG_LEVEL },
+    logger: {
+      level: config.LOG_LEVEL,
+      ...config.LOG_PRETTY ? {
+        transport: { target: "pino-pretty" },
+      } : {},
+    },
     ajv: {
       customOptions: {
         coerceTypes: "array",

--- a/apps/auth/src/config/env.ts
+++ b/apps/auth/src/config/env.ts
@@ -10,7 +10,7 @@
  * See the Mulan PSL v2 for more details.
  */
 
-import { envConfig, host, port, str } from "@scow/lib-config";
+import { bool, envConfig, host, port, str } from "@scow/lib-config";
 import { getKeyPair } from "@scow/lib-ssh";
 import { homedir } from "os";
 import { join } from "path";
@@ -27,6 +27,7 @@ export const config = envConfig({
     default: "info",
     desc: "日志等级",
   }),
+  LOG_PRETTY: bool({ desc: "以可读的方式输出log", default: false }),
 
   BASE_PATH: str({ desc: "整个系统的base path", default: "/" }),
 

--- a/apps/mis-server/package.json
+++ b/apps/mis-server/package.json
@@ -42,7 +42,8 @@
     "dotenv": "16.0.3",
     "node-cron": "3.0.2",
     "uuid": "9.0.0",
-    "wait-on": "7.0.1"
+    "wait-on": "7.0.1",
+    "pino-pretty": "9.2.0"
   },
   "devDependencies": {
     "@types/google-protobuf": "3.15.6",

--- a/apps/mis-server/src/app.ts
+++ b/apps/mis-server/src/app.ts
@@ -27,7 +27,13 @@ export async function createServer() {
   const server = new Server({
     host: config.HOST,
     port: config.PORT,
-    logger: { level: config.LOG_LEVEL },
+
+    logger: {
+      level: config.LOG_LEVEL,
+      ...config.LOG_PRETTY ? {
+        transport: { target: "pino-pretty" },
+      } : {},
+    },
   });
 
   for (const plugin of plugins) {

--- a/apps/mis-server/src/config/env.ts
+++ b/apps/mis-server/src/config/env.ts
@@ -10,7 +10,7 @@
  * See the Mulan PSL v2 for more details.
  */
 
-import { envConfig, host, port, str } from "@scow/lib-config";
+import { bool, envConfig, host, port, str } from "@scow/lib-config";
 import { getKeyPair } from "@scow/lib-ssh";
 import { homedir } from "os";
 import { join } from "path";
@@ -22,6 +22,7 @@ export const config = envConfig({
     default: "info",
     desc: "日志等级",
   }),
+  LOG_PRETTY: bool({ desc: "以可读的方式输出log", default: false }),
 
   SSH_PRIVATE_KEY_PATH: str({ desc: "SSH私钥路径", default: join(homedir(), ".ssh", "id_rsa") }),
   SSH_PUBLIC_KEY_PATH: str({ desc: "SSH公钥路径", default: join(homedir(), ".ssh", "id_rsa.pub") }),

--- a/apps/portal-server/package.json
+++ b/apps/portal-server/package.json
@@ -35,7 +35,8 @@
     "wait-on": "7.0.1",
     "ts-log": "2.2.5",
     "shell-quote": "1.8.0",
-    "dayjs": "1.11.7"
+    "dayjs": "1.11.7",
+    "pino-pretty": "9.2.0"
   },
   "devDependencies": {
     "@ddadaal/tsgrpc-client": "0.17.3",

--- a/apps/portal-server/src/app.ts
+++ b/apps/portal-server/src/app.ts
@@ -25,7 +25,12 @@ export async function createServer() {
   const server = new Server({
     host: config.HOST,
     port: config.PORT,
-    logger: { level: config.LOG_LEVEL },
+    logger: {
+      level: config.LOG_LEVEL,
+      ...config.LOG_PRETTY ? {
+        transport: { target: "pino-pretty" },
+      } : {},
+    },
   });
 
   for (const plugin of plugins) {

--- a/apps/portal-server/src/config/env.ts
+++ b/apps/portal-server/src/config/env.ts
@@ -10,7 +10,7 @@
  * See the Mulan PSL v2 for more details.
  */
 
-import { envConfig, host, num, port, str } from "@scow/lib-config";
+import { bool, envConfig, host, num, port, str } from "@scow/lib-config";
 import { getKeyPair } from "@scow/lib-ssh";
 import { homedir } from "os";
 import { join } from "path";
@@ -22,6 +22,7 @@ export const config = envConfig({
     default: "info",
     desc: "日志等级",
   }),
+  LOG_PRETTY: bool({ desc: "以可读的方式输出log", default: false }),
 
   SSH_PRIVATE_KEY_PATH: str({ desc: "SSH私钥路径", default: join(homedir(), ".ssh", "id_rsa") }),
   SSH_PUBLIC_KEY_PATH: str({ desc: "SSH公钥路径", default: join(homedir(), ".ssh", "id_rsa.pub") }),

--- a/deploy/local/config-example.py
+++ b/deploy/local/config-example.py
@@ -24,6 +24,15 @@ COMMON = {
   "IMAGE_TAG": "master",
 }
 
+# ------- 日志配置 -------
+#
+# LOG.LEVEL: 日志等级，可选trace, debug, info, warn, error。默认info
+# LOG.PRETTY: 是否输出更适合直接读的log。如果为False，则输出json格式的日志。默认False
+# LOG = {
+#   # "LEVEL": "info",
+#   # "PRETTY": False,
+# }
+
 #
 # ------- 门户系统 -------
 #

--- a/deploy/local/generate.py
+++ b/deploy/local/generate.py
@@ -52,7 +52,7 @@ MIS_PATH = get_cfg(["MIS", "BASE_PATH"], "/mis")
 check_path_format("MIS.BASE_PATH", MIS_PATH)
 
 LOG_LEVEL = get_cfg(["LOG", "LEVEL"], "info")
-LOG_PRETTY = get_cfg(["LOG", "PRETTY"], False)
+LOG_PRETTY = json.dumps(get_cfg(["LOG", "PRETTY"], False))
 
 
 def path_join(*args):

--- a/deploy/local/generate.py
+++ b/deploy/local/generate.py
@@ -51,6 +51,10 @@ check_path_format("PORTAL.BASE_PATH", PORTAL_PATH)
 MIS_PATH = get_cfg(["MIS", "BASE_PATH"], "/mis")
 check_path_format("MIS.BASE_PATH", MIS_PATH)
 
+LOG_LEVEL = get_cfg(["LOG", "LEVEL"], "info")
+LOG_PRETTY = get_cfg(["LOG", "PRETTY"], False)
+
+
 def path_join(*args):
   def join(a, b):
     if a == "/":
@@ -206,6 +210,8 @@ def create_auth_service():
 
     au_env = {
         "BASE_PATH": BASE_PATH,
+        "LOG_LEVEL": LOG_LEVEL,
+        "LOG_PRETTY": LOG_PRETTY,
     }
 
     AUTH_PORT = get_cfg(["DEBUG", "OPEN_PORTS", "AUTH"])
@@ -227,7 +233,12 @@ def create_portal_server_service():
 
     ports = [(port, 5000)] if port else []
 
-    portal_server = Service("portal-server", generate_image("portal-server"), ports, ps_volumes, None)
+    env = {
+      "LOG_LEVEL": LOG_LEVEL,
+      "LOG_PRETTY": LOG_PRETTY,
+    }
+
+    portal_server = Service("portal-server", generate_image("portal-server"), ports, ps_volumes, env)
     return portal_server
 
 
@@ -267,7 +278,9 @@ def create_db_service():
 
 def create_mis_server_service():
     ms_env = {
-        "DB_PASSWORD": cfg.MIS["DB_PASSWORD"]
+        "DB_PASSWORD": cfg.MIS["DB_PASSWORD"],
+        "LOG_LEVEL": LOG_LEVEL,
+        "LOG_PRETTY": LOG_PRETTY,
     }
     ms_volumes = {
         "/etc/hosts": "/etc/hosts",

--- a/docs/docs/deploy/ops/index.md
+++ b/docs/docs/deploy/ops/index.md
@@ -50,4 +50,21 @@ LOG = {
 }
 ```
 
+当`LOG.PRETTY`为`True`时，输出日志格式如下：
 
+```
+[02:27:00.372] INFO (18): request completed
+    reqId: "req-3"
+    res: {
+      "statusCode": 200
+    }
+    responseTime: 0.3789879999967525
+```
+
+当`LOG.PRETTY`为`False`时，输出日志格式如下：
+
+```json
+{"level":30,"time":1676429663943,"pid":18,"hostname":"d3fc2f53e863","reqId":"req-1","res":{"statusCode":200},"responseTime":4.37828900013119,"msg":"request completed"}
+```
+
+当您需要使用日志收集工具时，建议您使用JSON格式输出日志，然后使用日志分析工具来查看和分析收集到的日志。

--- a/docs/docs/deploy/ops/index.md
+++ b/docs/docs/deploy/ops/index.md
@@ -10,19 +10,44 @@ title: 运维
 ## 更新
 
 要更新本系统，如果更新没有引入破坏性升级，那么只需要重新拉取(pull)并重启容器即可。
-  - 如果采用的是`docker compose`部署方法，只需要`./compose.sh pull && ./compose.sh up -d`即可
+
+```bash
+./compose.sh pull
+./compose.sh up -d
+```
 
 如果更新引入了破坏性的变更，请根据对应的更新说明，修改配置后在进行部署。
 
-## 查看日志
+## 日志
 
-各个组件的日志直接写到`stdout`。
+### 查看日志
 
-对于使用镜像部署的部分，可以使用常用的docker日志管理命令或者工具管理日志。如果使用的`docker compose`，可以使用`./compose.sh logs -f`后面跟对应服务名称的方式查看服务的日志。
+各个组件的日志直接写到`stdout`。可以使用常用的docker日志管理命令或者工具管理日志。如果使用的`docker compose`，可以使用`./compose.sh logs -f`后面跟对应服务名称的方式查看服务的日志。
 
 ```bash
-# 如果docker compose中服务名为auth，使用此命令可以查看auth服务的日志
+# 查看认证系统的日志
 ./compose.sh logs -f auth
+
+# 查看门户系统服务器端的日志
+./compose.sh logs -f portal-server
+
+# 查看管理系统服务器端的日志
+./compose.sh logs -f mis-server
+```
+
+### 配置日志输出
+
+您可以通过`config.py`配置门户系统后端（`portal-server`）、管理系统后端（`mis-server`）和内置认证系统（`auth`）的日志输出选项。
+
+```python
+# ------- 日志配置 -------
+#
+# LOG.LEVEL: 日志等级，可选trace, debug, info, warn, error。默认info
+# LOG.PRETTY: 是否输出更适合直接读的log。如果为False，则输出json格式的日志。默认False
+LOG = {
+  "LEVEL": "info",
+  "PRETTY": True,
+}
 ```
 
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,7 @@ importers:
       ldapjs: 2.3.3
       liquidjs: 10.4.0
       nanoid: 4.0.1
+      pino-pretty: 9.2.0
     dependencies:
       '@fastify/error': 3.2.0
       '@fastify/formbody': 7.4.0
@@ -113,6 +114,7 @@ importers:
       ldapjs: 2.3.3
       liquidjs: 10.4.0
       nanoid: 4.0.1
+      pino-pretty: 9.2.0
     devDependencies:
       '@types/asn1': 0.2.0
       '@types/ldapjs': 2.2.5
@@ -144,6 +146,7 @@ importers:
       '@types/wait-on': 5.3.1
       dotenv: 16.0.3
       node-cron: 3.0.2
+      pino-pretty: 9.2.0
       uuid: 9.0.0
       wait-on: 7.0.1
     dependencies:
@@ -166,6 +169,7 @@ importers:
       '@sinclair/typebox': 0.25.21
       dotenv: 16.0.3
       node-cron: 3.0.2
+      pino-pretty: 9.2.0
       uuid: 9.0.0
       wait-on: 7.0.1
     devDependencies:
@@ -298,6 +302,7 @@ importers:
       dayjs: 1.11.7
       dotenv: 16.0.3
       node-cron: 3.0.2
+      pino-pretty: 9.2.0
       shell-quote: 1.8.0
       ts-log: 2.2.5
       uuid: 9.0.0
@@ -315,6 +320,7 @@ importers:
       dayjs: 1.11.7
       dotenv: 16.0.3
       node-cron: 3.0.2
+      pino-pretty: 9.2.0
       shell-quote: 1.8.0
       ts-log: 2.2.5
       uuid: 9.0.0
@@ -7871,7 +7877,6 @@ packages:
 
   /dateformat/4.6.3:
     resolution: {integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==}
-    dev: true
 
   /dayjs/1.11.7:
     resolution: {integrity: sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ==}
@@ -9001,7 +9006,6 @@ packages:
 
   /fast-copy/3.0.0:
     resolution: {integrity: sha512-4HzS+9pQ5Yxtv13Lhs1Z1unMXamBdn5nA4bEi1abYpDNSpSp7ODYQ1KPMF6nTatfEzgH6/zPvXKU1zvHiUjWlA==}
-    dev: true
 
   /fast-decode-uri-component/1.0.1:
     resolution: {integrity: sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==}
@@ -9067,7 +9071,6 @@ packages:
 
   /fast-safe-stringify/2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
-    dev: true
 
   /fast-uri/2.1.0:
     resolution: {integrity: sha512-qKRta6N7BWEFVlyonVY/V+BMLgFqktCUV0QjT259ekAIlbVrMaFnFLxJ4s/JPl4tou56S1BzPufI60bLe29fHA==}
@@ -9933,7 +9936,6 @@ packages:
     dependencies:
       glob: 8.0.3
       readable-stream: 3.6.0
-    dev: true
 
   /history/4.10.1:
     resolution: {integrity: sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==}
@@ -11282,7 +11284,6 @@ packages:
   /joycon/3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
-    dev: true
 
   /js-git/0.7.8:
     resolution: {integrity: sha512-+E5ZH/HeRnoc/LW0AmAyhU+mNcWBzAKE+30+IDMLSLbbK+Tdt02AdkOKq9u15rlJsDEGFqtgckc8ZM59LhhiUA==}
@@ -13317,7 +13318,6 @@ packages:
       secure-json-parse: 2.5.0
       sonic-boom: 3.2.0
       strip-json-comments: 3.1.1
-    dev: true
 
   /pino-std-serializers/6.0.0:
     resolution: {integrity: sha512-mMMOwSKrmyl+Y12Ri2xhH1lbzQxwwpuru9VjyJpgFIH4asSj88F2csdMwN6+M5g1Ll4rmsYghHLQJw81tgZ7LQ==}


### PR DESCRIPTION
`config.py`增加日志输出配置

- `LOG_LEVEL`: 日志等级，可选`trace`, `debug`, `info`, `warn`, `error`
- `LOG_PRETTY`: 是否以易读的方式(pretty)输出日志，如果是false则输出json格式的日志。使用[`pino-pretty`](https://github.com/pinojs/pino-pretty)来pretty print日志

![image](https://user-images.githubusercontent.com/8363856/218784059-175c331b-5372-4f5b-967f-3c312193b910.png)

