### PR TITLE
fix(cli): 修复cli更新release版本

### DIFF
--- a/.changeset/weak-clouds-shop.md
+++ b/.changeset/weak-clouds-shop.md
@@ -1,0 +1,6 @@
+---
+"@scow/cli": patch
+"@scow/docs": patch
+---
+
+修复 cli 更新 release 版本

--- a/apps/cli/src/cmd/updateCli.ts
+++ b/apps/cli/src/cmd/updateCli.ts
@@ -166,7 +166,7 @@ Please provide your GitHub personal access token via GITHUB_TOKEN in env or .env
     if (!options.release) {
       log("Neither --pr, --release nor --branch is specified. Downloading latest release.");
       const resp = await octokit.rest.repos.getLatestRelease({ owner, repo });
-      log("Downloading release %s", resp.data.tag_name);
+      log("Latest release is %s.", resp.data.tag_name);
       return resp.data;
     } else {
       log("Downloading release %s", options.release);
@@ -175,7 +175,7 @@ Please provide your GitHub personal access token via GITHUB_TOKEN in env or .env
     }
   })();
 
-  const assetName = "scow-cli-" + arch;
+  const assetName = "cli-" + arch;
 
   const asset = release.assets.find((a) => a.name === assetName);
 

--- a/docs/docs/deploy/install/scow-cli.md
+++ b/docs/docs/deploy/install/scow-cli.md
@@ -83,7 +83,13 @@ scow-cli使用运行目录下的`install.yaml`作为配置来管理集群，但�
 # 更新到test分支的最新cli版本
 ./cli update --branch test
 
-# 更新至v0.4.0版本的scow-cli
+# 更新至最新版本的scow-cli
+./cli update
+
+# 更新cli至v0.4.0版本
+./cli update --release v0.4.0
+
+# 下载v0.4.0版本的scow-cli并保存到./cli-test
 ./cli update --release v0.4.0 -o ./cli-test
 ```
 


### PR DESCRIPTION
之前CLI的`update --release`无法使用，因为asset name不正确。这个PR修复了这个问题。