### PR TITLE
feat(cli): CLI支持设置HTTP代理

### DIFF
--- a/.changeset/pretty-goats-type.md
+++ b/.changeset/pretty-goats-type.md
@@ -1,0 +1,7 @@
+---
+"@scow/gateway": patch
+"@scow/cli": patch
+"@scow/docs": patch
+---
+
+cli 支持设置HTTP代理

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -21,7 +21,9 @@
     "octokit": "2.0.14",
     "jszip": "3.10.1",
     "dotenv": "16.0.3",
-    "death": "1.1.0"
+    "death": "1.1.0",
+    "https-proxy-agent": "5.0.1",
+    "node-fetch-commonjs": "3.2.4"
   },
   "devDependencies": {
     "@types/yargs": "17.0.24",

--- a/apps/cli/src/cmd/updateCli.ts
+++ b/apps/cli/src/cmd/updateCli.ts
@@ -82,13 +82,13 @@ export const updateCli = async (options: Options) => {
     }
   }
 
-  const arch = getArch();
-
   const agent = proxyUrl ? createProxyAgent(proxyUrl) : undefined;
 
   if (proxyUrl) {
     log("Using proxy %s", proxyUrl);
   }
+
+  const arch = getArch();
 
   // built-in fetch doesn't work with proxy
   // https://github.com/octokit/rest.js/issues/43
@@ -196,7 +196,7 @@ Please provide your GitHub personal access token via GITHUB_TOKEN in env or .env
   log("Asset: %s. Download URL: %s", asset.name, asset.browser_download_url);
 
   log("Downloading...");
-  const content = await download(asset.browser_download_url);
+  const content = await download(asset.browser_download_url, { agent });
 
   await unlink(outputPath);
   await fs.promises.writeFile(outputPath, Buffer.from(content));

--- a/apps/cli/src/config/proxy.ts
+++ b/apps/cli/src/config/proxy.ts
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2022 Peking University and Peking University Institute for Computing and Digital Economy
+ * SCOW is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *          http://license.coscl.org.cn/MulanPSL2
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PSL v2 for more details.
+ */
+
+import createHttpsProxyAgent from "https-proxy-agent";
+
+export const proxyUrl =
+  process.env.HTTPS_PROXY || process.env.https_proxy || process.env.HTTP_PROXY || process.env.http_proxy;
+
+export const createProxyAgent = (proxyUrl: string) => {
+  return createHttpsProxyAgent(proxyUrl);
+};
+

--- a/docs/docs/deploy/install/scow-cli.md
+++ b/docs/docs/deploy/install/scow-cli.md
@@ -120,7 +120,7 @@ GITHUB_TOKEN={token}
 
 # 代理
 
-CLI需要访问网络的功能（例如更新scow-cli）可以设置代理。您可以通过设置`HTTPS_PROXY`, `https_proxy`, `HTTP_PROXY`, `http_proxy`环境变量来设置代理。如果多个环境变量同时存在，则使用优先级为上面列出来的顺序。
+CLI需要访问网络的功能（例如更新scow-cli）可以设置HTTP代理。您可以通过设置`HTTPS_PROXY`, `https_proxy`, `HTTP_PROXY`, `http_proxy`环境变量来设置代理。如果多个环境变量同时存在，则使用优先级为上面列出来的顺序。
 
 ```bash
 export HTTPS_PROXY=http://localhost:1080

--- a/docs/docs/deploy/install/scow-cli.md
+++ b/docs/docs/deploy/install/scow-cli.md
@@ -118,7 +118,16 @@ scow-cli使用运行目录下的`install.yaml`作为配置来管理集群，但�
 GITHUB_TOKEN={token}
 ```
 
-## 打印调试日志
+# 代理
+
+CLI需要访问网络的功能（例如更新scow-cli）可以设置代理。您可以通过设置`HTTPS_PROXY`, `https_proxy`, `HTTP_PROXY`, `http_proxy`环境变量来设置代理。如果多个环境变量同时存在，则使用优先级为上面列出来的顺序。
+
+```bash
+export HTTPS_PROXY=http://localhost:1080
+./cli update
+```
+
+# 打印调试日志
 
 ```bash
 DEBUG="scow:cli" ./cli

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -194,12 +194,18 @@ importers:
       dotenv:
         specifier: 16.0.3
         version: 16.0.3
+      https-proxy-agent:
+        specifier: 5.0.1
+        version: 5.0.1
       js-yaml:
         specifier: 4.1.0
         version: 4.1.0
       jszip:
         specifier: 3.10.1
         version: 3.10.1
+      node-fetch-commonjs:
+        specifier: 3.2.4
+        version: 3.2.4
       octokit:
         specifier: 2.0.14
         version: 2.0.14
@@ -9514,6 +9520,14 @@ packages:
       xxhashjs: 0.2.2
     dev: true
 
+  /fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.2.1
+    dev: false
+
   /figlet@1.5.2:
     resolution: {integrity: sha512-WOn21V8AhyE1QqVfPIVxe3tupJacq1xGkPTB4iagT6o+P2cAgEOOwIxMftr4+ZCTI6d551ij9j61DFr0nsP2uQ==}
     engines: {node: '>= 0.4.0'}
@@ -9719,6 +9733,13 @@ packages:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       mime-types: 2.1.35
+
+  /formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
+    dependencies:
+      fetch-blob: 3.2.0
+    dev: false
 
   /forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
@@ -12996,10 +13017,23 @@ packages:
       uuid: 8.3.2
     dev: false
 
+  /node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    dev: false
+
   /node-emoji@1.11.0:
     resolution: {integrity: sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==}
     dependencies:
       lodash: 4.17.21
+    dev: false
+
+  /node-fetch-commonjs@3.2.4:
+    resolution: {integrity: sha512-bZW7+ldcuuMPLTJk8DufhT6qHDRdljYD0jqBjmrYfcInaYcReX5kK42SQsu/jvtit/tER28yYjnk63PEEmNPtg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      formdata-polyfill: 4.0.10
+      web-streams-polyfill: 3.2.1
     dev: false
 
   /node-fetch@2.6.7:
@@ -17856,6 +17890,11 @@ packages:
 
   /web-namespaces@1.1.4:
     resolution: {integrity: sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw==}
+    dev: false
+
+  /web-streams-polyfill@3.2.1:
+    resolution: {integrity: sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==}
+    engines: {node: '>= 8'}
     dev: false
 
   /webidl-conversions@3.0.1:


### PR DESCRIPTION
现在在使用CLI更新CLI时支持设置HTTP代理，通过`HTTPS_PROXY`, `https_proxy`, `HTTP_PROXY`, `http_proxy`环境变量设置。

![image](https://user-images.githubusercontent.com/8363856/234283680-e763b5ec-2c92-4c56-9400-df97d099c084.png)
