### PR TITLE
refactor: 使用本地的ts-proto生成pb文件

### DIFF
--- a/libs/protos/buf.gen.yaml
+++ b/libs/protos/buf.gen.yaml
@@ -1,6 +1,7 @@
 version: v1
 plugins:
-  - remote: buf.build/stephenh/plugins/ts-proto
+  - name: ts-proto
+    path: node_modules/ts-proto/protoc-gen-ts_proto
     out: generated
     opt:
       - unrecognizedEnum=false

--- a/libs/protos/buf.gen.yaml
+++ b/libs/protos/buf.gen.yaml
@@ -2,6 +2,7 @@ version: v1
 plugins:
   - name: ts-proto
     path: node_modules/ts-proto/protoc-gen-ts_proto
+    strategy: all
     out: generated
     opt:
       - unrecognizedEnum=false

--- a/libs/protos/package.json
+++ b/libs/protos/package.json
@@ -18,6 +18,9 @@
     "protobufjs": "7.2.3",
     "@scow/grpc-api": "workspace:*"
   },
+  "devDependencies": {
+    "ts-proto": "1.146.0"
+  },
   "keywords": [],
   "author": "",
   "license": "ISC"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -869,6 +869,10 @@ importers:
       protobufjs:
         specifier: 7.2.3
         version: 7.2.3
+    devDependencies:
+      ts-proto:
+        specifier: 1.146.0
+        version: 1.146.0
 
   libs/slurm:
     dependencies:
@@ -6104,6 +6108,10 @@ packages:
     resolution: {integrity: sha512-1cYJrqq9GezNFPsWTZpFut/d4CjpZqA0vhqDUPFWYKF1oIyBz5qnoYMzR+0C/T96t3ebLAC1SSnwrVOm5/j74A==}
     dev: true
 
+  /@types/object-hash@1.3.4:
+    resolution: {integrity: sha512-xFdpkAkikBgqBdG9vIlsqffDV8GpvnPEzs0IUtr1v3BEB97ijsFQ4RXVbUZwjFThhB4MDSTUfvmxUD5PGx0wXA==}
+    dev: true
+
   /@types/parse-json@4.0.0:
     resolution: {integrity: sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==}
 
@@ -7594,6 +7602,11 @@ packages:
   /caniuse-lite@1.0.30001431:
     resolution: {integrity: sha512-zBUoFU0ZcxpvSt9IU66dXVT/3ctO1cy4y9cscs1szkPlcWb6pasYM144GqrUygUbT+k7cmUCW61cvskjcv0enQ==}
 
+  /case-anything@2.1.10:
+    resolution: {integrity: sha512-JczJwVrCP0jPKh05McyVsuOg6AYosrB9XWZKbQzXeDAm2ClE/PJE/BcrrQrVyGYH7Jg8V/LDupmyL4kFlVsVFQ==}
+    engines: {node: '>=12.13'}
+    dev: true
+
   /ccount@1.1.0:
     resolution: {integrity: sha512-vlNK021QdI7PNeiUh/lKkC/mNHHfV0m/Ad5JoI0TYtlBnJAslM/JIkm/tGC88bkLIwO6OQ5uV6ztS6kVAtCDlg==}
     dev: false
@@ -8515,6 +8528,10 @@ packages:
       whatwg-url: 11.0.0
     dev: true
 
+  /dataloader@1.4.0:
+    resolution: {integrity: sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==}
+    dev: true
+
   /date-fns@2.29.3:
     resolution: {integrity: sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==}
     engines: {node: '>=0.11'}
@@ -8740,6 +8757,12 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /detect-libc@1.0.3:
+    resolution: {integrity: sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==}
+    engines: {node: '>=0.10'}
+    hasBin: true
+    dev: true
+
   /detect-libc@2.0.1:
     resolution: {integrity: sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==}
     engines: {node: '>=8'}
