### PR TITLE
fix(ssh): 配置SCOW免密认证时，如果用户的authorized_keys已存在，则将SCOW的公钥插入，而不覆盖已有的authorized_keys文件

### DIFF
--- a/.changeset/calm-sheep-clap.md
+++ b/.changeset/calm-sheep-clap.md
@@ -1,0 +1,5 @@
+---
+"@scow/lib-ssh": patch
+---
+
+配置 SCOW 免密认证时，如果用户的 authorized_keys 已存在，则将 SCOW 的公钥插入，而不覆盖已有的 authorized_keys 文件

--- a/libs/ssh/src/key.ts
+++ b/libs/ssh/src/key.ts
@@ -14,8 +14,9 @@ import fs from "fs";
 import { join } from "path";
 import type { Logger } from "ts-log";
 
-import { sftpAppendFile, sftpChmod, sftpChown, sftpStatOrUndefined, sftpWriteFile } from "./sftp";
-import { sshConnect } from "./ssh";
+import { sftpAppendFile, sftpChmod, sftpChown, sftpMkdir, sftpStatOrUndefined, sftpWriteFile } from "./sftp";
+import { getUserHomedir, sshConnect, sshConnectByPassword } from "./ssh";
+
 export interface KeyPair {
   publicKey: string;
   privateKey: string;
@@ -84,3 +85,59 @@ export async function insertKeyAsRoot(
   });
 }
 
+/**
+ * Login as user by password and insert the host's public key to the user's authorized_keys to enable public key login
+ *
+ * @param address the address
+ * @param username the username
+ * @param password password
+ * @param rootKeyPair key pair
+ * @param logger logger
+ */
+export async function insertKeyAsUser(
+  address: string, username: string, password: string,
+  rootKeyPair: KeyPair, logger: Logger,
+) {
+
+  await sshConnectByPassword(address, username, password, logger, async (ssh) => {
+    const userHomeDir = await getUserHomedir(ssh, username, logger);
+
+    const sftp = await ssh.requestSFTP();
+    const stat = await sftpStatOrUndefined(sftp)(userHomeDir);
+
+    if (!stat) {
+      logger.warn("Home directory %s of user %s doesn't exist even after login as the user. Insert key as root.",
+        userHomeDir, username);
+
+      await insertKeyAsRoot(username, address, rootKeyPair, logger);
+      return;
+    }
+
+    // make sure user home dir is a directory
+    if (!stat.isDirectory()) {
+      throw new Error(`${userHomeDir} of user ${username} exists but is not a directory`);
+    }
+
+    // make sure ~/.ssh exists and has correct permission
+    const sshDir = join(userHomeDir, ".ssh");
+    const sshDirStat = await sftpStatOrUndefined(sftp)(sshDir);
+    if (!sshDirStat) {
+      logger.info("%s not exists in %s user %s. Creating it.", sshDir, address, username);
+      await sftpMkdir(sftp)(sshDir);
+      await sftpChmod(sftp)(sshDir, "700");
+    }
+
+    // check if authorized_keys exists
+    const keyFilePath = join(sshDir, "authorized_keys");
+    const authorizedKeysStat = await sftpStatOrUndefined(sftp)(keyFilePath);
+    if (!authorizedKeysStat) {
+      logger.info("%s not exists in %s for user %s. Create the file and insert public key",
+        keyFilePath, address, username);
+      await sftpWriteFile(sftp)(keyFilePath, rootKeyPair.publicKey + "\n");
+      await sftpChmod(sftp)(keyFilePath, "644");
+    } else {
+      logger.info("%s exists in %s for user %s. Insert public key", keyFilePath, address, username);
+      await sftpAppendFile(sftp)(keyFilePath, "\n" + rootKeyPair.publicKey + "\n");
+    }
+  });
+}

--- a/libs/ssh/src/key.ts
+++ b/libs/ssh/src/key.ts
@@ -14,7 +14,7 @@ import fs from "fs";
 import { join } from "path";
 import type { Logger } from "ts-log";
 
