### PR TITLE
fix(cli): 当配置了fluentd日志时，在生成compose文件或者运行compose命令时，首先创建fluentd的日志目录

### DIFF
--- a/.changeset/lazy-hotels-buy.md
+++ b/.changeset/lazy-hotels-buy.md
@@ -1,0 +1,5 @@
+---
+"@scow/cli": patch
+---
+
+当配置了 fluentd 日志，在执行 compose 命令或者生成 compose 配置时创建 log 目录并修改权限

--- a/apps/cli/src/cmd/init.ts
+++ b/apps/cli/src/cmd/init.ts
@@ -17,7 +17,6 @@ import { debug, log } from "src/log";
 
 
 interface Options {
-  configPath: string;
   outputPath: string;
 }
 

--- a/apps/cli/src/compose/cmd.ts
+++ b/apps/cli/src/compose/cmd.ts
@@ -43,7 +43,6 @@ export function runComposeCommand(config: InstallConfigSchema, args: string[]) {
 
   const composeConfig = createComposeSpec(config);
 
-
   const filename = `docker-compose-${Date.now()}.yml`;
 
   writeFileSync(filename, dump(composeConfig), { encoding: "utf-8" });

--- a/apps/cli/src/compose/index.ts
+++ b/apps/cli/src/compose/index.ts
@@ -10,6 +10,7 @@
  * See the Mulan PSL v2 for more details.
  */
 
+import { chmodSync, mkdirSync } from "fs";
 import path from "path";
 import { LoggingOption, ServiceSpec } from "src/compose/spec";
 import { InstallConfigSchema } from "src/config/install";
@@ -90,6 +91,11 @@ export const createComposeSpec = (config: InstallConfigSchema) => {
 
   // fluentd
   if (config.log.fluentd) {
+    // create log dir
+    mkdirSync(config.log.fluentd.logDir, { recursive: true });
+    // TODO may give fewer permissions
+    chmodSync(config.log.fluentd.logDir, 0o777);
+
     addService("log", {
       image: config.log.fluentd.image,
       environment: {},

--- a/apps/cli/tests/compose.test.ts
+++ b/apps/cli/tests/compose.test.ts
@@ -10,15 +10,23 @@
  * See the Mulan PSL v2 for more details.
  */
 
-import { init } from "src/cmd/init";
-import { compareDirectories, testBaseFolder } from "tests/utils";
+import { statSync } from "fs";
+import { join } from "path";
+import { createComposeSpec } from "src/compose";
+import { getInstallConfig } from "src/config/install";
+import { configPath, testBaseFolder } from "tests/utils";
 
-it("extracts init config to output path", async () => {
-  await init({
-    outputPath: testBaseFolder,
-  });
+it("creates log dir for fluentd", async () => {
 
-  // testBaseFolder and configPath should be the same
-  expect(await compareDirectories(testBaseFolder, "assets")).toBe(true);
+  const config = getInstallConfig(configPath);
+
+  const logDir = join(testBaseFolder, "logdir");
+
+  config.log.fluentd = { logDir, image: "fluentd:v1.14.0-1.0" };
+
+  createComposeSpec(config);
+
+  const s = statSync(logDir);
+
+  expect(s.mode).toBe(0o40777);
 });
-

--- a/apps/cli/tests/global.d.ts
+++ b/apps/cli/tests/global.d.ts
@@ -10,15 +10,4 @@
  * See the Mulan PSL v2 for more details.
  */
 
-import { init } from "src/cmd/init";
-import { compareDirectories, testBaseFolder } from "tests/utils";
-
-it("extracts init config to output path", async () => {
-  await init({
-    outputPath: testBaseFolder,
-  });
-
-  // testBaseFolder and configPath should be the same
-  expect(await compareDirectories(testBaseFolder, "assets")).toBe(true);
-});
-
+import "jest-extended";

--- a/apps/cli/tests/utils.ts
+++ b/apps/cli/tests/utils.ts
@@ -13,8 +13,17 @@
 import { existsSync, promises as fsp } from "fs";
 import { join } from "path";
 
-export const configPath = "tests/init.test.ts";
+export const configPath = "tests/install.yaml";
 export const testBaseFolder = `tests/testFolder${process.env.JEST_WORKER_ID}`;
+
+beforeEach(async () => {
+  await fsp.mkdir(testBaseFolder, { recursive: true });
+
+});
+
+afterEach(async () => {
+  await fsp.rm(testBaseFolder, { recursive: true });
+});
 
 export async function compareDirectories(dir1: string, dir2: string): Promise<boolean> {
   const files1 = await fsp.readdir(dir1);


### PR DESCRIPTION
当配置了fluentd日志时，在生成compose文件或者运行compose命令时，首先创建fluentd的日志目录并修改权限到777。