### PR TITLE
docs:  丰富 scow-cli 文档，增加下载参考命令

### DIFF
--- a/.changeset/blue-singers-tan.md
+++ b/.changeset/blue-singers-tan.md
@@ -1,0 +1,5 @@
+---
+"@scow/docs": patch
+---
+
+丰富 scow-cli 文档，增加下载参考命令

--- a/docs/docs/deploy/install/scow-cli.md
+++ b/docs/docs/deploy/install/scow-cli.md
@@ -20,16 +20,16 @@ scow-cli是SCOW集群安装、配置和管理工具，您可以使用scow-cli高
 # 如果没有wget，可以先install
 yum install wget
 
-# 下载对应的release版本。修改latest、cli-x64可下载指定版本
-# 可修改latest为v0.4.0即可下载0.4.0版本的cli，如 https://github.com/PKUHPC/SCOW/releases/download/v0.4.0/cli-x64
-# 可修改cli-x64为cli-arm64下载arm64版本，如 https://github.com/PKUHPC/SCOW/releases/download/latest/cli-arm64
+# 下载对应的release版本。修改latest、cli-x64可下载指定版本cli
+# 修改latest为v0.4.0即可下载0.4.0版本的cli，如 https://github.com/PKUHPC/SCOW/releases/download/v0.4.0/cli-x64
+# 可修改cli-x64为cli-arm64下载arm64版本，如 https://github.com/PKUHPC/SCOW/releases/download/v0.4.0/cli-arm64
 wget https://github.com/PKUHPC/SCOW/releases/download/latest/cli-x64
 
 # 重命名
 mv cli-x64 cli
 
 #修改文件权限
-chmod 777 cli
+chmod +x cli
 ```
 
 # 配置

--- a/docs/docs/deploy/install/scow-cli.md
+++ b/docs/docs/deploy/install/scow-cli.md
@@ -14,6 +14,22 @@ scow-cli是SCOW集群安装、配置和管理工具，您可以使用scow-cli高
 
 想获取最新的scow-cli版本？您可以从GitHub Actions的[`Test, Build and Publish Projects` workflow](https://github.com/PKUHPC/SCOW/actions/workflows/test-build-publish.yaml)中下载到上传到Archive的`scow-cli`。
 
+- 参考命令
+
+```bash
+# 如果没有wget，可以先install
+yum install wget
+
+# 下载对应的release版本，修改latest、cli-x64即可下载指定版本
+wget https://github.com/PKUHPC/SCOW/releases/download/latest/cli-x64
+
+# 重命名
+mv cli-x64 cli
+
+#修改文件权限
+chmod 777 cli
+```
+
 # 配置
 
 scow-cli使用运行目录下的`install.yaml`作为配置来管理集群，但您可以通过`-c`命令行选项指定`install.yaml`的路径。

--- a/docs/docs/deploy/install/scow-cli.md
+++ b/docs/docs/deploy/install/scow-cli.md
@@ -20,7 +20,9 @@ scow-cli是SCOW集群安装、配置和管理工具，您可以使用scow-cli高
 # 如果没有wget，可以先install
 yum install wget
 
-# 下载对应的release版本，修改latest、cli-x64即可下载指定版本
+# 下载对应的release版本。修改latest、cli-x64可下载指定版本
+# 可修改latest为v0.4.0即可下载0.4.0版本的cli，如 https://github.com/PKUHPC/SCOW/releases/download/v0.4.0/cli-x64
+# 可修改cli-x64为cli-arm64下载arm64版本，如 https://github.com/PKUHPC/SCOW/releases/download/latest/cli-arm64
 wget https://github.com/PKUHPC/SCOW/releases/download/latest/cli-x64
 
 # 重命名


### PR DESCRIPTION
增加scow-cli下载及修改权限的参考命令，让用户使用起来更简单
```bash
```bash
# 如果没有wget，可以先install
yum install wget

# 下载对应的release版本，修改latest、cli-x64即可下载指定版本
wget https://github.com/PKUHPC/SCOW/releases/download/latest/cli-x64

# 重命名
mv cli-x64 cli

#修改文件权限
chmod 777 cli
```