@@ -8925,6 +8948,12 @@ packages:
   /dotenv@16.0.3:
     resolution: {integrity: sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==}
     engines: {node: '>=12'}
+
+  /dprint-node@1.0.7:
+    resolution: {integrity: sha512-NTZOW9A7ipb0n7z7nC3wftvsbceircwVHSgzobJsEQa+7RnOMbhrfX5IflA6CtC4GA63DSAiHYXa4JKEy9F7cA==}
+    dependencies:
+      detect-libc: 1.0.3
+    dev: true
 
   /duplexer3@0.1.5:
     resolution: {integrity: sha512-1A8za6ws41LQgv9HrE/66jyC5yuSjQ3L/KOpFtoBilsAK2iA2wuS5rTt1OCzIvtS2V7nVmedsUU+DGRcjBmOYA==}
@@ -13442,6 +13471,11 @@ packages:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
+  /object-hash@1.3.1:
+    resolution: {integrity: sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA==}
+    engines: {node: '>= 0.10.0'}
+    dev: true
+
   /object-inspect@1.12.2:
     resolution: {integrity: sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==}
 
@@ -14686,6 +14720,26 @@ packages:
     dependencies:
       xtend: 4.0.2
     dev: false
+
+  /protobufjs@6.11.3:
+    resolution: {integrity: sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==}
+    hasBin: true
+    requiresBuild: true
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.4
+      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.0
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.0
+      '@types/long': 4.0.2
+      '@types/node': 18.16.0
+      long: 4.0.0
+    dev: true
 
   /protobufjs@7.2.3:
     resolution: {integrity: sha512-TtpvOqwB5Gdz/PQmOjgsrGH1nHjAQVCN7JG4A6r1sXRWESL5rNMAiRcBQlCAdKxZcAbstExQePYG8xof/JVRgg==}
@@ -17376,6 +17430,32 @@ packages:
       typescript: 5.0.4
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+    dev: true
+
+  /ts-poet@6.4.1:
+    resolution: {integrity: sha512-AjZEs4h2w4sDfwpHMxQKHrTlNh2wRbM5NRXmLz0RiH+yPGtSQFbe9hBpNocU8vqVNgfh0BIOiXR80xDz3kKxUQ==}
+    dependencies:
+      dprint-node: 1.0.7
+    dev: true
+
+  /ts-proto-descriptors@1.8.0:
+    resolution: {integrity: sha512-iV20plcI8+GRkeZIAygxOOH0p2xpOsKfw9kI1W20NCwawi1/4bG/YRd9rQY9XSJP+lD9j7XbSy3tFFuikfsljw==}
+    dependencies:
+      long: 4.0.0
+      protobufjs: 6.11.3
+    dev: true
+
+  /ts-proto@1.146.0:
+    resolution: {integrity: sha512-OyBZRjmqqw+aatLEUbRooWO6VKTtOLJQyaQFMciigEZPNgTsWtApqHpQDtqDMQFWEXhIARqEV+B7ZJx8cljhZA==}
+    hasBin: true
+    dependencies:
+      '@types/object-hash': 1.3.4
+      case-anything: 2.1.10
+      dataloader: 1.4.0
+      object-hash: 1.3.1
+      protobufjs: 6.11.3
+      ts-poet: 6.4.1
+      ts-proto-descriptors: 1.8.0
     dev: true
 
   /tsc-alias@1.8.5:


### PR DESCRIPTION
之前都是使用的ts-proto在buf的plugin云上托管的插件来生成proto文件（ https://github.com/stephenh/ts-proto#buf ），但是buf自己没有给生成插件加缓存，每次生成proto文件都需要去云上获取插件，一旦网络出现一点波动就出问题。

![image](https://user-images.githubusercontent.com/8363856/234814307-5fedbe60-8878-4741-9c0b-ea47c3d728f0.png)

这个PR在@scow/protos项目的本地安装了ts-proto，并使用本地的ts-proto进行pb文件的生成。