-import { sftpChmod, sftpChown, sftpWriteFile } from "./sftp";
+import { sftpAppendFile, sftpChmod, sftpChown, sftpStatOrUndefined, sftpWriteFile } from "./sftp";
 import { sshConnect } from "./ssh";
 export interface KeyPair {
   publicKey: string;
@@ -47,29 +47,40 @@ export async function insertKeyAsRoot(
     const userID = await ssh.execCommand(`id -u ${user}`);
     const userGID = await ssh.execCommand(`id -g ${user}`);
 
+    const uid = Number(userID.stdout.trim());
+    const gid = Number(userGID.stdout.trim());
+
     const userHomeDir = homeDir.stdout.trim();
 
     const sftp = await ssh.requestSFTP();
+
     // make sure user home directory exists.
     await ssh.mkdir(userHomeDir, undefined, sftp);
-
-    const sshDir = join(userHomeDir, ".ssh");
-
-    await ssh.mkdir(sshDir, undefined, sftp);
     // root create the directory, so we need to change the owner
-    await sftpChown(sftp)(userHomeDir, Number(userID.stdout.trim()), Number(userGID.stdout.trim()));
+    await sftpChown(sftp)(userHomeDir, uid, gid);
 
+    // make sure .ssh dir exists
+    const sshDir = join(userHomeDir, ".ssh");
+    const sshDirStat = await sftpStatOrUndefined(sftp)(sshDir);
+    if (!sshDirStat) {
+      logger.info("%s not exists in %s user %s. Creating it.", sshDir, host, user);
+      await ssh.mkdir(sshDir, undefined, sftp);
+      await sftpChmod(sftp)(sshDir, "700");
+      await sftpChown(sftp)(sshDir, uid, gid);
+    }
+
+    // insert key
     const keyFilePath = join(sshDir, "authorized_keys");
-    await sftpChmod(sftp)(sshDir, "700");
-    await sftpWriteFile(sftp)(keyFilePath, rootKeyPair.publicKey);
-    logger.info("Writing key to user %s, userID %s to %s in file %s", user, userID, host, keyFilePath);
-
-    await sftpChmod(sftp)(keyFilePath, "644");
-
-    await sftpChown(sftp)(sshDir, Number(userID.stdout.trim()), Number(userGID.stdout.trim()));
-
-    await sftpChown(sftp)(keyFilePath, Number(userID.stdout.trim()), Number(userGID.stdout.trim()));
-
+    const keyFileStat = await sftpStatOrUndefined(sftp)(keyFilePath);
+    if (!keyFileStat) {
+      logger.info("Writing key to user %s, userID %s to %s in file %s", user, uid, host, keyFilePath);
+      await sftpWriteFile(sftp)(keyFilePath, rootKeyPair.publicKey + "\n");
+      await sftpChmod(sftp)(keyFilePath, "644");
+      await sftpChown(sftp)(keyFilePath, uid, gid);
+    } else {
+      logger.info("%s exists for user %s in %s. Appending public key", keyFilePath, user, host);
+      await sftpAppendFile(sftp)(keyFilePath, "\n" + rootKeyPair.publicKey + "\n");
+    }
   });
 }
 

--- a/libs/ssh/src/sftp.ts
+++ b/libs/ssh/src/sftp.ts
@@ -54,6 +54,9 @@ export const sftpRealPath = (sftp: SFTPWrapper) =>
 export const sftpStat = (sftp: SFTPWrapper) =>
   handleSftpError(promisify(sftp.stat.bind(sftp) as typeof sftp["stat"]));
 
+export const sftpStatOrUndefined = (sftp: SFTPWrapper) => (path: string) =>
+  sftpStat(sftp)(path).catch(() => undefined);
+
 export const sftpUnlink = (sftp: SFTPWrapper) =>
   handleSftpError(promisify(sftp.unlink.bind(sftp) as typeof sftp["unlink"]));
 
@@ -66,5 +69,7 @@ export const sftpRename = (sftp: SFTPWrapper) =>
 export const sftpMkdir = (sftp: SFTPWrapper) =>
   handleSftpError(promisify(sftp.mkdir.bind(sftp) as typeof sftp["mkdir"]));
 
+export const sftpAppendFile = (sftp: SFTPWrapper) =>
+  handleSftpError(promisify(sftp.appendFile.bind(sftp) as typeof sftp["appendFile"]));
 
 

--- a/libs/ssh/src/ssh.ts
+++ b/libs/ssh/src/ssh.ts
@@ -11,12 +11,11 @@
  */
 
 import { NodeSSH, SSHExecCommandOptions, SSHExecCommandResponse } from "node-ssh";
-import { join } from "path";
 import { quote } from "shell-quote";
 import type { Logger } from "ts-log";
 
 import { insertKeyAsRoot, KeyPair } from "./key";
