### PR TITLE
fix(mis): 修复slurm中AllowAccounts=ALL情况下封锁账号失败的情况

### DIFF
--- a/.changeset/slow-llamas-rest.md
+++ b/.changeset/slow-llamas-rest.md
@@ -1,0 +1,5 @@
+---
+"@scow/mis-server": patch
+---
+
+修复 slurm 中 AllowAccounts=ALL 情况下封锁账号失败的情况


### PR DESCRIPTION
修改了slurm.sh 文件，解决AllowAccounts=ALL情况下的封锁账号失败情况，以及AllowAccounts=ALL情况下查询账号是否被封锁的问题