### PR TITLE
feat(mis): 导入用户模块删除租户选择框，只支持导入到默认租户中

### DIFF
--- a/.changeset/young-coats-hunt.md
+++ b/.changeset/young-coats-hunt.md
@@ -1,0 +1,7 @@
+---
+"@scow/mis-server": minor
+"@scow/mis-web": minor
+"@scow/grpc-api": minor
+---
+
+导入用户功能只支持导入默认租户

--- a/apps/mis-server/src/services/admin.ts
+++ b/apps/mis-server/src/services/admin.ts
@@ -79,7 +79,7 @@ export const adminServiceServer = plugin((server) => {
     },
 
     importUsers: async ({ request, em, logger }) => {
-      const { data, tenantName, whitelist } = request;
+      const { data, whitelist } = request;
 
       if (!data) {
         throw <ServiceError> {
@@ -102,7 +102,7 @@ export const adminServiceServer = plugin((server) => {
         };
       }
 
-      const reply = await importUsers(data as ImportUsersData, em, whitelist, tenantName, logger);
+      const reply = await importUsers(data as ImportUsersData, em, whitelist, logger);
 
       return [reply];
 

--- a/apps/mis-server/tests/admin/importUsers.test.ts
+++ b/apps/mis-server/tests/admin/importUsers.test.ts
@@ -60,12 +60,12 @@ const data = {
 
 it("imports users and accounts", async () => {
   const em = orm.em.fork();
-  
+
   // user1 has existed
   const tenant = await em.findOneOrFail(Tenant, { name: "default" });
   await em.persistAndFlush(new User({ name: "user1Name", userId: "user1", email: "", tenant }));
 
-  await asyncClientCall(client, "importUsers", { data: data, tenantName: "default", whitelist: true });
+  await asyncClientCall(client, "importUsers", { data: data, whitelist: true });
 
   const accounts = await em.find(Account, {});
   expect(accounts.map((x) => x.accountName)).toIncludeSameMembers(data.accounts.map((x) => x.accountName));
@@ -98,9 +98,9 @@ it("import users and accounts if in different tenant", async () => {
   const tenant1 = await em.findOneOrFail(Tenant, { name: "tenant1" });
   await em.persistAndFlush(new User({ name: "user1Name", userId: "user1", email: "", tenant: tenant1 }));
 
-  await asyncClientCall(client, "importUsers", { data: data, tenantName: "default", whitelist: true })
-    .catch((e) => 
-    { console.log(e); 
+  await asyncClientCall(client, "importUsers", { data: data, whitelist: true })
+    .catch((e) =>
+    { console.log(e);
       expect(e.code).toBe(Status.INVALID_ARGUMENT); });
 
 });

--- a/apps/mis-web/src/pageComponents/admin/ImportUsersTable.tsx
+++ b/apps/mis-web/src/pageComponents/admin/ImportUsersTable.tsx
@@ -11,7 +11,7 @@
  */
 
 import { queryToString, useQuerystring } from "@scow/lib-web/build/utils/querystring";
-import { ClusterAccountInfo, GetClusterUsersResponse, 
+import { ClusterAccountInfo, GetClusterUsersResponse,
   ImportUsersData, UserInAccount } from "@scow/protos/build/server/admin";
 import { App, Button, Checkbox, Drawer, Form, Select, Space, Table, Tooltip } from "antd";
 import Router from "next/router";
@@ -24,7 +24,6 @@ import { FilterFormContainer } from "src/components/FilterFormContainer";
 import { DefaultClusterStore } from "src/stores/DefaultClusterStore";
 import { publicConfig } from "src/utils/config";
 
-import { TenantSelector } from "../tenant/TenantSelector";
 
 export const ImportUsersTable: React.FC = () => {
   const { message } = App.useApp();
@@ -38,7 +37,7 @@ export const ImportUsersTable: React.FC = () => {
     ? publicConfig.CLUSTERS[clusterParam]
     : defaultClusterStore.cluster);
 
-  const [form] = Form.useForm<{tenantName: string, data: GetClusterUsersResponse, whitelist: boolean}>();
+  const [form] = Form.useForm<{data: GetClusterUsersResponse, whitelist: boolean}>();
 
   const [loading, setLoading] = useState(false);
 
@@ -62,7 +61,7 @@ export const ImportUsersTable: React.FC = () => {
 
   return (
     <div>
-      
+
       <Form
         form={form}
         onFinish={async () => {
@@ -70,7 +69,7 @@ export const ImportUsersTable: React.FC = () => {
 
           setLoading(true);
 
-          const { data: changedData, tenantName, whitelist } = await form.validateFields();
+          const { data: changedData, whitelist } = await form.validateFields();
           const importData: ImportUsersData = { accounts: []};
 
           changedData?.accounts.forEach((x, i) => {
@@ -86,12 +85,11 @@ export const ImportUsersTable: React.FC = () => {
 
           await api.importUsers({ body: {
             data: importData,
-            tenantName,
             whitelist,
           } })
             .httpError(400, () => { message.error("数据格式不正确"); })
             .then(() => { message.success("导入成功"); })
-            .finally(() => { 
+            .finally(() => {
               setLoading(false);
               reload();
             });
@@ -99,30 +97,19 @@ export const ImportUsersTable: React.FC = () => {
       >
         <FilterFormContainer>
           <Space align="center">
-            选择集群：
+            选择集群，以账户为单位导入到默认租户中
             <SingleClusterSelector
               value={cluster}
               onChange={(value) => {
                 Router.push({ query: { cluster: value.id } });
               }}
             />
-          </Space>
-        </FilterFormContainer>
-        <FilterFormContainer>
-          <Space align="center">
-            导入账户及账户下的用户到SCOW平台的
-            <Form.Item name={"tenantName"}>
-              <TenantSelector placeholder="选择租户" autoSelect />
-            </Form.Item>
-            租户中
-            <Space size="large">
-              <Button type="primary" htmlType="submit" loading={loading}>
+            <Button type="primary" htmlType="submit" loading={loading}>
               导入
-              </Button>
-              <a onClick={reload}>
+            </Button>
+            <a onClick={reload}>
               刷新
-              </a>
-            </Space>
+            </a>
           </Space>
         </FilterFormContainer>
         <Table
@@ -154,8 +141,8 @@ export const ImportUsersTable: React.FC = () => {
           <Table.Column<ClusterAccountInfo>
             dataIndex="owner"
             title="拥有者"
-            render={(_, r, i) => 
-              r.included ? 
+            render={(_, r, i) =>
+              r.included ?
                 "该账户已导入" : selectedAccounts?.includes(r) ? (
                   <Form.Item name={["data", "accounts", i, "owner"]} rules={[{ required: true, message: "请选择一个拥有者" }]}>
                     <Select

--- a/apps/mis-web/src/pages/api/admin/importUsers.ts
+++ b/apps/mis-web/src/pages/api/admin/importUsers.ts
@@ -25,7 +25,6 @@ export interface ImportUsersSchema {
 
   body: {
     data: ImportUsersData;
-    tenantName: string;
     whitelist: boolean;
   }
 
@@ -46,12 +45,12 @@ export default route<ImportUsersSchema>("ImportUsersSchema",
       if (!info) { return; }
     }
 
-    const { data, tenantName, whitelist } = req.body;
+    const { data, whitelist } = req.body;
 
     const client = getClient(AdminServiceClient);
 
     return await asyncClientCall(client, "importUsers", {
-      data, tenantName, whitelist,
+      data, whitelist,
     })
       .then(() => ({ 204: null }))
       .catch(handlegRPCError({

--- a/protos/server/admin.proto
+++ b/protos/server/admin.proto
@@ -57,8 +57,7 @@ message ImportUsersData {
 
 message ImportUsersRequest {
   ImportUsersData data = 1;
-  string tenant_name = 2;
-  bool whitelist = 3;
+  bool whitelist = 2;
 }
 
 // INVAD_ARGUMENT: the data format is not acceptable


### PR DESCRIPTION


之前的版本中新增了选择租户导入的功能，现在删除这个功能，只能导入到默认租户default中
![image](https://user-images.githubusercontent.com/98016770/227097917-d395ee2f-0125-4b5e-a116-2664d0051196.png)

![image](https://user-images.githubusercontent.com/98016770/227097754-5e5e9b77-0a50-4771-bfd0-9358f256fa4f.png)
