### PR TITLE
ci: 当@scow/grpc-api版本变化时，创建一个api-v{版本}的tag

### DIFF
--- a/.github/workflows/test-build-publish.yaml
+++ b/.github/workflows/test-build-publish.yaml
@@ -6,7 +6,7 @@ on:
     branches: [master]
   push:
     tags:
-      - "**"
+      - "v*"
     branches:
       - master
 

--- a/.github/workflows/test-build-publish.yaml
+++ b/.github/workflows/test-build-publish.yaml
@@ -6,7 +6,7 @@ on:
     branches: [master]
   push:
     tags:
-      - "v*"
+      - "v**"
     branches:
       - master
 

--- a/scripts/tag.mjs
+++ b/scripts/tag.mjs
@@ -13,12 +13,24 @@
 /**
  * Compare the version of the current package.json and protos/package.json with the version of the last commit
  * If the version is changed, create a tag and push it to the remote repository
+ *
+ * Usage:
+ *   node scripts/tag.mjs
+ *   node scripts/tag.mjs --dry-run: only print the command to be executed
  */
 
 import { execSync } from "child_process";
 import { readFileSync } from "fs";
 
-const exec = (cmd) => execSync(cmd, { stdio: "inherit", encoding: "utf-8" });
+const dryRun = process.argv.includes("--dry-run");
+
+const exec = (cmd) => {
+  if (!dryRun) {
+    execSync(cmd, { stdio: "inherit", encoding: "utf-8" });
+  } else {
+    console.log("Trying to run command: %s", cmd);
+  }
+};
 
 function getVersion(path) {
   const lastFile = execSync(`git --no-pager show HEAD^1:${path}`, { encoding: "utf-8" });
@@ -41,7 +53,7 @@ if (rootVersion.current !== rootVersion.last) {
   console.log("App version is changed from %s to %s", rootVersion.last, rootVersion.current);
   exec(`git tag -a v${rootVersion.current} -m 'SCOW Release v${rootVersion.current}'`);
 } else {
-  console.log("App version is not changed. Ignored");
+  console.log("App version %s is not changed.", rootVersion.current);
 }
 
 // Tag SCOW API Release
@@ -51,6 +63,8 @@ if (scowApiVersion.current !== scowApiVersion.last) {
   changed = true;
   console.log("SCOW API version is changed from %s to %s", scowApiVersion.last, scowApiVersion.current);
   exec(`git tag -a api-v${scowApiVersion.current} -m 'SCOW API Release v${scowApiVersion.current}'`);
+} else {
+  console.log("SCOW API Version %s is not changed.", scowApiVersion.current);
 }
 
 if (changed) {

--- a/scripts/tag.mjs
+++ b/scripts/tag.mjs
@@ -11,7 +11,7 @@
  */
 
 /**
- * Compare the version of the current package.json with the version of the last commit
+ * Compare the version of the current package.json and protos/package.json with the version of the last commit
  * If the version is changed, create a tag and push it to the remote repository
  */
 
@@ -20,20 +20,40 @@ import { readFileSync } from "fs";
 
 const exec = (cmd) => execSync(cmd, { stdio: "inherit", encoding: "utf-8" });
 
-const lastPackageJson = execSync("git --no-pager show HEAD^1:package.json", { encoding: "utf-8" });
+function getVersion(path) {
+  const lastFile = execSync(`git --no-pager show HEAD^1:${path}`, { encoding: "utf-8" });
 
-const lastVersion = JSON.parse(lastPackageJson).version;
+  const currentFile = readFileSync(path, { encoding: "utf-8" });
 
-const currentVersion = JSON.parse(readFileSync("package.json", { encoding: "utf-8" })).version;
+  const last = JSON.parse(lastFile).version;
 
-if (lastVersion === currentVersion) {
-  console.log("App version is not changed. Ignored");
-  process.exit(0);
+  const current = JSON.parse(currentFile).version;
+
+  return { last, current };
 }
 
-console.log("App version is changed from %s to %s", lastVersion, currentVersion);
+// Tag SCOW Release
+let changed = false;
+const rootVersion = getVersion("package.json");
 
-exec(`git tag -a v${currentVersion} -m 'Release v${currentVersion}'`);
-exec("git push --tags");
+if (rootVersion.current !== rootVersion.last) {
+  changed = true;
+  console.log("App version is changed from %s to %s", rootVersion.last, rootVersion.current);
+  exec(`git tag -a v${rootVersion.current} -m 'SCOW Release v${rootVersion.current}'`);
+} else {
+  console.log("App version is not changed. Ignored");
+}
 
+// Tag SCOW API Release
+const scowApiVersion = getVersion("protos/package.json");
 
+if (scowApiVersion.current !== scowApiVersion.last) {
+  changed = true;
+  console.log("SCOW API version is changed from %s to %s", scowApiVersion.last, scowApiVersion.current);
+  exec(`git tag -a api-v${scowApiVersion.current} -m 'SCOW API Release v${scowApiVersion.current}'`);
+}
+
+if (changed) {
+  console.log("New Tag Created. Push tags.");
+  exec("git push --tags");
+}


### PR DESCRIPTION
当@scow/grpc-api版本变化时，创建一个api-v{版本}的tag并push到仓库中。这使得用户可以直接使用git的tag来找到想要使用SCOW API版本的相关文件。