### PR TITLE
feat(dev): 支持在Dev Container中运行测试开发环境

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,9 +2,9 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/docker-existing-dockerfile
 {
   "name": "SCOW Dev Env",
-  "build": {
-    "dockerfile": "./Dockerfile"
-  },
+  "dockerComposeFile": "./docker-compose.devcontainer.yml",
+  "service": "scow-dev",
+  "workspaceFolder": "/workspace/SCOW",
   "features": {
     "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
   },

--- a/.devcontainer/docker-compose.devcontainer.yml
+++ b/.devcontainer/docker-compose.devcontainer.yml
@@ -1,0 +1,81 @@
+# Copyright (c) 2022 Peking University and Peking University Institute for Computing and Digital Economy
+# SCOW is licensed under Mulan PSL v2.
+# You can use this software according to the terms and conditions of the Mulan PSL v2.
+# You may obtain a copy of Mulan PSL v2 at:
+#          http://license.coscl.org.cn/MulanPSL2
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+# EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+# MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+# See the Mulan PSL v2 for more details.
+
+version: "3"
+
+services:
+
+  scow-dev:
+    image: scow-dev
+    build:
+      context: .
+      dockerfile: Dockerfile
+    command: /bin/sh -c "while sleep 1000; do :; done"
+    volumes:
+      # Mounts the project folder to '/workspace'. The target path inside the container
+      # should match what your application expects. In this case, the compose file is
+      # in a sub-folder, so you will mount '..'. You would then reference this path as the
+      # 'workspaceFolder' in '.devcontainer/devcontainer.json' so VS Code starts here.
+      - ..:/workspace/SCOW:cached
+
+  db:
+    image: mysql:8
+    environment:
+      MYSQL_ROOT_PASSWORD: mysqlrootpassword
+    volumes:
+      - "db:/var/lib/mysql"
+    network_mode: service:scow-dev
+
+  redis:
+    image: redis:alpine
+    network_mode: service:scow-dev
+
+  jobTableDb:
+    image: mariadb:5.5
+    command: mysqld --port 3307
+    environment:
+      MYSQL_ROOT_PASSWORD: jobtablepassword
+    volumes:
+      - jobtabledb:/var/lib/mysql
+    network_mode: service:scow-dev
+
+  ssh-server:
+    image: alpine-ssh
+    build:
+      context: ../dev/ssh-server
+    environment:
+      SSH_PORT: 22222
+    network_mode: service:scow-dev
+
+  ldap:
+    image: ldaptest
+    build:
+      context: ..
+      dockerfile: dev/ldap/Dockerfile
+    volumes:
+      - ldap:/var/lib/ldap
+    ulimits:
+      nofile:
+        soft: 10240
+        hard: 10240
+    network_mode: service:scow-dev
+
+  ldapadmin:
+    image: osixia/phpldapadmin
+    ports:
+      - 3890:80
+    environment:
+      PHPLDAPADMIN_LDAP_HOSTS: ldap://scow-dev:389
+      PHPLDAPADMIN_HTTPS: false
+
+volumes:
+  db:
+  ldap:
+  jobtabledb:

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ internal
 out
 dist
 version.json
+.pnpm-store

--- a/apps/auth/tests/callback.test.ts
+++ b/apps/auth/tests/callback.test.ts
@@ -15,10 +15,11 @@ process.env.AUTH_TYPE = "ssh";
 import { FastifyInstance } from "fastify";
 import { buildApp } from "src/app";
 import { CallbackHostnameNotAllowedError } from "src/auth/callback";
-import { allowedCallbackUrl, createFormData, notAllowedCallbackUrl } from "tests/utils";
+import { allowedCallbackUrl, createFormData,
+  notAllowedCallbackUrl, testUserPassword, testUserUsername } from "tests/utils";
 
-const username = "test";
-const password = "1234";
+const username = testUserUsername;
+const password = testUserPassword;
 const token = "token";
 const code = "code";
 

--- a/apps/auth/tests/ssh.test.ts
+++ b/apps/auth/tests/ssh.test.ts
@@ -14,10 +14,10 @@ process.env.AUTH_TYPE = "ssh";
 
 import { FastifyInstance } from "fastify";
 import { buildApp } from "src/app";
-import { allowedCallbackUrl, createFormData } from "tests/utils";
+import { allowedCallbackUrl, createFormData, testUserPassword, testUserUsername } from "tests/utils";
 
-const username = "test";
-const password = "1234";
+const username = testUserUsername;
+const password = testUserPassword;
 const token = "token";
 const code = "code";
 

--- a/apps/auth/tests/utils.ts
+++ b/apps/auth/tests/utils.ts
@@ -12,6 +12,9 @@
 
 import { authConfig } from "src/config/auth";
 
+export const testUserUsername = "test";
+export const testUserPassword = "test";
+
 export const allowedCallbackUrl = "http://" + authConfig.allowedCallbackHostnames[0] + "/callback";
 export const notAllowedCallbackUrl = "http://baddomain.com:29392/callback";
 

--- a/dev/ssh-server/Dockerfile
+++ b/dev/ssh-server/Dockerfile
@@ -14,12 +14,14 @@ ENV TZ Asia/Shanghai
 
 RUN apk add --no-cache openssh=9.1_p1-r2 sudo
 
+RUN echo 'root:root' | chpasswd
+
 COPY ./entry.sh /entry.sh
 
 RUN ssh-keygen -A ; mkdir /root/.ssh
 
 RUN echo "PermitRootLogin yes" >> /etc/ssh/sshd_config; sed -i -e '$aPubkeyAcceptedKeyTypes=+ssh-rsa\n' /etc/ssh/sshd_config
 
-RUN adduser -D test;echo "test:1234" | chpasswd ; mkdir /home/test/.ssh/ ; chown test.test home/test/.ssh/
+RUN adduser -D test;echo "test:test" | chpasswd ; mkdir /home/test/.ssh/ ; chown test.test home/test/.ssh/
 
 CMD ["sh", "/entry.sh"]

--- a/dev/ssh-server/entry.sh
+++ b/dev/ssh-server/entry.sh
@@ -8,10 +8,17 @@
 # MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
 # See the Mulan PSL v2 for more details.
 
-cp /id_rsa.pub /home/test/.ssh/authorized_keys
-cp /id_rsa.pub /root/.ssh/authorized_keys
+if [ -f /id_rsa.pub ]; then
+  cp /id_rsa.pub /home/test/.ssh/authorized_keys
+  cp /id_rsa.pub /root/.ssh/authorized_keys
 
-chown -R root: /root/.ssh/
-chown -R test: /home/test/.ssh/
+  chown -R root: /root/.ssh/
+  chown -R test: /home/test/.ssh/
+fi
+
+
+if [ -n "$SSH_PORT" ]; then
+  echo -e "Port $SSH_PORT\n" >>/etc/ssh/sshd_config
+fi
 
 /usr/sbin/sshd -D

--- a/docs/docs/contribution/dev.md
+++ b/docs/docs/contribution/dev.md
@@ -109,7 +109,7 @@ pnpm build
 
 ## 测试开发环境
 
-我们使用docker搭建了一套简单的开发环境，可以用来跑一些项目的测试。具体开发环境请参考[docker-compose.dev.yml](%REPO_FILE_URL%/dev/docker-compose.dev.yml)。
+我们使用docker搭建了一套简单的开发环境，主要用于运行项目的单元和集成测试。具体开发环境请参考[docker-compose.dev.yml](%REPO_FILE_URL%/dev/docker-compose.dev.yml)。
 
 开发环境包括
 
@@ -130,7 +130,7 @@ pnpm build
 
 Dev Container在启动时同时会启动测试开发环境，且测试开发环境的故启动后您不再需要手动启动开发环境。且这些服务均启动于开发容器的网络中，可以直接使用`localhost`连接到这些服务。
 
-SSH服务器注意：由于SSH服务器容器和开发环境所在容器为并列关系，SSH服务器不能直接使用开发容器所在的文件，故您需要在启动Dev Container后手动生成SSH密钥并配置公钥登录：
+注意：由于SSH服务器容器和开发环境所在容器为并列关系，SSH服务器不能直接使用开发容器所在的文件，故您需要在启动Dev Container后手动生成SSH密钥并配置公钥登录：
 
 ```bash
 # 在Dev Container中执行

--- a/docs/docs/contribution/dev.md
+++ b/docs/docs/contribution/dev.md
@@ -107,28 +107,47 @@ pnpm build
 
 ```
 
-
 ## 测试开发环境
 
 我们使用docker搭建了一套简单的开发环境，可以用来跑一些项目的测试。具体开发环境请参考[docker-compose.dev.yml](%REPO_FILE_URL%/dev/docker-compose.dev.yml)。
 
-:::caution
-
-使用Dev Container环境启动的开发环境目前无法直接使用测试开发环境。请使用vagrant进行开发，请参考(文档)[%REPO_FILE_URL%/dev/vagrant/README.md]。
-
-:::
-
 开发环境包括
 
 - 可以通过`3306`端口连接的的MySQL8数据库
-    - root密码为[dev/.env.dev](%REPO_FILE_URL%/dev/.env.dev)中的`MYSQL_ROOT_PASSWORD`
+    - root密码为[dev/.env.dev](%REPO_FILE_URL%/dev/.env.dev)中的`MYSQL_ROOT_PASSWORD`，为`mysqlrootpassword`
 - 可以通过`6379`端口连接的redis:alpine
 - 可以通过`3307`端口连接的mariadb:5.5作为job table
-    - root密码为[dev/.env.dev](%REPO_FILE_URL%/dev/.env.dev)中的`JOB_TABLE_PASSWORD`
-- 可以通过`22222`端口连接的SSH服务器
-    - 可以直接使用本地的`~/.ssh/id_rsa.pub`登录`root`和`test`用户，也可以通过用户名`test`、密码`test`登录`test`用户
+    - root密码为[dev/.env.dev](%REPO_FILE_URL%/dev/.env.dev)中的`JOB_TABLE_PASSWORD`，为`jobtablepassword`
 - 可以通过`389`端口连接的LDAP服务器，详情参考[LDAP文档](../deploy/config/auth/ldap.md#LDAP镜像)
 - 可以通过`3890`端口访问的[phpLDAPadmin](https://phpldapadmin.sourceforge.net/wiki/index.php/Main_Page)，可以用于登录`389`端口的LDAP服务器
+    - **Dev Container**：由于这个容器修改监听端口比较复杂，且开发环境并不会直接和这个容器交互，故这个容器映射到的宿主机的3890端口。
+- 可以通过`22222`端口连接的SSH服务器
+    - 具有两个用户：root用户`root`（密码`root`）和普通用户`test`（密码`test`）
+    - **本地开发**：可以直接使用本地的`~/.ssh/id_rsa.pub`登录`root`和`test`用户
+    - **Dev Container**：见下文
+
+### Dev Container环境
+
+Dev Container在启动时同时会启动测试开发环境，且测试开发环境的故启动后您不再需要手动启动开发环境。且这些服务均启动于开发容器的网络中，可以直接使用`localhost`连接到这些服务。
+
+SSH服务器注意：由于SSH服务器容器和开发环境所在容器为并列关系，SSH服务器不能直接使用开发容器所在的文件，故您需要在启动Dev Container后手动生成SSH密钥并配置公钥登录：
+
+```bash
+# 在Dev Container中执行
+
+# 生成RSA类型SSH公钥
+ssh-keygen -t rsa -N '' -f ~/.ssh/id_rsa
+
+# 给root和test用户配置公钥登录
+
+# 运行后输入root密码root
+ssh-copy-id -p22222 root@localhost
+
+# 运行后输入test密码test
+ssh-copy-id -p22222 test@localhost
+```
+
+### 本地开发
 
 ```bash
 # 构建并启动开发环境

--- a/libs/ssh/tests/utils.ts
+++ b/libs/ssh/tests/utils.ts
@@ -22,7 +22,7 @@ import { SFTPWrapper } from "ssh2";
 export const target = "localhost:22222";
 export const rootUserId = "root";
 export const testUserId = "test";
-export const testUserPassword = "1234";
+export const testUserPassword = "test";
 
 export interface TestSshServer {
   ssh: NodeSSH;


### PR DESCRIPTION
此PR支持了Dev Container中运行测试开发环境。在启动开发环境时同时测试开发环境，并将开发环境中的容器启动到开发环境所在的容器的网络栈下，以支持在开发环境中使用localhost连接到测试开发服务。

![image](https://user-images.githubusercontent.com/8363856/222901696-4cd21146-af58-453c-ad20-90c70fbd1764.png)

注意：
1. 本PR修改了`ssh-server`的镜像。如果已经在本地构建好了开发环境并启动过测试开发环境，想迁移到dev container，为了保证运行开发环境时`ssh-server`的镜像为最新，请先手动运行`docker compose -f dev/docker-compose.dev.yml build ssh-server`更新`ssh-server`服务的镜像。具体修改有：
    - `ssh-server`镜像的root用户密码修改为`root`，test用户密码修改为`test`
    - `ssh-server`在启动时支持不存在`/id_rsa.pub`文件的情况，以支持在dev container中启动的情况
2. 如果之前启动过dev container，本次更新后需要重新构建dev container所在容器。
3. dev container需要一些配置才能完整运行测试开发环境。请查看文档https://pkuhpc.github.io/SCOW/docs/contribution/dev部分以配置。