### PR TITLE
fix(auth): 修复当部署的端口号非80时，回调地址出错的问题

### DIFF
--- a/.changeset/perfect-countries-itch.md
+++ b/.changeset/perfect-countries-itch.md
@@ -1,0 +1,7 @@
+---
+"@scow/gateway": patch
+"@scow/auth": patch
+"@scow/docs": patch
+---
+
+修复当部署的端口号非 80 时，回调地址出错的问题

--- a/apps/auth/src/auth/callback.ts
+++ b/apps/auth/src/auth/callback.ts
@@ -34,16 +34,17 @@ export const CallbackUrlNotValidError = createError(
 
 export async function validateCallbackHostname(callbackUrl: string, req: FastifyRequest) {
 
-  const incomingDomain = req.hostname;
+  // req.hostname includes port, which we don't want
+  const incomingHostname = req.hostname.split(":")[0];
 
   try {
-    const domain = new URL(callbackUrl).hostname;
+    const callbackHostname = new URL(callbackUrl).hostname;
 
-    if (domain === incomingDomain) {
+    if (callbackHostname === incomingHostname) {
       return;
     }
 
-    if (!allowedCallbackHostnames.has(domain)) {
+    if (!allowedCallbackHostnames.has(callbackHostname)) {
       throw new CallbackHostnameNotAllowedError();
 
     }

--- a/apps/gateway/includes/headers
+++ b/apps/gateway/includes/headers
@@ -1,3 +1,3 @@
-proxy_set_header Host   $host;
+proxy_set_header Host   $http_host;
 proxy_set_header X-Real-IP      $remote_addr;
 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/docs/docs/deploy/config/auth/config.md
+++ b/docs/docs/deploy/config/auth/config.md
@@ -5,9 +5,9 @@ title: 内置认证系统配置
 
 # 内置认证系统配置
 
-## 允许回调域名
+## 允许回调主机名
 
-当登录完成后，认证系统将会回调到登录时传入的`callbackUrl`参数。为了保证安全性，认证系统默认只允许回调到和认证系统相同的域名下。您可以通过配置`auth.yml`下的`allowedCallbackHostnames`配置项来配置允许回调的域名。
+当登录完成后，认证系统将会回调到登录时传入的`callbackUrl`参数。为了保证安全性，认证系统默认只允许回调到和认证系统相同的主机名下。您可以通过配置`auth.yml`下的`allowedCallbackHostnames`配置项来配置允许回调的主机名。注意，主机名(hostname)不包括端口号。
 
 ```yaml title="config/auth.yml"
 allowedCallbackHostnames：


### PR DESCRIPTION
![CbLHAC2IO3](https://user-images.githubusercontent.com/8363856/222620706-ce429bd8-35b8-4c12-b9a4-7c2239cd8347.jpg)

当系统没有部署在80端口时，系统在进入认证系统进行登录配置回调地址时，没有包括端口号。因为之前gateway在转发host header的值的时候，使用的是`$host`变量，这个变量不包括端口号。现在把它改成`$http_host`，直接把上游的host header转发到下游，这样下游才能知道端口号的信息。

同时，这个PR还将代码中和文档中涉及到hostname的变量名和文档术语统一到主机名（hostname）。