### PR TITLE
fix(portal): 修复home目录下创建文件夹失败的问题，下拉选择框支持搜索

### DIFF
--- a/apps/mis-web/src/pageComponents/tenant/TenantSelector.tsx
+++ b/apps/mis-web/src/pageComponents/tenant/TenantSelector.tsx
@@ -58,6 +58,7 @@ export const TenantSelector: React.FC<Props> = ({
   return (
     <Input.Group compact>
       <Select
+        showSearch
         loading={isLoading}
         options={data ? data.names.map((x) => ({ label: x, value: x })) : []}
         placeholder={placeholder}

--- a/apps/portal-web/src/pageComponents/filemanager/CreateFileModal.tsx
+++ b/apps/portal-web/src/pageComponents/filemanager/CreateFileModal.tsx
@@ -39,6 +39,7 @@ export const CreateFileModal: React.FC<Props> = ({ open, onClose, path, reload, 
     setLoading(true);
     await api.createFile({ body: { cluster, path: join(path, newFileName) } })
       .httpError(409, () => { message.error("同名文件或者目录已经存在！"); })
+      .httpError(500, (e) => { message.error(e?.message); })
       .then(() => {
         message.success("创建成功");
         reload();

--- a/apps/portal-web/src/pages/api/file/createFile.ts
+++ b/apps/portal-web/src/pages/api/file/createFile.ts
@@ -28,16 +28,15 @@ export interface CreateFileSchema {
 
   responses: {
     204: null;
-    409: { code: "ALREADY_EXISTS" }
+    409: { code: "ALREADY_EXISTS" };
     400: { code: "INVALID_CLUSTER" };
+    500: { code: "INVALID_ARGUMENT", message: string };
   }
 }
 
 const auth = authenticate(() => true);
 
 export default route<CreateFileSchema>("CreateFileSchema", async (req, res) => {
-
-
 
   const info = await auth(req, res);
 
@@ -52,6 +51,7 @@ export default route<CreateFileSchema>("CreateFileSchema", async (req, res) => {
   }).then(() => ({ 204: null }), handlegRPCError({
     [status.NOT_FOUND]: () => ({ 400: { code: "INVALID_CLUSTER" as const } }),
     [status.ALREADY_EXISTS]: () => ({ 409: { code: "ALREADY_EXISTS" as const } }),
+    [status.INVALID_ARGUMENT]: (e) => ({ 500: { code: "INVALID_ARGUMENT" as const, message: e?.details } }),
   }));
 
 });


### PR DESCRIPTION
此PR主要回归了以下2个issue：
1、fixed [系统初试化导入用户功能下指定账户拥有者需要下拉搜索功能](https://github.com/PKUHPC/scow-internal-dev/issues/174)

<img width="696" alt="搜索" src="https://user-images.githubusercontent.com/25954437/221873531-134d68c9-18e1-413d-bd7e-605309391476.png">

fixed [home目录创建文件夹报错](https://github.com/PKUHPC/scow-internal-dev/issues/177)，展示了无法创建的原因

<img width="456" alt="屏幕截图_20230228_213501" src="https://user-images.githubusercontent.com/25954437/221873603-8b17254d-7f49-45c8-a549-827cded0b97e.png">
