### PR TITLE
fix(portal): 修复在测试开发环境下文件系统的默认路径不为用户目录

### DIFF
--- a/apps/portal-web/src/apis/api.mock.ts
+++ b/apps/portal-web/src/apis/api.mock.ts
@@ -84,7 +84,7 @@ export const mockApi: MockApi<typeof api> = {
   createFile: null,
   deleteDir: null,
   deleteFile: null,
-  getHomeDirectory: async () => ({ path: "/home/ddadaal" }),
+  getHomeDirectory: null,
   mkdir: null,
   moveFileItem: null,
 


### PR DESCRIPTION
原问题：在测试开发环境下，打开文件管理系统，默认的路径总是为/home/ddadaal。
原因：调用了mock中的getHomeDirectory的api，该api返回为写死的。
修复：将mock中的getHomeDirectory的api的返回改为null，此时调用getHomeDirectory将调用portal-server端的api，返回适应用户身份的默认路径。