### PR TITLE
fix(mis-web): 修复平台管理租户充值记录过滤条件tenantName手动清空时结果为空

### DIFF
--- a/.changeset/plenty-carrots-divide.md
+++ b/.changeset/plenty-carrots-divide.md
@@ -1,0 +1,5 @@
+---
+"@scow/mis-web": patch
+---
+
+平台管理租户充值记录过滤条件 tenantName 手动清空时，传参由“”改为 undefined

--- a/apps/mis-web/src/pageComponents/admin/TenantPaymentTable.tsx
+++ b/apps/mis-web/src/pageComponents/admin/TenantPaymentTable.tsx
@@ -67,7 +67,7 @@ export const TenantPaymentTable: React.FC<Props> = ({
           initialValues={query}
           onFinish={async () => {
             const { tenantName, time } = await form.validateFields();
-            setQuery({ tenantName, time });
+            setQuery({ tenantName: tenantName === "" ? undefined : tenantName, time });
           }}
         >
           {


### PR DESCRIPTION
当前系统下，平台管理的租户充值记录页面。填入租户名进行条件搜索后，手动将租户输入框清空再点击搜索，结果为空。原因是输入框手动清空后，调用api时会传参tenantName=""，与预期不符。此处fix将其改为传参undefined会得到预期结果