### PR TITLE
feat(portal): 增加文件上传限制可配置功能

### DIFF
--- a/.changeset/many-humans-work.md
+++ b/.changeset/many-humans-work.md
@@ -1,8 +1,8 @@
 ---
-"@scow/portal-web": patch
-"@scow/demo-vagrant": patch
-"@scow/gateway": patch
-"@scow/deploy-compose": patch
+"@scow/portal-web": minor
+"@scow/demo-vagrant": minor
+"@scow/gateway": minor
+"@scow/deploy-compose": minor
 ---
 
 上传文件、请求最大体积限制可配置

--- a/.changeset/many-humans-work.md
+++ b/.changeset/many-humans-work.md
@@ -1,0 +1,8 @@
+---
+"@scow/portal-web": patch
+"@scow/demo-vagrant": patch
+"@scow/gateway": patch
+"@scow/deploy-compose": patch
+---
+
+上传文件、请求最大体积限制可配置

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ out
 dist
 version.json
 .pnpm-store
+.DS_Store

--- a/apps/gateway/src/env.ts
+++ b/apps/gateway/src/env.ts
@@ -14,7 +14,7 @@ import { envConfig, str } from "@scow/lib-config";
 
 export const config = envConfig({
   RESOLVER: str({ desc: "DNS地址", default: "127.0.0.11" }),
-  CLIENT_MAX_BODY_SIZE: str({ desc: "请求文件大小限制", default: "1g" }),
+  // CLIENT_MAX_BODY_SIZE: str({ desc: "请求文件大小限制", default: "1g" }),
 
   BASE_PATH: str({ desc: "base path", default: "" }),
 

--- a/apps/gateway/src/env.ts
+++ b/apps/gateway/src/env.ts
@@ -14,7 +14,6 @@ import { envConfig, str } from "@scow/lib-config";
 
 export const config = envConfig({
   RESOLVER: str({ desc: "DNS地址", default: "127.0.0.11" }),
-  // CLIENT_MAX_BODY_SIZE: str({ desc: "请求文件大小限制", default: "1g" }),
 
   BASE_PATH: str({ desc: "base path", default: "" }),
 

--- a/apps/gateway/src/env.ts
+++ b/apps/gateway/src/env.ts
@@ -15,6 +15,8 @@ import { envConfig, str } from "@scow/lib-config";
 export const config = envConfig({
   RESOLVER: str({ desc: "DNS地址", default: "127.0.0.11" }),
 
+  CLIENT_MAX_BODY_SIZE: str({ desc: "请求文件大小限制", default: "1G" }),
+
   BASE_PATH: str({ desc: "base path", default: "" }),
 
   PORTAL_PATH: str({ desc: "门户系统路径", default: "/" }),

--- a/apps/portal-web/config.js
+++ b/apps/portal-web/config.js
@@ -50,6 +50,8 @@ const specs = {
   MIS_URL: str({ desc: "如果部署了管理系统，管理系统的URL。如果和本系统域名相同，可以只写完整的路径。将会覆盖配置文件。空字符串等价于未部署管理系统", default: "" }),
 
   NOVNC_CLIENT_URL: str({ desc: "novnc客户端的URL。如果和本系统域名相同，可以只写完整路径", default: "/vnc" }),
+
+  CLIENT_MAX_BODY_SIZE: str({ desc: "限制整个系统上传（请求）文件的大小，可接受的格式为nginx的client_max_body_size可接受的值", default: "1g" }),
 };
 
 const mockEnv = process.env.NEXT_PUBLIC_USE_MOCK === "1";
@@ -143,6 +145,8 @@ const buildRuntimeConfig = async (phase, basePath) => {
     PASSWORD_PATTERN_MESSAGE: commonConfig.passwordPattern?.errorMessage,
 
     BASE_PATH: basePath,
+
+    CLIENT_MAX_BODY_SIZE: config.CLIENT_MAX_BODY_SIZE,
   }
 
   if (!building && !testenv) {

--- a/apps/portal-web/config.js
+++ b/apps/portal-web/config.js
@@ -51,7 +51,7 @@ const specs = {
 
   NOVNC_CLIENT_URL: str({ desc: "novnc客户端的URL。如果和本系统域名相同，可以只写完整路径", default: "/vnc" }),
 
-  CLIENT_MAX_BODY_SIZE: str({ desc: "限制整个系统上传（请求）文件的大小，可接受的格式为nginx的client_max_body_size可接受的值", default: "1g" }),
+  CLIENT_MAX_BODY_SIZE: str({ desc: "限制整个系统上传（请求）文件的大小，可接受的格式为nginx的client_max_body_size可接受的值", default: "1G" }),
 };
 
 const mockEnv = process.env.NEXT_PUBLIC_USE_MOCK === "1";

--- a/apps/portal-web/src/pageComponents/filemanager/UploadModal.tsx
+++ b/apps/portal-web/src/pageComponents/filemanager/UploadModal.tsx
@@ -46,7 +46,7 @@ export const UploadModal: React.FC<Props> = ({ open, onClose, path, reload, clus
         文件将会上传到：<strong>{path}</strong>。同名文件将会被覆盖。
       </p>
       <p>
-        单个上传文件体积最大为：<strong>{publicConfig.CLIENT_MAX_BODY_SIZE}</strong>。
+        单个上传文件大小最大为：<strong>{publicConfig.CLIENT_MAX_BODY_SIZE}</strong>。
       </p>
       <Upload.Dragger
         name="file"

--- a/apps/portal-web/src/pageComponents/filemanager/UploadModal.tsx
+++ b/apps/portal-web/src/pageComponents/filemanager/UploadModal.tsx
@@ -15,6 +15,7 @@ import { App, Button, Modal, Upload } from "antd";
 import { join } from "path";
 import { api } from "src/apis";
 import { urlToUpload } from "src/pageComponents/filemanager/api";
+import { publicConfig } from "src/utils/config";
 
 interface Props {
   open: boolean;
@@ -43,6 +44,9 @@ export const UploadModal: React.FC<Props> = ({ open, onClose, path, reload, clus
     >
       <p>
         文件将会上传到：<strong>{path}</strong>。同名文件将会被覆盖。
+      </p>
+      <p>
+        单个上传文件体积最大为：<strong>{publicConfig.CLIENT_MAX_BODY_SIZE}</strong>。
       </p>
       <Upload.Dragger
         name="file"

--- a/apps/portal-web/src/utils/config.ts
+++ b/apps/portal-web/src/utils/config.ts
@@ -71,7 +71,8 @@ export interface PublicRuntimeConfig {
   PASSWORD_PATTERN_MESSAGE: string | undefined;
 
   BASE_PATH: string;
-
+  // 上传（请求）文件的大小限制
+  CLIENT_MAX_BODY_SIZE: string;
 }
 
 export const runtimeConfig: ServerRuntimeConfig = getConfig().serverRuntimeConfig;

--- a/deploy/local/config-example.py
+++ b/deploy/local/config-example.py
@@ -27,9 +27,9 @@ COMMON = {
 # ------- 网关配置 -------
 #
 # GATEWAY.UPLOAD_FILE_SIZE_LIMIT：限制整个系统上传（请求）文件的大小，可接受的格式为nginx的client_max_body_size可接受的值，默认为1G
-GATEWAY = {
-  "UPLOAD_FILE_SIZE_LIMIT": "1G",
-}
+# GATEWAY = {
+#   "UPLOAD_FILE_SIZE_LIMIT": "1G",
+# }
 
 # ------- 日志配置 -------
 #

--- a/deploy/local/config-example.py
+++ b/deploy/local/config-example.py
@@ -14,16 +14,21 @@
 #
 # COMMON.PORT: 整个系统的入口端口
 # COMMON.BASE_PATH: 整个系统的部署根路径。以/开头，不要以/结尾，如果是根路径写"/"
-# COMMON.UPLOAD_FILE_SIZE_LIMIT：限制整个系统上传（请求）文件的大小，可接受的格式为nginx的client_max_body_size可接受的值，默认为1G
 # COMMON.IMAGE: 镜像地址，据实际情况填写
 # COMMON.IMAGE_TAG: 镜像tag，据实际情况填写
 # 如果您的镜像是本地构建的，IMAGE和IMAGE_TAG必须和构建时的镜像名和tag保持一致。
 COMMON = {
   "PORT": 80,
   "BASE_PATH": "/",
-  "UPLOAD_FILE_SIZE_LIMIT": "1G",
   "IMAGE": "ghcr.io/pkuhpc/scow/scow",
   "IMAGE_TAG": "master",
+}
+
+# ------- 网关配置 -------
+#
+# GATEWAY.UPLOAD_FILE_SIZE_LIMIT：限制整个系统上传（请求）文件的大小，可接受的格式为nginx的client_max_body_size可接受的值，默认为1G
+GATEWAY = {
+  "UPLOAD_FILE_SIZE_LIMIT": "1G",
 }
 
 # ------- 日志配置 -------

--- a/deploy/local/config-example.py
+++ b/deploy/local/config-example.py
@@ -14,12 +14,14 @@
 #
 # COMMON.PORT: 整个系统的入口端口
 # COMMON.BASE_PATH: 整个系统的部署根路径。以/开头，不要以/结尾，如果是根路径写"/"
+# COMMON.UPLOAD_FILE_SIZE_LIMIT：限制整个系统上传（请求）文件的大小，可接受的格式为nginx的client_max_body_size可接受的值，默认为1G
 # COMMON.IMAGE: 镜像地址，据实际情况填写
 # COMMON.IMAGE_TAG: 镜像tag，据实际情况填写
 # 如果您的镜像是本地构建的，IMAGE和IMAGE_TAG必须和构建时的镜像名和tag保持一致。
 COMMON = {
   "PORT": 80,
   "BASE_PATH": "/",
+  "UPLOAD_FILE_SIZE_LIMIT": "1G",
   "IMAGE": "ghcr.io/pkuhpc/scow/scow",
   "IMAGE_TAG": "master",
 }

--- a/deploy/local/generate.py
+++ b/deploy/local/generate.py
@@ -55,7 +55,7 @@ LOG_LEVEL = get_cfg(["LOG", "LEVEL"], "info")
 LOG_PRETTY = json.dumps(get_cfg(["LOG", "PRETTY"], False))
 
 # 设置上传（请求）文件大小限制
-CLIENT_MAX_BODY_SIZE = get_cfg(["COMMON", "UPLOAD_FILE_SIZE_LIMIT"], "1G")
+CLIENT_MAX_BODY_SIZE = get_cfg(["GATEWAY", "UPLOAD_FILE_SIZE_LIMIT"], "1G")
 
 # easy migration from IMAGE_BASE to IMAGE
 SCOW_IMAGE = get_cfg(["COMMON", "IMAGE"])

--- a/deploy/local/generate.py
+++ b/deploy/local/generate.py
@@ -54,6 +54,9 @@ check_path_format("MIS.BASE_PATH", MIS_PATH)
 LOG_LEVEL = get_cfg(["LOG", "LEVEL"], "info")
 LOG_PRETTY = json.dumps(get_cfg(["LOG", "PRETTY"], False))
 
+# 设置上传（请求）文件大小限制
+CLIENT_MAX_BODY_SIZE = get_cfg(["COMMON", "UPLOAD_FILE_SIZE_LIMIT"], "1G")
+
 # easy migration from IMAGE_BASE to IMAGE
 SCOW_IMAGE = get_cfg(["COMMON", "IMAGE"])
 if not SCOW_IMAGE:
@@ -186,6 +189,7 @@ def create_gateway_service():
         "BASE_PATH": "" if BASE_PATH == "/" else BASE_PATH,
         "PORTAL_PATH": PORTAL_PATH,
         "MIS_PATH": MIS_PATH,
+        "CLIENT_MAX_BODY_SIZE": CLIENT_MAX_BODY_SIZE,
     }
 
     gateway = Service("gateway", SCOW_IMAGE_NAME, gw_ports, {
@@ -261,6 +265,7 @@ def create_portal_web_service():
         "MIS_DEPLOYED": "false" if cfg.MIS == False else "true",
         "AUTH_EXTERNAL_URL": path_join(BASE_PATH, "/auth"),
         "NOVNC_CLIENT_URL": path_join(BASE_PATH, "/vnc"),
+        "CLIENT_MAX_BODY_SIZE": CLIENT_MAX_BODY_SIZE,
     }
     pw_volumes = {
         "/etc/hosts": "/etc/hosts",

--- a/deploy/vagrant/scow/scow-deployment/config.py
+++ b/deploy/vagrant/scow/scow-deployment/config.py
@@ -4,12 +4,14 @@
 #
 # COMMON.PORT: 整个系统的入口端口
 # COMMON.BASE_PATH: 整个系统的部署根路径。以/开头，不要以/结尾，如果是根路径写"/"
+# COMMON.UPLOAD_FILE_SIZE_LIMIT：限制整个系统上传（请求）文件的大小，可接受的格式为nginx的client_max_body_size可接受的值，默认为1G
 # COMMON.IMAGE: 镜像仓库地址，据实际情况填写
 # COMMON.IMAGE_TAG: 镜像tag，据实际情况填写
 # 如果您的镜像是本地构建的，IMAGE_BASE和IMAGE_TAG必须和构建时.env.build中的值保持一致。
 COMMON = {
   "PORT": 80,
   "BASE_PATH": "/",
+  "UPLOAD_FILE_SIZE_LIMIT": "1G",
   # "IMAGE": "mirrors.pku.edu.cn/pkuhpc/scow/scow",
   "IMAGE": "ghcr.io/pkuhpc/scow/scow",
   "IMAGE_TAG": "master",

--- a/deploy/vagrant/scow/scow-deployment/config.py
+++ b/deploy/vagrant/scow/scow-deployment/config.py
@@ -19,9 +19,9 @@ COMMON = {
 # ------- 网关配置 -------
 #
 # GATEWAY.UPLOAD_FILE_SIZE_LIMIT：限制整个系统上传（请求）文件的大小，可接受的格式为nginx的client_max_body_size可接受的值，默认为1G
-GATEWAY = {
-  "UPLOAD_FILE_SIZE_LIMIT": "1G",
-}
+# GATEWAY = {
+#   "UPLOAD_FILE_SIZE_LIMIT": "1G",
+# }
 
 #
 # ------- 门户系统 -------

--- a/deploy/vagrant/scow/scow-deployment/config.py
+++ b/deploy/vagrant/scow/scow-deployment/config.py
@@ -4,17 +4,23 @@
 #
 # COMMON.PORT: 整个系统的入口端口
 # COMMON.BASE_PATH: 整个系统的部署根路径。以/开头，不要以/结尾，如果是根路径写"/"
-# COMMON.UPLOAD_FILE_SIZE_LIMIT：限制整个系统上传（请求）文件的大小，可接受的格式为nginx的client_max_body_size可接受的值，默认为1G
 # COMMON.IMAGE: 镜像仓库地址，据实际情况填写
 # COMMON.IMAGE_TAG: 镜像tag，据实际情况填写
 # 如果您的镜像是本地构建的，IMAGE_BASE和IMAGE_TAG必须和构建时.env.build中的值保持一致。
 COMMON = {
   "PORT": 80,
   "BASE_PATH": "/",
-  "UPLOAD_FILE_SIZE_LIMIT": "1G",
   # "IMAGE": "mirrors.pku.edu.cn/pkuhpc/scow/scow",
   "IMAGE": "ghcr.io/pkuhpc/scow/scow",
   "IMAGE_TAG": "master",
+}
+
+
+# ------- 网关配置 -------
+#
+# GATEWAY.UPLOAD_FILE_SIZE_LIMIT：限制整个系统上传（请求）文件的大小，可接受的格式为nginx的client_max_body_size可接受的值，默认为1G
+GATEWAY = {
+  "UPLOAD_FILE_SIZE_LIMIT": "1G",
 }
 
 #

--- a/docs/docs/refs/env/gateway.md
+++ b/docs/docs/refs/env/gateway.md
@@ -9,7 +9,7 @@ title: "gateway"
 
 | 名字 | 类型 | 描述 | 默认值 |
 | -- | -- | -- | -- |
-|`CLIENT_MAX_BODY_SIZE`|字符串|请求body最大大小，nginx的client_max_body_size配置|1g|
+|`CLIENT_MAX_BODY_SIZE`|字符串|请求body最大大小，nginx的client_max_body_size配置，从配置项UPLOAD_FILE_SIZE_LIMIT获取|1G|
 |`ACCESS_LOG`|字符串|nginx的access_log配置|/var/log/nginx/access.log|
 |`ERROR_LOG`|字符串|nginx的error_log配置|/var/log/nginx/error.log|
 |`EXTRA`|字符串|更多的配置，将会应用到server块里||


### PR DESCRIPTION
用户部署配置：
修改scow-deployment/config.py文件中的网关配置，取消对GATEWAY 的注释，修改UPLOAD_FILE_SIZE_LIMIT的值，如将默认的1G改为50M：
```py
# ------- 网关配置 -------
#
# GATEWAY.UPLOAD_FILE_SIZE_LIMIT：限制整个系统上传（请求）文件的大小，可接受的格式为nginx的client_max_body_size可接受的值，默认为1G
# GATEWAY = {
#   "UPLOAD_FILE_SIZE_LIMIT": "1G",
# }

# ------- 网关配置 -------
#
# GATEWAY.UPLOAD_FILE_SIZE_LIMIT：限制整个系统上传（请求）文件的大小，可接受的格式为nginx的client_max_body_size可接受的值，默认为1G
GATEWAY = {
   "UPLOAD_FILE_SIZE_LIMIT": "50M",
 }
```




PR合并前测试步骤，用户部署无需关注：
1、与正常流程一样拉取镜像
2、修改scow-deployment 下的config.py文件，参照用户部署配置，可将UPLOAD_FILE_SIZE_LIMIT的值改为其它值，例如5M。
3、PR未被合并前，还需要修改scow-deployment 下的generate.py，增加了对UPLOAD_FILE_SIZE_LIMIT的配置，具体参考此PR对deploy/local/generate.py文件的修改，复制即可。
4、进入文件管理，点击文件上传，展示了文件上传的最大限制。尝试上传1个10M的文件，失败

![image](https://user-images.githubusercontent.com/25954437/227121002-df50b29a-c65c-48cb-89ff-138a9c6b899a.png)

