### PR TITLE
fix(web): 修复web项目浏览器刷新时页面布局闪动的问题

### DIFF
--- a/.changeset/fifty-adults-jam.md
+++ b/.changeset/fifty-adults-jam.md
@@ -1,0 +1,7 @@
+---
+"@scow/portal-web": patch
+"@scow/mis-web": patch
+"@scow/lib-web": patch
+---
+
+修复 web 项目第一次访问时页面布局混乱的问题

--- a/apps/mis-web/package.json
+++ b/apps/mis-web/package.json
@@ -54,7 +54,8 @@
     "simstate": "3.0.1",
     "styled-components": "5.3.10",
     "tslib": "2.5.0",
-    "typescript": "5.0.4"
+    "typescript": "5.0.4",
+    "@ant-design/cssinjs": "1.9.1"
   },
   "devDependencies": {
     "@ddadaal/next-typed-api-routes-cli": "0.6.1",

--- a/apps/mis-web/src/pages/_app.tsx
+++ b/apps/mis-web/src/pages/_app.tsx
@@ -15,7 +15,7 @@ import "antd/dist/reset.css";
 
 import { failEvent, fromApi } from "@ddadaal/next-typed-api-routes-runtime/lib/client";
 import { AntdConfigProvider } from "@scow/lib-web/build/layouts/AntdConfigProvider";
-import { DarkModeProvider } from "@scow/lib-web/build/layouts/darkMode";
+import { DarkModeCookie, DarkModeProvider, getDarkModeCookieValue } from "@scow/lib-web/build/layouts/darkMode";
 import { GlobalStyle } from "@scow/lib-web/build/layouts/globalStyle";
 import { getHostname } from "@scow/lib-web/build/utils/getHostname";
 import { useConstant } from "@scow/lib-web/build/utils/hooks";
@@ -83,6 +83,7 @@ interface ExtraProps {
   userInfo: User | undefined;
   primaryColor: string;
   footerText: string;
+  darkModeCookieValue: DarkModeCookie | undefined;
 }
 
 type Props = AppProps & { extra: ExtraProps };
@@ -126,8 +127,7 @@ function MyApp({ Component, pageProps, extra }: Props) {
         />
       </Head>
       <StoreProvider stores={[userStore, defaultClusterStore]}>
-        <DarkModeProvider>
-
+        <DarkModeProvider initial={extra.darkModeCookieValue}>
           <AntdConfigProvider color={primaryColor}>
             <FloatButtons />
             <GlobalStyle />
@@ -148,6 +148,7 @@ MyApp.getInitialProps = async (appContext: AppContext) => {
     userInfo: undefined,
     footerText: "",
     primaryColor: "",
+    darkModeCookieValue: getDarkModeCookieValue(appContext.ctx.req),
   };
 
   // This is called on server on first load, and on client on every page transition

--- a/apps/mis-web/src/pages/_document.tsx
+++ b/apps/mis-web/src/pages/_document.tsx
@@ -10,30 +10,42 @@
  * See the Mulan PSL v2 for more details.
  */
 
+import { createCache, extractStyle, StyleProvider } from "@ant-design/cssinjs";
 import Document from "next/document";
 import { ServerStyleSheet } from "styled-components";
+
 
 export default class MyDocument extends Document {
   static async getInitialProps(ctx) {
     const sheet = new ServerStyleSheet();
     const originalRenderPage = ctx.renderPage;
 
+    const antdCache = createCache();
+
     try {
       ctx.renderPage = () =>
         originalRenderPage({
           enhanceApp: (App) => (props) =>
-            sheet.collectStyles(<App {...props} />),
+            sheet.collectStyles(
+              <StyleProvider cache={antdCache}>
+                <App {...props} />,
+              </StyleProvider>,
+            ),
         });
 
       const initialProps = await Document.getInitialProps(ctx);
+      // Generate the css string for the styles coming from jss
+      const antdCss = extractStyle(antdCache);
       return {
         ...initialProps,
-        styles: [initialProps.styles, sheet.getStyleElement()],
+        styles: [
+          initialProps.styles,
+          sheet.getStyleElement(),
+          <style key="antd" dangerouslySetInnerHTML={{ __html: antdCss }} />,
+        ],
       };
     } finally {
       sheet.seal();
     }
   }
-
-  
 }

--- a/apps/portal-web/package.json
+++ b/apps/portal-web/package.json
@@ -42,6 +42,7 @@
     "@scow/protos": "workspace:*",
     "@scow/utils": "workspace:*",
     "@sinclair/typebox": "0.28.5",
+    "@ant-design/cssinjs": "1.9.1",
     "@uiw/codemirror-theme-github": "4.19.16",
     "@uiw/react-codemirror": "4.19.16",
     "antd": "5.4.5",

--- a/apps/portal-web/src/pages/_app.tsx
+++ b/apps/portal-web/src/pages/_app.tsx
@@ -15,7 +15,7 @@ import "antd/dist/reset.css";
 
 import { failEvent, fromApi } from "@ddadaal/next-typed-api-routes-runtime/lib/client";
 import { AntdConfigProvider } from "@scow/lib-web/build/layouts/AntdConfigProvider";
-import { DarkModeProvider } from "@scow/lib-web/build/layouts/darkMode";
+import { DarkModeCookie, DarkModeProvider, getDarkModeCookieValue } from "@scow/lib-web/build/layouts/darkMode";
 import { GlobalStyle } from "@scow/lib-web/build/layouts/globalStyle";
 import { getHostname } from "@scow/lib-web/build/utils/getHostname";
 import { useConstant } from "@scow/lib-web/build/utils/hooks";
@@ -87,6 +87,7 @@ interface ExtraProps {
   primaryColor: string;
   footerText: string;
   apps: App[];
+  darkModeCookieValue: DarkModeCookie | undefined;
 }
 
 type Props = AppProps & { extra: ExtraProps };
@@ -131,7 +132,7 @@ function MyApp({ Component, pageProps, extra }: Props) {
         />
       </Head>
       <StoreProvider stores={[userStore, defaultClusterStore, appsStore]}>
-        <DarkModeProvider>
+        <DarkModeProvider initial={extra.darkModeCookieValue}>
           <AntdConfigProvider color={primaryColor}>
             <FloatButtons />
             <GlobalStyle />
@@ -149,11 +150,13 @@ function MyApp({ Component, pageProps, extra }: Props) {
 }
 
 MyApp.getInitialProps = async (appContext: AppContext) => {
+
   const extra: ExtraProps = {
     userInfo: undefined,
     footerText: "",
     primaryColor: "",
     apps: [],
+    darkModeCookieValue: getDarkModeCookieValue(appContext.ctx.req),
   };
 
   // This is called on server on first load, and on client on every page transition

--- a/libs/web/package.json
+++ b/libs/web/package.json
@@ -17,7 +17,8 @@
   "dependencies": {
     "@scow/utils": "workspace:*",
     "zod": "3.21.4",
-    "mime-types": "2.1.35"
+    "mime-types": "2.1.35",
+    "nookies": "2.5.2"
   },
   "peerDependencies": {
     "antd": "5.4.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -979,6 +979,9 @@ importers:
       mime-types:
         specifier: 2.1.35
         version: registry.npmmirror.com/mime-types@2.1.35
+      nookies:
+        specifier: 2.5.2
+        version: 2.5.2
       zod:
         specifier: 3.21.4
         version: 3.21.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -350,6 +350,9 @@ importers:
 
   apps/mis-web:
     dependencies:
+      '@ant-design/cssinjs':
+        specifier: 1.9.1
+        version: 1.9.1(react-dom@18.2.0)(react@18.2.0)
       '@ant-design/icons':
         specifier: 5.0.1
         version: 5.0.1(react-dom@18.2.0)(react@18.2.0)
@@ -568,6 +571,9 @@ importers:
 
   apps/portal-web:
     dependencies:
+      '@ant-design/cssinjs':
+        specifier: 1.9.1
+        version: 1.9.1(react-dom@18.2.0)(react@18.2.0)
       '@ant-design/icons':
         specifier: 5.0.1
         version: 5.0.1(react-dom@18.2.0)(react@18.2.0)
@@ -758,8 +764,6 @@ importers:
       webpack:
         specifier: 5.80.0
         version: 5.80.0
-
-  deploy/local: {}
 
   deploy/vagrant: {}
 
@@ -1291,12 +1295,12 @@ packages:
       react: '>=16.0.0'
       react-dom: '>=16.0.0'
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.21.5
       '@emotion/hash': 0.8.0
       '@emotion/unitless': 0.7.5
       classnames: 2.3.2
       csstype: 3.1.1
-      rc-util: 5.29.2(react-dom@18.2.0)(react@18.2.0)
+      rc-util: 5.30.0(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       stylis: 4.1.3
@@ -2647,7 +2651,7 @@ packages:
     resolution: {integrity: sha512-mrzLkl6U9YLF8qpqI7TB82PESyEGjm/0Ly91jG575eVxMMlb8fYfOXFZIJ8XfLrJZQbm7dlKry2bJmXBUEkdFg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      regenerator-runtime: 0.13.10
+      regenerator-runtime: 0.13.11
 
   /@babel/runtime@7.21.0:
     resolution: {integrity: sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==}
@@ -2660,7 +2664,6 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       regenerator-runtime: 0.13.11
-    dev: false
 
   /@babel/template@7.18.10:
     resolution: {integrity: sha512-TI+rCtooWHr3QJ27kJxfjutghu44DLnasDMwpDqCXVTal9RLp3RSYNh4NdBrRP2cQAoG9A8juOQl6P6oZG4JxA==}
@@ -4482,7 +4485,7 @@ packages:
   /@manypkg/find-root@1.1.0:
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.21.5
       '@types/node': 12.20.55
       find-up: 4.1.0
       fs-extra: 8.1.0
@@ -5533,7 +5536,7 @@ packages:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.21.5
       rc-util: 5.30.0(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -5542,7 +5545,7 @@ packages:
     resolution: {integrity: sha512-9N8nRk0oKj1qJzANKl+n9eNSMUGsZtjwNuDCiZ/KA+dt1fE3zq5x2XxclRcAbOIXnZcJ53ozP2Pa60gyELXagA==}
     engines: {node: '>=8.x'}
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.21.5
 
   /@rc-component/mutate-observer@1.0.0(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-okqRJSfNisXdI6CUeOLZC5ukBW/8kir2Ii4PJiKpUt+3+uS7dxwJUMxsUZquxA1rQuL8YcEmKVp/TCnR+yUdZA==}
@@ -5564,7 +5567,7 @@ packages:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.21.5
       classnames: 2.3.2
       rc-util: 5.30.0(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
@@ -10651,7 +10654,7 @@ packages:
   /history@4.10.1:
     resolution: {integrity: sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==}
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.21.5
       loose-envify: 1.4.0
       resolve-pathname: 3.0.0
       tiny-invariant: 1.3.1
@@ -15008,7 +15011,7 @@ packages:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.21.5
       classnames: 2.3.2
       dom-align: 1.12.4
       lodash: 4.17.21
@@ -15214,7 +15217,7 @@ packages:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.21.5
       classnames: 2.3.2
       rc-resize-observer: 1.3.1(react-dom@18.2.0)(react@18.2.0)
       rc-util: 5.30.0(react-dom@18.2.0)(react@18.2.0)
@@ -15460,7 +15463,7 @@ packages:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.21.5
       classnames: 2.3.2
       rc-align: 4.0.12(react-dom@18.2.0)(react@18.2.0)
       rc-motion: 2.7.3(react-dom@18.2.0)(react@18.2.0)
@@ -15486,7 +15489,7 @@ packages:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
     dependencies:
-      '@babel/runtime': 7.20.1
+      '@babel/runtime': 7.21.5
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       react-is: 16.13.1
@@ -15508,7 +15511,7 @@ packages:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.21.5
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       react-is: 16.13.1
@@ -15520,7 +15523,7 @@ packages:
       react: '*'
       react-dom: '*'
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.21.5
       classnames: 2.3.2
       rc-resize-observer: 1.3.1(react-dom@18.2.0)(react@18.2.0)
       rc-util: 5.30.0(react-dom@18.2.0)(react@18.2.0)
@@ -15628,7 +15631,7 @@ packages:
       react: ^16.6.0 || ^17.0.0 || ^18.0.0
       react-dom: ^16.6.0 || ^17.0.0 || ^18.0.0
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.21.5
       invariant: 2.2.4
       prop-types: 15.8.1
       react: 17.0.2
@@ -15674,7 +15677,7 @@ packages:
       react-loadable: '*'
       webpack: '>=4.41.1 || 5.x'
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.21.5
       react-loadable: /@docusaurus/react-loadable@5.5.2(react@17.0.2)
       webpack: 5.80.0
     dev: false
@@ -15685,7 +15688,7 @@ packages:
       react: '>=15'
       react-router: '>=5'
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.21.5
       react: 17.0.2
       react-router: 5.3.4(react@17.0.2)
     dev: false
@@ -15695,7 +15698,7 @@ packages:
     peerDependencies:
       react: '>=15'
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.21.5
       history: 4.10.1
       loose-envify: 1.4.0
       prop-types: 15.8.1
@@ -15710,7 +15713,7 @@ packages:
     peerDependencies:
       react: '>=15'
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.21.5
       history: 4.10.1
       hoist-non-react-statics: 3.3.2
       loose-envify: 1.4.0
@@ -15728,7 +15731,7 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.21.5
       react: 17.0.2
       use-composed-ref: 1.3.0(react@17.0.2)
       use-latest: 1.2.1(@types/react@18.0.18)(react@17.0.2)
@@ -15902,16 +15905,13 @@ packages:
     resolution: {integrity: sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==}
     dev: false
 
-  /regenerator-runtime@0.13.10:
-    resolution: {integrity: sha512-KepLsg4dU12hryUO7bp/axHAKvwGOCV0sGloQtpagJ12ai+ojVDqkeGSiRX1zlq+kjIMZ1t7gpze+26QqtdGqw==}
-
   /regenerator-runtime@0.13.11:
     resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
 
   /regenerator-transform@0.15.0:
     resolution: {integrity: sha512-LsrGtPmbYg19bcPHwdtmXwbW+TqNvtY4riE3P83foeHRroMbH6/2ddFBfab3t7kbzc7v7p4wbkIecHImqt0QNg==}
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.21.5
     dev: false
 
   /regexp.prototype.flags@1.4.3:


### PR DESCRIPTION
之前，每次第一次加载页面（例如刷新浏览器）时，页面布局和黑暗模式会混乱：

![pre-style-fix](https://user-images.githubusercontent.com/8363856/235686960-00d81d3f-869f-4867-a226-c3609eaf8bf4.gif)

修复后：

![post-style-fix](https://user-images.githubusercontent.com/8363856/235688642-2ef37434-2f0c-4cb4-964e-3baa4c04b90f.gif)


布局闪动（称为layout shift）是因为HTML是在浏览器端刷新好了发到了客户端，但是样式不是在服务器端渲染的而是在客户端渲染的。当HTML发到客户端、浏览器开始渲染HTML时并没有样式，故一开始就会出现只有HTML没有样式的问题。这个问题的解决参考了：https://github.com/ant-design/ant-design/issues/40610，在Custom Document中增加了在服务器端提取样式的代码。

黑暗模式是另一个问题。之前，用户的黑暗模式的选择是存放在local storage里的，服务器无法访问，故服务器在渲染时只能用默认的黑色或者白色渲染，然后把渲染好的样式发送到客户端，然后客户端再读取用户的选择，再调整样式，这对选择使用另一种模式的用户都会出现先出现了黑色（白色）的样式（服务器端渲染的），然后在客户端换成了另一个（客户端渲染的）。这个PR的解决方案是把用户的黑暗模式的选择存放到cookie（scow-dark）中，这样服务器端就可以知道用户的选项，从而在服务器端渲染时就使用客户端的选择渲染样式。