### PR TITLE
feat: 从镜像中去除next.js的CI Build Cache

### DIFF
--- a/.changeset/moody-cameras-crash.md
+++ b/.changeset/moody-cameras-crash.md
@@ -1,0 +1,6 @@
+---
+"@scow/mis-web": patch
+"@scow/portal-web": patch
+---
+
+从最终镜像中去除 next.js build cache，减小镜像大小

--- a/docker/Dockerfile.scow
+++ b/docker/Dockerfile.scow
@@ -33,7 +33,13 @@ RUN node scripts/createVersionFile.mjs version.json
 RUN pnpm build --filter="!docs"
 
 RUN node scripts/copyDist.mjs
-RUN cd ./dist && pnpm i --offline --prod --frozen-lockfile
+
+WORKDIR /app/dist
+
+RUN pnpm i --offline --prod --frozen-lockfile
+
+# delete next.js build caches to reduce 200MB+ image size
+RUN rm -rf apps/mis-web/.next/cache apps/portal-web/.next/cache 
 
 FROM base AS runner
 


### PR DESCRIPTION
Next.js有个功能是在构建时保存构建缓存：https://nextjs.org/docs/advanced-features/ci-build-caching。 但是我们用不上这个功能，却白白占据200M+的缓存内容。

这个PR从最终镜像中去除了这些缓存内容，把容器大小从980M减少到了700M左右。

![image](https://user-images.githubusercontent.com/8363856/223117754-3d78fa5a-350c-44ab-bb45-aa84cb610900.png)
