### PR TITLE
feat(auth): LDAP添加用户和组时，支持删除预添加的属性

### DIFF
--- a/.changeset/five-donkeys-repair.md
+++ b/.changeset/five-donkeys-repair.md
@@ -1,0 +1,6 @@
+---
+"@scow/auth": minor
+"@scow/docs": minor
+---
+
+认证系统新建用户和组时支持删除预添加的属性

--- a/apps/auth/src/auth/ldap/createUser.ts
+++ b/apps/auth/src/auth/ldap/createUser.ts
@@ -25,11 +25,13 @@ import { promisify } from "util";
  * @param extraProps the extraProps config
  * @param placeholderObj the object where the values of placeholders ({{ }}) are from
  */
-const applyExtraProps = (obj: object, extraProps: Record<string, string | string[]>, placeholderObj: object) => {
+const applyExtraProps = (obj: object, extraProps: Record<string, string | string[] | null>, placeholderObj: object) => {
 
   for (const key in extraProps) {
     const value = extraProps[key];
-    if (Array.isArray(value)) {
+    if (value === null) {
+      delete obj[key];
+    } else if (Array.isArray(value)) {
       obj[key] = value.map((x) => parsePlaceholder(x, placeholderObj));
     } else {
       obj[key] = parsePlaceholder(value, placeholderObj);

--- a/apps/auth/src/config/auth.ts
+++ b/apps/auth/src/config/auth.ts
@@ -55,9 +55,16 @@ export const LdapConfigSchema = Type.Object({
       新的组节点的DN为{groupIdDnKey}={用户ID},{groupBase}
       如果不填写，则使用ldap.attrs.uid的值
       ` })),
-      extraProps: Type.Optional(Type.Record(Type.String(), Type.Union([Type.String(), Type.Array(Type.String())], {
-        description: "组的节点应该额外拥有的属性值。可以使用 {{ 用户节点的属性key }}来使用用户节点的属性值",
-      }))),
+      extraProps: Type.Optional(Type.Record(
+        Type.String(), 
+        Type.Union([Type.Null(), Type.String(), Type.Array(Type.String())],
+          {
+            description: `
+          组的节点应该额外拥有的属性值。
+          值可以为字符串、字符串列表或者null。如果为null，则不会添加此值。
+          符串可以使用 {{ 用户节点的属性key }}来使用用户节点的属性值
+        `,
+          }))),
     }, { description: "如果groupStrategy采用newGroupPerUser，填写新的组节点的配置信息" })),
 
     oneGroupForAllUsers: Type.Optional(Type.Object({
@@ -78,9 +85,11 @@ export const LdapConfigSchema = Type.Object({
     extraProps: Type.Optional(
       Type.Record(
         Type.String(),
-        Type.Union([Type.String(), Type.Array(Type.String())]),
+        Type.Union([Type.Null(), Type.String(), Type.Array(Type.String())]),
         { description: `
-          LDAP增加用户时，用户项除了id、name和mail，还应该添加哪些属性
+          LDAP增加用户时，用户项除了id、name和mail，还应该添加哪些属性。
+          属性值可以为字符串、字符串列表或者null。
+          如果属性值为null，那么将不会添加这个属性。如果值为null的属性名为默认添加的值，则那个默认添加的值也不会被添加。
           如果这里出现了uid, name或email同名的属性，这里的值将替代用户输入的值。
           属性值支持使用 {{ 用户节点的属性key }} 格式来使用已有用户节点的属性值
           例如：{ sn: "{{ cn }}" }，那么添加时将会增加一个sn属性，其值为cn的属性，即为用户输入的姓名

--- a/docs/docs/deploy/config/auth/ldap.md
+++ b/docs/docs/deploy/config/auth/ldap.md
@@ -50,21 +50,21 @@ LDAP认证系统支持的功能如下表：
 
 表中`??`表示如果前面的配置值设置了，就采用前面的值，如果没有设置，则采用后面的值。
 
-| 属性名                               | 值                                                                            |
-| ------------------------------------ | ----------------------------------------------------------------------------- |
-| DN                                   | `{ldap.addUser.userIdDnKey ?? ldap.attrs.uid}=用户名,{ldap.addUser.userBase}` |
-| `ldap.attrs.uid`                     | 用户名                                                                        |
-| sn                                   | 用户名                                                                        |
-| loginShell                           | /bin/bash                                                                     |
-| objectClass                          | ["inetOrgPerson", "posixAccount", "shadowAccount"]                            |
-| homeDirectory                        | `ldap.addUser.homeDir`，其中的`{{ username }}`替换为用户名                    |
-| uidNumber                            | 数据库中的用户项的id + `ldap.addUser.uidStart`                                |
-| gidNumber                            | 取决于`ldap.groupStrategy`，见下文                                            |
-| `ldap.attrs.name`（如果设置了）      | 用户姓名                                                                      |
-| `ldap.attrs.mail`（如果设置了）      | 用户的邮箱                                                                    |
-| `ldap.addUser.extraProps`中的每个key | key对应的值，其中`{{ key }}`替换为`key`本节点的对应的属性的值                 |
+| 属性名                               | 值                                                                                                                                          |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| DN                                   | `{ldap.addUser.userIdDnKey ?? ldap.attrs.uid}=用户名,{ldap.addUser.userBase}`                                                               |
+| `ldap.attrs.uid`                     | 用户名                                                                                                                                      |
+| sn                                   | 用户名                                                                                                                                      |
+| loginShell                           | /bin/bash                                                                                                                                   |
+| objectClass                          | ["inetOrgPerson", "posixAccount", "shadowAccount"]                                                                                          |
+| homeDirectory                        | `ldap.addUser.homeDir`，其中的`{{ username }}`替换为用户名                                                                                  |
+| uidNumber                            | 数据库中的用户项的id + `ldap.addUser.uidStart`                                                                                              |
+| gidNumber                            | 取决于`ldap.groupStrategy`，见下文                                                                                                          |
+| `ldap.attrs.name`（如果设置了）      | 用户姓名                                                                                                                                    |
+| `ldap.attrs.mail`（如果设置了）      | 用户的邮箱                                                                                                                                  |
+| `ldap.addUser.extraProps`中的每个key | key对应的值，对应的值可以为字符串、字符串列表或者`null`。字符串或者字符串列表中的每一项其中的`{{ key }}`替换为`key`本节点的对应的属性的值。 |
 
-如果`ldap.addUser.extraProps`中包括已经存在的key，则会替换对应的属性。
+如果`ldap.addUser.extraProps`中包括已经存在的属性名，则会替换对应的属性。如果这里面某个值为`null`，则会删除对应的属性。
 
 3. 配置新用户所属的组。
 
@@ -72,15 +72,15 @@ LDAP认证系统支持的功能如下表：
 
 如果`ldap.addUser.groupStrategy`设置为`newGroupPerUser`，则新用户的`gidNumber`的值等于用户的uidNumber，并且会创建一个新的LDAP节点作为新用户的group，其DN以及属性值如下表所示。
 
-| 属性名                                               | 值                                                                                                         |
-| ---------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| DN                                                   | `{ldap.newGroupPerUser.groupIdDnKey ?? ldap.attrs.userId}=用户名,{ldap.addUser.newGroupPerUser.groupBase}` |
-| objectClass                                          | ["posixGroup"]                                                                                             |
-| memberUid                                            | 用户名                                                                                                     |
-| gidNumber                                            | 同用户的uidNumber                                                                                          |
-| `ldap.addUser.newGroupPerUser.extraProps`中的每个key | key对应的值，其中`{{ key }}`替换为本节点的`key`对应的属性的值                                              |
+| 属性名                                               | 值                                                                                                                                          |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| DN                                                   | `{ldap.newGroupPerUser.groupIdDnKey ?? ldap.attrs.userId}=用户名,{ldap.addUser.newGroupPerUser.groupBase}`                                  |
+| objectClass                                          | ["posixGroup"]                                                                                                                              |
+| memberUid                                            | 用户名                                                                                                                                      |
+| gidNumber                                            | 同用户的uidNumber                                                                                                                           |
+| `ldap.addUser.newGroupPerUser.extraProps`中的每个key | key对应的值，对应的值可以为字符串、字符串列表或者`null`。字符串或者字符串列表中的每一项其中的`{{ key }}`替换为`key`本节点的对应的属性的值。 |
 
-如果`ldap.addUser.newGroupPerUser.extraProps`中包括已经存在的key，则会替换对应的属性。
+如果`ldap.addUser.newGroupPerUser.extraProps`中包括已经存在的属性名，则会替换对应的属性。如果这里面某个值为`null`，则会删除对应的属性。
 
 4. 设置新用户的密码为用户输入的密码
 


### PR DESCRIPTION
在使用LDAP认证系统时，当添加用户时，系统将在新的用户和组节点中预添加进一些属性。

https://pkuhpc.github.io/SCOW/docs/deploy/config/auth/ldap#%E5%88%9B%E5%BB%BA%E7%94%A8%E6%88%B7

但是当用户修改了节点的objectClass时，有的属性可能不允许存在。

这个PR支持通过extraProps，把属性设置为null，来从节点中删除某个特殊的属性值。

这个PR未添加测试，因为对于测试用的LDAP来说，目前预添加的属性均是必要的，不能删除。