### PR TITLE
fix(web): 前端显示用户姓名时使用认证系统返回的用户姓名

### DIFF
--- a/.changeset/rich-ducks-visit.md
+++ b/.changeset/rich-ducks-visit.md
@@ -1,0 +1,7 @@
+---
+"@scow/portal-web": patch
+"@scow/mis-web": patch
+"@scow/lib-web": patch
+---
+
+前端显示用户姓名时使用认证系统返回的用户姓名

--- a/apps/mis-web/src/auth/token.ts
+++ b/apps/mis-web/src/auth/token.ts
@@ -19,6 +19,8 @@ import { UserInfo } from "src/models/User";
 import { getClient } from "src/utils/client";
 import { runtimeConfig } from "src/utils/config";
 
+export interface AuthUserInfo {
+}
 
 export async function validateToken(token: string): Promise<UserInfo | undefined> {
 
@@ -44,7 +46,7 @@ export async function validateToken(token: string): Promise<UserInfo | undefined
   return {
     accountAffiliations: userInfo.affiliations,
     identityId: resp.identityId,
-    name: authUserInfo?.name || resp.identityId,
+    name: authUserInfo?.name,
     platformRoles: userInfo.platformRoles,
     tenant: userInfo.tenantName,
     tenantRoles: userInfo.tenantRoles,

--- a/apps/mis-web/src/auth/token.ts
+++ b/apps/mis-web/src/auth/token.ts
@@ -11,7 +11,7 @@
  */
 
 import { asyncClientCall } from "@ddadaal/tsgrpc-client";
-import { validateToken as valToken } from "@scow/lib-auth";
+import { getUser, validateToken as authValidateToken } from "@scow/lib-auth";
 import { GetUserInfoResponse, UserServiceClient } from "@scow/protos/build/server/user";
 import { MOCK_USER_INFO } from "src/apis/api.mock";
 import { USE_MOCK } from "src/apis/useMock";
@@ -26,12 +26,14 @@ export async function validateToken(token: string): Promise<UserInfo | undefined
     return MOCK_USER_INFO;
   }
 
-  const resp = await valToken(runtimeConfig.AUTH_INTERNAL_URL, token).catch(() => undefined);
-
+  const resp = await authValidateToken(runtimeConfig.AUTH_INTERNAL_URL, token).catch(() => undefined);
 
   if (!resp) {
     return undefined;
   }
+
+  const authUserInfo = await getUser(runtimeConfig.AUTH_INTERNAL_URL, { identityId: resp.identityId })
+    .catch(() => undefined);
 
   const client = getClient(UserServiceClient);
 
@@ -42,7 +44,7 @@ export async function validateToken(token: string): Promise<UserInfo | undefined
   return {
     accountAffiliations: userInfo.affiliations,
     identityId: resp.identityId,
-    name: userInfo.name,
+    name: authUserInfo?.name || resp.identityId,
     platformRoles: userInfo.platformRoles,
     tenant: userInfo.tenantName,
     tenantRoles: userInfo.tenantRoles,

--- a/apps/mis-web/src/models/User.ts
+++ b/apps/mis-web/src/models/User.ts
@@ -71,7 +71,7 @@ export type AccountAffiliation = Static<typeof AccountAffiliationSchema>;
 
 export const UserInfoSchema = Type.Object({
   tenant: Type.String(),
-  name: Type.String(),
+  name: Type.Optional(Type.String()),
   identityId: Type.String(),
   accountAffiliations: Type.Array(AccountAffiliationSchema),
   tenantRoles: Type.Array(Type.Enum(TenantRole)),

--- a/apps/mis-web/src/pages/api/auth/validateToken.ts
+++ b/apps/mis-web/src/pages/api/auth/validateToken.ts
@@ -19,7 +19,7 @@ import type { PlatformRole, TenantRole, UserRole } from "src/models/User";
 export interface UserInfo {
   identityId: string;
   tenant: string;
-  name: string;
+  name?: string;
   accountAffiliations: { accountName: string; role: UserRole }[];
   platformRoles: PlatformRole[];
   tenantRoles: TenantRole[];

--- a/apps/mis-web/src/stores/UserStore.ts
+++ b/apps/mis-web/src/stores/UserStore.ts
@@ -18,7 +18,7 @@ import { AccountAffiliation, PlatformRole, TenantRole } from "src/models/User";
 export interface User {
   tenant: string;
   identityId: string;
-  name: string;
+  name?: string;
   token: string;
   tenantRoles: TenantRole[];
   platformRoles: PlatformRole[];

--- a/apps/portal-web/src/auth/token.ts
+++ b/apps/portal-web/src/auth/token.ts
@@ -10,7 +10,7 @@
  * See the Mulan PSL v2 for more details.
  */
 
-import { validateToken as valToken } from "@scow/lib-auth"; 
+import { getUser, validateToken as authValidateToken } from "@scow/lib-auth";
 import { USE_MOCK } from "src/apis/useMock";
 import { UserInfo } from "src/models/User";
 import { runtimeConfig } from "src/utils/config";
@@ -21,19 +21,23 @@ export async function validateToken(token: string | undefined): Promise<UserInfo
     if (!runtimeConfig.MOCK_USER_ID) {
       throw new Error("Using mock user id but runtimeConfig.MOCK_USER_ID is not set");
     }
-    return { identityId: runtimeConfig.MOCK_USER_ID };
+    return { identityId: runtimeConfig.MOCK_USER_ID, name: runtimeConfig.MOCK_USER_ID };
   }
 
   if (!token) { return undefined; }
 
-  const resp = await valToken(runtimeConfig.AUTH_INTERNAL_URL, token).catch(() => undefined);
+  const resp = await authValidateToken(runtimeConfig.AUTH_INTERNAL_URL, token).catch(() => undefined);
 
   if (!resp) {
     return undefined;
   }
 
+  const userInfo = await getUser(runtimeConfig.AUTH_INTERNAL_URL, { identityId: resp.identityId })
+    .catch(() => undefined);
+
   return {
     identityId: resp.identityId,
+    name: userInfo?.name ?? resp.identityId,
   };
 
 }

--- a/apps/portal-web/src/auth/token.ts
+++ b/apps/portal-web/src/auth/token.ts
@@ -37,7 +37,7 @@ export async function validateToken(token: string | undefined): Promise<UserInfo
 
   return {
     identityId: resp.identityId,
-    name: userInfo?.name ?? resp.identityId,
+    name: userInfo?.name,
   };
 
 }

--- a/apps/portal-web/src/models/User.ts
+++ b/apps/portal-web/src/models/User.ts
@@ -12,5 +12,5 @@
 
 export interface UserInfo {
   identityId: string;
-  name: string;
+  name?: string;
 }

--- a/apps/portal-web/src/models/User.ts
+++ b/apps/portal-web/src/models/User.ts
@@ -12,4 +12,5 @@
 
 export interface UserInfo {
   identityId: string;
+  name: string;
 }

--- a/apps/portal-web/src/pages/api/auth/validateToken.ts
+++ b/apps/portal-web/src/pages/api/auth/validateToken.ts
@@ -17,7 +17,7 @@ import { route } from "src/utils/route";
 // Write another plain UserInfo;
 export interface UserInfo {
   identityId: string;
-  name: string;
+  name?: string;
 }
 
 export interface ValidateTokenSchema {

--- a/apps/portal-web/src/pages/api/auth/validateToken.ts
+++ b/apps/portal-web/src/pages/api/auth/validateToken.ts
@@ -17,6 +17,7 @@ import { route } from "src/utils/route";
 // Write another plain UserInfo;
 export interface UserInfo {
   identityId: string;
+  name: string;
 }
 
 export interface ValidateTokenSchema {

--- a/apps/portal-web/src/stores/UserStore.ts
+++ b/apps/portal-web/src/stores/UserStore.ts
@@ -16,7 +16,7 @@ import { destroyUserInfoCookie } from "src/auth/cookie";
 
 export interface User {
   identityId: string;
-  name: string;
+  name?: string;
   token: string;
 }
 

--- a/apps/portal-web/src/stores/UserStore.ts
+++ b/apps/portal-web/src/stores/UserStore.ts
@@ -16,6 +16,7 @@ import { destroyUserInfoCookie } from "src/auth/cookie";
 
 export interface User {
   identityId: string;
+  name: string;
   token: string;
 }
 

--- a/libs/web/src/layouts/base/header/UserIndicator.tsx
+++ b/libs/web/src/layouts/base/header/UserIndicator.tsx
@@ -47,7 +47,7 @@ export const UserIndicator: React.FC<Props> = ({
             trigger={["click"]}
             menu={{
               items: [
-                ...user.name !== undefined ? [{ key: "username", disabled: true, label: `用户姓名：${user.name}` }] : [],
+                { key: "username", disabled: true, label: `用户姓名：${user.name}` },
                 { key: "userid", disabled: true, label: `用户ID：${user.identityId}` },
                 { key: "profileLink", label: <Link href="/profile">个人信息</Link> },
                 { key: "logout", onClick: logout, label: "退出登录" },

--- a/libs/web/src/layouts/base/header/UserIndicator.tsx
+++ b/libs/web/src/layouts/base/header/UserIndicator.tsx
@@ -47,7 +47,7 @@ export const UserIndicator: React.FC<Props> = ({
             trigger={["click"]}
             menu={{
               items: [
-                { key: "username", disabled: true, label: `用户姓名：${user.name}` },
+                ...user.name ? [{ key: "username", disabled: true, label: `用户姓名：${user.name}` }] : [],
                 { key: "userid", disabled: true, label: `用户ID：${user.identityId}` },
                 { key: "profileLink", label: <Link href="/profile">个人信息</Link> },
                 { key: "logout", onClick: logout, label: "退出登录" },

--- a/libs/web/src/layouts/base/types.ts
+++ b/libs/web/src/layouts/base/types.ts
@@ -12,7 +12,7 @@
 
 export interface UserInfo {
   identityId: string;
-  name?: string;
+  name: string;
   token: string;
 }
 

--- a/libs/web/src/layouts/base/types.ts
+++ b/libs/web/src/layouts/base/types.ts
@@ -12,7 +12,7 @@
 
 export interface UserInfo {
   identityId: string;
-  name: string;
+  name?: string;
   token: string;
 }
 


### PR DESCRIPTION
#591 支持了从认证系统中获取用户姓名。这个PR使在门户和管理系统登录后，显示在网页右上角的用户姓名为从认证系统中获取的用户姓名。如果从认证系统中获取不到用户名，则使用用户的ID显示。

在一个LDAP的集群中的测试方法：

1. 登录门户系统，查看登录后右上角显示的用户姓名是否为LDAP里用户的姓名
2. 修改管理系统数据库，在`user`表中将一个用户的姓名列修改为其他的，然后登录管理系统，查看登录后右上角显示的用户姓名是否为LDAP里用户的姓名