-import { sftpAppendFile, sftpChmod, SftpError, sftpMkdir, sftpStatOrUndefined, sftpWriteFile } from "./sftp";
+import { SftpError } from "./sftp";
 
 export class SshConnectError extends Error {
   constructor(options?: ErrorOptions) {
@@ -216,62 +215,7 @@ export const getUserHomedir = async (ssh: NodeSSH, username: string, logger: Log
   return resp.stdout.trim();
 };
 
-/**
- * Login as user by password and insert the host's public key to the user's authorized_keys to enable public key login
- *
- * @param address the address
- * @param username the username
- * @param password password
- * @param rootKeyPair key pair
- * @param logger logger
- */
-export async function insertKeyAsUser(
-  address: string, username: string, password: string,
-  rootKeyPair: KeyPair, logger: Logger,
-) {
 
-  await sshConnectByPassword(address, username, password, logger, async (ssh) => {
-    const userHomeDir = await getUserHomedir(ssh, username, logger);
-
-    const sftp = await ssh.requestSFTP();
-    const stat = await sftpStatOrUndefined(sftp)(userHomeDir);
-
-    if (!stat) {
-      logger.warn("Home directory %s of user %s doesn't exist even after login as the user. Insert key as root.",
-        userHomeDir, username);
-
-      await insertKeyAsRoot(username, address, rootKeyPair, logger);
-      return;
-    }
-
-    // make sure user home dir is a directory
-    if (!stat.isDirectory()) {
-      throw new Error(`${userHomeDir} of user ${username} exists but is not a directory`);
-    }
-
-    // make sure ~/.ssh exists and has correct permission
-    const sshDir = join(userHomeDir, ".ssh");
-    const sshDirStat = await sftpStatOrUndefined(sftp)(sshDir);
-    if (!sshDirStat) {
-      logger.info("%s not exists in %s user %s. Creating it.", sshDir, address, username);
-      await sftpMkdir(sftp)(sshDir);
-      await sftpChmod(sftp)(sshDir, "700");
-    }
-
-    // check if authorized_keys exists
-    const keyFilePath = join(sshDir, "authorized_keys");
-    const authorizedKeysStat = await sftpStatOrUndefined(sftp)(keyFilePath);
-    if (!authorizedKeysStat) {
-      logger.info("%s not exists in %s for user %s. Create the file and insert public key",
-        keyFilePath, address, username);
-      await sftpWriteFile(sftp)(keyFilePath, rootKeyPair.publicKey + "\n");
-      await sftpChmod(sftp)(keyFilePath, "644");
-    } else {
-      logger.info("%s exists in %s for user %s. Insert public key", keyFilePath, address, username);
-      await sftpAppendFile(sftp)(keyFilePath, "\n" + rootKeyPair.publicKey + "\n");
-    }
-  });
-}
 
 export async function sshRmrf(ssh: NodeSSH, path: string) {
   await ssh.exec("rm", ["-rf", path]).catch((e) => {

--- a/libs/ssh/tests/sshKey.test.ts
+++ b/libs/ssh/tests/sshKey.test.ts
@@ -11,12 +11,12 @@
  */
 
 import { join } from "path";
-import { insertKeyAsRoot } from "src/key";
-import { sftpExists, sftpReadFile, sftpStat } from "src/sftp";
-import { insertKeyAsUser, sshConnect, sshRmrf } from "src/ssh";
+import { insertKeyAsRoot, insertKeyAsUser, KeyPair } from "src/key";
+import { sftpChmod, sftpChown, sftpExists, sftpMkdir, sftpReadFile, sftpStat, sftpWriteFile } from "src/sftp";
+import { sshConnect, sshRmrf } from "src/ssh";
 
 import { connectToTestServerAsRoot,
-  createTestItems, resetTestServerAsRoot, rootKeyPair, target, TestSshServer } from "./utils";
+  createTestItems, generateSshKeyPair, resetTestServerAsRoot, rootKeyPair, target, TestSshServer } from "./utils";
 
 let serverSsh: TestSshServer;
 const randomPostfix = String(Math.ceil(Math.random() * 1000 + 1));
@@ -29,7 +29,7 @@ const password = "12345678";
 beforeEach(async () => {
   serverSsh = await connectToTestServerAsRoot();
   await createTestItems(serverSsh);
-  // creat user
+  // create user
   await serverSsh.ssh.execCommand(`adduser -D -h ${home} ${testUser}`);
   await serverSsh.ssh.execCommand(`echo ${testUser}:${password}|chpasswd`);
 });
@@ -64,17 +64,20 @@ it("insert key as root", async () => {
   const userID = await serverSsh.ssh.execCommand(`id -u ${testUser}`);
   const userGID = await serverSsh.ssh.execCommand(`id -g ${testUser}`);
 
+  const uid = Number(userID.stdout.trim());
+  const gid = Number(userGID.stdout.trim());
+
   const keyStats = await sftpStat(serverSsh.sftp)(keyFile);
   const keyPermission = (keyStats.mode & parseInt("777", 8)).toString(8);
   expect(keyPermission).toEqual("644");
-  expect(keyStats.uid).toBe(Number(userID.stdout.trim()));
-  expect(keyStats.gid).toBe(Number(userGID.stdout.trim()));
+  expect(keyStats.uid).toBe(uid);
+  expect(keyStats.gid).toBe(gid);
 
   const sshStats = await sftpStat(serverSsh.sftp)(sshDir);
   const sshPermission = (sshStats.mode & parseInt("777", 8)).toString(8);
   expect(sshPermission).toEqual("700");
-  expect(sshStats.uid).toBe(Number(userID.stdout.trim()));
-  expect(sshStats.gid).toBe(Number(userGID.stdout.trim()));
+  expect(sshStats.uid).toBe(uid);
+  expect(sshStats.gid).toBe(gid);
 });
 
 it("insert keys as user", async () => {
@@ -86,4 +89,45 @@ it("insert keys as user", async () => {
   expect(await sftpExists(serverSsh.sftp, keyFile)).toBeTrue();
 
   await tryLoginAsUser();
+});
+
+
+describe("doesn't override authorized_keys if exists", () => {
+
+  let existingKey: KeyPair;
+
+  beforeEach(async () => {
+
+    existingKey = await generateSshKeyPair();
+
+    const userUID = Number((await serverSsh.ssh.execCommand(`id -g ${testUser}`)).stdout);
+    const userGID = Number((await serverSsh.ssh.execCommand(`id -u ${testUser}`)).stdout);
+
+    await sftpMkdir(serverSsh.sftp)(sshDir);
+    await sftpChown(serverSsh.sftp)(sshDir, userUID, userGID);
+    await sftpWriteFile(serverSsh.sftp)(keyFile, existingKey.publicKey);
+    await sftpChown(serverSsh.sftp)(keyFile, userUID, userGID);
+    await sftpChmod(serverSsh.sftp)(keyFile, "644");
+  });
+
+  const checkExistingKeys = async () => {
+    const keyContent = (await sftpReadFile(serverSsh.sftp)(keyFile)).toString();
+    expect(keyContent).toInclude(existingKey.publicKey);
+  };
+
+  it("as user", async () => {
+
+    await insertKeyAsUser(target, testUser, password, rootKeyPair, console);
+    await tryLoginAsUser();
+
+    await checkExistingKeys();
+  });
+
+  it("as root", async () => {
+
+    await insertKeyAsRoot(testUser, target, rootKeyPair, console);
+    await tryLoginAsUser();
+    await checkExistingKeys();
+  });
+
 });

--- a/libs/ssh/tests/utils.ts
+++ b/libs/ssh/tests/utils.ts
@@ -10,11 +10,11 @@
  * See the Mulan PSL v2 for more details.
  */
 
-import { randomBytes } from "crypto";
+import { generateKeyPair, randomBytes } from "crypto";
 import { NodeSSH } from "node-ssh";
 import { homedir } from "os";
 import { dirname, join } from "path";
-import { getKeyPair } from "src/key";
+import { getKeyPair, KeyPair } from "src/key";
 import { sftpWriteFile } from "src/sftp";
 import { sshRawConnect, sshRmrf } from "src/ssh";
 import { SFTPWrapper } from "ssh2";
@@ -64,3 +64,25 @@ export async function createTestItems({ sftp, ssh }: TestSshServer): Promise<str
   return base;
 }
 
+export async function generateSshKeyPair() {
+  return new Promise<KeyPair>((res, rej) => {
+    generateKeyPair("rsa", {
+      modulusLength: 2048,
+      publicKeyEncoding: {
+        type: "spki",
+        format: "pem",
+      },
+      privateKeyEncoding: {
+        type: "pkcs8",
+        format: "pem",
+        cipher: "aes-256-cbc",
+        passphrase: "",
+      },
+    }, (err, publicKey, privateKey) => {
+      // Handle errors and use the generated key pair.
+      if (err) { rej(err); }
+
+      res({ publicKey, privateKey });
+    });
+  });
+}


### PR DESCRIPTION
目前，SCOW在登录一个用户时，如果发现无法直接公钥登录登录节点，则SCOW会自动给这个用户配置免密登录，步骤为：

1. 用用户的用户名和密码登录登录节点
2. 如果用户的家目录存在，则把SCOW公钥写入~/.ssh/authorized_keys，如果文件不存在则创建
3. 如果家目录不存在，则
    4. 以root身份登录登录节点
    5. 创建用户的家目录
    6. 创建~/.ssh/authorized_keys文件并写入内容
    7. 修改目录和文件的权限和owner  

但是有时候SCOW无法直接公钥登录用户的原因不是因为authorized_keys不存在，而是因为文件存在但是文件中不存在SCOW的公钥。目前的方案的第二步中，如果authorized_keys已经存在，则SCOW将会直接覆盖authorized_keys文件。

SCOW在插入公钥的时候需要先判断authorized_keys文件是否存在，如果已经存在，则直接把SCOW的公钥内容写入authorized_keys文件后面。