### PR TITLE
feat(cli): check-config子命令，在不启动SCOW的情况下检查SCOW配置文件格式

### DIFF
--- a/.changeset/tiny-rocks-marry.md
+++ b/.changeset/tiny-rocks-marry.md
@@ -1,0 +1,6 @@
+---
+"@scow/cli": patch
+"@scow/docs": patch
+---
+
+cli 增加 check-config 命令，可检查 SCOW 配置文件格式

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -23,7 +23,8 @@
     "dotenv": "16.0.3",
     "death": "1.1.0",
     "https-proxy-agent": "5.0.1",
-    "node-fetch-commonjs": "3.2.4"
+    "node-fetch-commonjs": "3.2.4",
+    "@scow/config": "workspace:*"
   },
   "devDependencies": {
     "@types/yargs": "17.0.24",

--- a/apps/cli/src/cmd/checkConfig.ts
+++ b/apps/cli/src/cmd/checkConfig.ts
@@ -13,6 +13,7 @@
 import { getAppConfigs } from "@scow/config/build/app";
 import { getClusterConfigs } from "@scow/config/build/cluster";
 import { getClusterTextsConfig } from "@scow/config/build/clusterTexts";
+import { getCommonConfig } from "@scow/config/build/common";
 import { getMisConfig } from "@scow/config/build/mis";
 import { getPortalConfig } from "@scow/config/build/portal";
 import { getUiConfig } from "@scow/config/build/ui";
@@ -44,10 +45,13 @@ export const checkConfig = ({
     }
   };
 
+  logger.info("Check common config");
+  tryRead(getCommonConfig);
+
   logger.info("Checking cluster config files");
   tryRead(getClusterConfigs);
 
-  logger.info("Checking cluster texts files");
+  logger.info("Checking clusterTexts config");
   tryRead(getClusterTextsConfig);
 
   logger.info("Checking UI config");

--- a/apps/cli/src/cmd/checkConfig.ts
+++ b/apps/cli/src/cmd/checkConfig.ts
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2022 Peking University and Peking University Institute for Computing and Digital Economy
+ * SCOW is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *          http://license.coscl.org.cn/MulanPSL2
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PSL v2 for more details.
+ */
+
+import { getAppConfigs } from "@scow/config/build/app";
+import { getClusterConfigs } from "@scow/config/build/cluster";
+import { getClusterTextsConfig } from "@scow/config/build/clusterTexts";
+import { getMisConfig } from "@scow/config/build/mis";
+import { getPortalConfig } from "@scow/config/build/portal";
+import { getUiConfig } from "@scow/config/build/ui";
+import { getInstallConfig } from "src/config/install";
+
+interface Options {
+  configPath: string;
+  continueOnError: boolean;
+  scowConfigPath: string;
+}
+
+
+export const checkConfig = ({
+  configPath, continueOnError, scowConfigPath,
+}: Options) => {
+
+  const logger = console;
+
+  const config = getInstallConfig(configPath);
+
+  const tryRead = (readFn: (path: string, logger) => any) => {
+    try {
+      readFn(scowConfigPath, logger);
+    } catch (e) {
+      logger.error(e);
+      if (!continueOnError) {
+        process.exit(1);
+      }
+    }
+  };
+
+  logger.info("Checking cluster config files");
+  tryRead(getClusterConfigs);
+
+  logger.info("Checking cluster texts files");
+  tryRead(getClusterTextsConfig);
+
+  logger.info("Checking UI config");
+  tryRead(getUiConfig);
+
+  if (config.portal) {
+    logger.info("Checking portal config");
+    tryRead(getPortalConfig);
+
+    logger.info("Checking app config");
+    tryRead(getAppConfigs);
+  } else {
+    logger.info("Portal is not deployed. Skip portal config check.");
+  }
+
+  if (config.mis) {
+    logger.info("Checking MIS configuration");
+    tryRead(getMisConfig);
+  } else {
+    logger.info("MIS is not deployed. Skip MIS config check.");
+  }
+};

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -15,6 +15,7 @@ dotenv.config();
 
 import { readFileSync } from "fs";
 import { join } from "path";
+import { checkConfig } from "src/cmd/checkConfig";
 import { runCompose } from "src/cmd/compose";
 import { enterDb } from "src/cmd/db";
 import { generateDockerComposeYml } from "src/cmd/generate";
@@ -49,6 +50,22 @@ yargs(hideBin(process.argv))
     });
   }, (argv) => {
     viewInstall(argv);
+  })
+  .command("check-config", "Check SCOW config files", (yargs) => {
+    return yargs.options({
+      scowConfigPath: {
+        type: "string",
+        description: "The directory containing SCOW config files",
+        default: "./config",
+      },
+      continueOnError: {
+        type: "boolean",
+        description: "Continue even a config has error",
+        default: false,
+      },
+    });
+  }, (argv) => {
+    checkConfig(argv);
   })
   .command("init", "Extract sample config files", (yargs) => {
     return yargs.options({

--- a/docs/docs/deploy/install/scow-cli.md
+++ b/docs/docs/deploy/install/scow-cli.md
@@ -61,6 +61,9 @@ scow-cli使用运行目录下的`install.yaml`作为配置来管理集群，但�
 
 # 查看当前使用install.yaml的内容
 ./cli view-install
+
+# 检查./config目录下的SCOW配置文件的格式
+./cli check-config
 ```
 
 # 从scow-deployment迁移

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -182,6 +182,9 @@ importers:
 
   apps/cli:
     dependencies:
+      '@scow/config':
+        specifier: workspace:*
+        version: link:../../libs/config
       '@scow/lib-config':
         specifier: workspace:*
         version: link:../../libs/libconfig


### PR DESCRIPTION
CLI增加`check-config`子命令，可以检查SCOW配置文件格式。

会检查的配置文件：

- 交互式应用配置（apps/*.yaml）
- 集群配置文件（clusters/*.yaml）
- 集群说明配置（clusterTexts.yaml）
- 公共配置文件（common.yaml）
- UI配置（ui.yaml）
- 管理系统配置（mis.yaml）：只有当install.yaml指定了部署管理系统时会检查
- 门户系统配置（portal.yaml）：只有当install.yaml指定了部署门户系统时会检查

![image](https://user-images.githubusercontent.com/8363856/234515899-3678ab99-b0d0-4081-b9d1-4cdbe14f0c15.png)
