### PR TITLE
chore: 使用npm分发的buf工具

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,17 +1,3 @@
 FROM mcr.microsoft.com/devcontainers/typescript-node:18
 
-# Install Buf command line tools
-ARG BUF_VERSION="1.11.0"
-
-RUN BIN="/usr/local/bin" && \
-  VERSION="${BUF_VERSION}" && \
-  curl -sSL \
-  "https://github.com/bufbuild/buf/releases/download/v${VERSION}/buf-$(uname -s)-$(uname -m)" \
-  -o "${BIN}/buf" && \
-  chmod +x "${BIN}/buf"
-
-
 RUN corepack enable
-
-# Install browsers
-RUN pnpm dlx playwright install && sudo pnpm dlx playwright install-deps

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,6 @@
     "options": [
       "--proto_path=./protos"
     ],
-  }
+  },
+  "buf.binaryPath": "node_modules/@bufbuild/buf/bin/buf"
 }

--- a/docs/docs/contribution/dev.md
+++ b/docs/docs/contribution/dev.md
@@ -44,7 +44,6 @@ title: 开发
 
 - [volta](https://volta.sh/)：管理node环境
 - [pnpm](https://pnpm.io/pnpm-cli)：推荐standalone安装
-- [buf](https://docs.buf.build/installation)：管理protobuf文件
 
 无需手动安装node。volta将会在第一次运行npm或者node命令时自动安装对应工具的对应版本。
 

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "concurrently": "7.6.0",
     "node-glob": "1.2.0",
     "globby": "13.1.3",
-    "@changesets/cli": "2.26.0"
+    "@changesets/cli": "2.26.0",
+    "@bufbuild/buf": "1.15.0"
   },
   "volta": {
     "node": "18.14.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,7 @@ importers:
 
   .:
     specifiers:
+      '@bufbuild/buf': 1.15.0
       '@changesets/cli': 2.26.0
       '@commitlint/config-conventional': 17.4.4
       '@ddadaal/eslint-config': 1.9.0
@@ -40,6 +41,7 @@ importers:
       turbo: 1.8.2
       typescript: 4.9.5
     devDependencies:
+      '@bufbuild/buf': 1.15.0
       '@changesets/cli': 2.26.0
       '@commitlint/config-conventional': 17.4.4
       '@ddadaal/eslint-config': 1.9.0_5iaio6tyb3577flnrafh2uytzm
@@ -2159,6 +2161,74 @@ packages:
 
   /@bcoe/v8-coverage/0.2.3:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+    dev: true
+
+  /@bufbuild/buf-darwin-arm64/1.15.0:
+    resolution: {integrity: sha512-sLN6uGc8sIBALa7Q4fB6rW9NM0MXK32pH6RRDUdl7aDrp/3A6TLKKBGiHcY81axUyxDTUNFb8dOwhHTI2H8FzQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@bufbuild/buf-darwin-x64/1.15.0:
+    resolution: {integrity: sha512-iHml29I/hOl7ORyp9ohiV7fC1WqPbM5UjogwVpA8j06o5SgxRhp42nd80XRAXCM+65ecwiu5JVuspicGzQFOgg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@bufbuild/buf-linux-aarch64/1.15.0:
+    resolution: {integrity: sha512-YQHXqV1HhdpmIUrYg+gZNWCf43XHJJO5TlJT+pzXB/92PoN8gNP3KdxeRaM2sExcCs91G6zy1/Ms9N6DpeidUQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@bufbuild/buf-linux-x64/1.15.0:
+    resolution: {integrity: sha512-DD2OcsfofawRPQKXLFMqV2GSzi4WyE7kKE1PvXBtJy7sombv5TM26vgdb+DQv4T4Z2i7vhKshnflNkfd3QXtXA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@bufbuild/buf-win32-arm64/1.15.0:
+    resolution: {integrity: sha512-wk65iDXWRicfrt/9Gb1voAn9eGP2giQfKMrKOoEyytnDHFolMSmQimKH6iQ1uS5Vn0gI/BVp582cF1m9YsbXEg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@bufbuild/buf-win32-x64/1.15.0:
+    resolution: {integrity: sha512-KVoMj52ghYfLwGjQ+t19XZiQy8jGSGUYIe/yVZz08rsm5msXHGYOt++Bk3wr48rcv8gts8jo2/h1Ebkj+F6emw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@bufbuild/buf/1.15.0:
+    resolution: {integrity: sha512-HX6AjKiI8TVFJKWdDGIUC/zZQG/8sf5FbmU5VdbK/U8tbfCwBADkJ6I+qP6HnDDtSU4obS164J0sibdGhAJKqg==}
+    engines: {node: '>=12'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@bufbuild/buf-darwin-arm64': 1.15.0
+      '@bufbuild/buf-darwin-x64': 1.15.0
+      '@bufbuild/buf-linux-aarch64': 1.15.0
+      '@bufbuild/buf-linux-x64': 1.15.0
+      '@bufbuild/buf-win32-arm64': 1.15.0
+      '@bufbuild/buf-win32-x64': 1.15.0
     dev: true
 
   /@changesets/apply-release-plan/6.1.3:

--- a/turbo.json
+++ b/turbo.json
@@ -64,9 +64,9 @@
         ".eslintcache"
       ]
     },
-    "@scow/protos#lint": {
+    "lint": {
       "inputs": [
-        "protos/**"
+        "**/*.proto"
       ]
     }
   }


### PR DESCRIPTION
现在buf已可通过npm安装（https://docs.buf.build/installation#install-the-buf-cli ），所以这个PR将buf增加到了根package.json，有以下好处

- 不再需要手动安装和管理buf
- renovate能和其他npm一样管理buf的版本