### PR TITLE
feat: 集群和应用配置文件可放在子文件夹中

### DIFF
--- a/.changeset/modern-scissors-kneel.md
+++ b/.changeset/modern-scissors-kneel.md
@@ -1,0 +1,7 @@
+---
+"@scow/lib-config": patch
+"@scow/config": patch
+"@scow/docs": patch
+---
+
+集群和应用配置文件可放在子文件夹中

--- a/docs/docs/deploy/config/cluster-config.md
+++ b/docs/docs/deploy/config/cluster-config.md
@@ -5,9 +5,9 @@ title: 集群配置文件
 
 # 集群配置文件
 
-对于每个需要进行部署的集群，需要在`config/clusters`目录下创建一个`{集群ID}.yml`文件，并编写集群的信息。当您的集群信息修改后，您需要同时手动修改对应的集群配置文件。
+对于每个需要进行部署的集群，需要在`config/clusters`目录下创建一个`{集群ID}/config.yml`（或`{集群ID}.yml`）文件，并编写集群的信息。当您的集群信息修改后，您需要同时手动修改对应的集群配置文件。
 
-```yaml title="config/clusters/hpc01.yml"
+```yaml title="config/clusters/hpc01/config.yml"
 # 此文件为hpc01.yml，对应的集群ID为hpc01
 
 # 集群显示名称

--- a/docs/docs/deploy/config/portal/apps/apps/jupyter.md
+++ b/docs/docs/deploy/config/portal/apps/apps/jupyter.md
@@ -13,9 +13,9 @@ title: Jupyter
 
 ## 配置文件
 
-创建`config/apps`目录，在里面创建`jupyter.yml`文件，其内容如下：
+创建`config/apps`目录，在里面创建`jupyter/config.yml`文件，其内容如下：
 
-```yaml title="config/apps/jupyter.yml"
+```yaml title="config/apps/jupyter/config.yml"
 # 这个应用的ID
 id: jupyter
 

--- a/docs/docs/deploy/config/portal/apps/apps/vscode.md
+++ b/docs/docs/deploy/config/portal/apps/apps/vscode.md
@@ -13,9 +13,9 @@ title: VSCode
 
 ## 配置文件
 
-创建`config/apps`目录，在里面创建`vscode.yml`文件，其内容如下：
+创建`config/apps`目录，在里面创建`vscode/config.yml`文件，其内容如下：
 
-```yaml title="config/apps/vscode.yml"
+```yaml title="config/apps/vscode/config.yml"
 # 这个应用的ID
 id: vscode
 

--- a/docs/docs/deploy/config/portal/apps/configure-vnc-app.md
+++ b/docs/docs/deploy/config/portal/apps/configure-vnc-app.md
@@ -16,9 +16,9 @@ title: 配置桌面类应用
 
 下面以使用emacs为示例介绍如何配置桌面类应用。
 
-创建`config/apps`目录，在里面创建`emacs.yml`文件，其内容如下：
+创建`config/apps`目录，在里面创建`emacs/config.yml`或者`emacs.yml`文件，其内容如下：
 
-```yaml title="config/apps/emacs.yml"
+```yaml title="config/apps/emacs/config.yml"
 # 这个应用的ID
 id: emacs
 

--- a/docs/docs/deploy/config/portal/apps/configure-web-app.md
+++ b/docs/docs/deploy/config/portal/apps/configure-web-app.md
@@ -13,9 +13,9 @@ title: 配置Web类应用
 
 下面以使用[coder/code-server](https://github.com/coder/code-server)启动VSCode的配置为例来讲解如何配置一个服务器类应用。
 
-创建`config/apps`目录，在里面创建`vscode.yml`文件，其内容如下：
+创建`config/apps`目录，在里面创建`vscode/config.yml`或`vscode.yml`文件，其内容如下：
 
-```yaml title="config/apps/vscode.yml"
+```yaml title="config/apps/vscode/config.yml"
 # 这个应用的ID
 id: vscode
 

--- a/libs/config/src/app.ts
+++ b/libs/config/src/app.ts
@@ -88,9 +88,14 @@ export type AppConfigSchema = Static<typeof AppConfigSchema>;
 
 export const APP_CONFIG_BASE_PATH = "apps";
 
-export const getAppConfigs: GetConfigFn<Record<string, AppConfigSchema>> = (baseConfigPath) => {
+export const getAppConfigs: GetConfigFn<Record<string, AppConfigSchema>> = (baseConfigPath, logger) => {
 
-  const appsConfig = getDirConfig(AppConfigSchema, APP_CONFIG_BASE_PATH, baseConfigPath ?? DEFAULT_CONFIG_BASE_PATH);
+  const appsConfig = getDirConfig(
+    AppConfigSchema,
+    APP_CONFIG_BASE_PATH,
+    baseConfigPath ?? DEFAULT_CONFIG_BASE_PATH,
+    logger,
+  );
 
   Object.entries(appsConfig).forEach(([id, config]) => {
     if (!config[config.type]) {

--- a/libs/config/src/cluster.ts
+++ b/libs/config/src/cluster.ts
@@ -47,10 +47,14 @@ export const ClusterConfigSchema = Type.Object({
 export type ClusterConfigSchema = Static<typeof ClusterConfigSchema>;
 
 
-export const getClusterConfigs: GetConfigFn<Record<string, ClusterConfigSchema>> = (baseConfigPath) => {
+export const getClusterConfigs: GetConfigFn<Record<string, ClusterConfigSchema>> = (baseConfigPath, logger) => {
 
-  const config = getDirConfig(ClusterConfigSchema,
-    CLUSTER_CONFIG_BASE_PATH, baseConfigPath ?? DEFAULT_CONFIG_BASE_PATH);
+  const config = getDirConfig(
+    ClusterConfigSchema,
+    CLUSTER_CONFIG_BASE_PATH,
+    baseConfigPath ?? DEFAULT_CONFIG_BASE_PATH,
+    logger,
+  );
 
   Object.entries(config).forEach(([id, c]) => {
     if (!c[c.scheduler]) {

--- a/libs/libconfig/src/fileConfig.ts
+++ b/libs/libconfig/src/fileConfig.ts
@@ -52,6 +52,24 @@ export function getConfig<T extends TSchema>(
   return result;
 }
 
+export class ConfigFileSchemaError extends Error {
+  constructor(
+    public readonly path: string,
+    public readonly cause: Error,
+  ) {
+    super(`Error reading config file ${path}: ${cause.message}`, { cause });
+  }
+}
+
+export class ConfigFileNotExistError extends Error {
+  constructor(
+    public readonly filename: string,
+    public readonly basePath: string,
+  ) {
+    super(`config ${filename} doesn't exist in ${basePath}`);
+  }
+}
+
 /**
  * 从文件中读取配置。
  * 读取优先级：yml -> yaml -> json
@@ -72,17 +90,34 @@ export function getConfigFromFile<T extends TSchema>(
       const content = fs.readFileSync(path, { encoding: "utf8" });
       const obj = validateObject(schema, loader(content));
       if (obj instanceof Error) {
-        throw new Error(`Error reading config file ${path}: ${obj.message}`);
+        throw new ConfigFileSchemaError(path, obj);
       }
       return obj;
     }
   }
 
-  throw new Error(`config ${filename} doesn't exist in ${basePath}`);
+  throw new ConfigFileNotExistError(filename, basePath);
 }
 
+/**
+ * 从目录中读取配置。
+ * 返回的对象为配置ID->配置对象的映射
+ * 配置ID为目录下的配置文件名（不包括扩展名）、或者包含config.yaml/yml/json的目录名。
+ * 当目录下同时存在文件和目录时，目录下的config配置文件优先。
+ *
+ * 例如，当目录中有文件a.yml, b.yaml, c/config.json, c.yaml时，返回的对象为 {a: ..., b: ..., c: c/config.json的配置}
+ *
+ * 读取优先级：yml -> yaml -> json
+ * 文件名作为配置ID，不要带扩展名
+ *
+ * @param schema 配置文件的JSON Schema
+ * @param dir 配置文件所在的目录
+ * @param basePath 配置目录
+ * @param logger 日志对象
+ * @returns 配置文件的ID到配置对象的映射
+ */
 export function getDirConfig<T extends TSchema>(
-  schema: T, dir: string, basePath: string,
+  schema: T, dir: string, basePath: string, logger?: Logger,
 ): Record<string, Static<T>> {
   const configDir = join(basePath, dir);
 
@@ -92,28 +127,42 @@ export function getDirConfig<T extends TSchema>(
 
   const files = fs.readdirSync(configDir);
 
-  return files.reduce((m, filename) => {
+  const result = {};
 
-    const ext = extname(filename).substring(1);
+  for (const filename of files) {
 
-    if (!(ext in parsers)) { return m; }
+    const fullPath = join(configDir, filename);
 
-    const configFilePath = join(configDir, filename);
+    const stat = fs.statSync(fullPath);
 
-    const content = fs.readFileSync(configFilePath, { encoding: "utf8" });
+    if (stat.isDirectory()) {
+      try {
+        const subDirConfigFilePath = join(dir, filename, "config");
+        const config = getConfigFromFile(schema, subDirConfigFilePath, basePath);
+        logger?.debug("Read dir config %s of id %s from %s", dir, filename, subDirConfigFilePath);
+        result[filename] = config;
+        continue;
+      } catch (e) {
+        if (!(e instanceof ConfigFileNotExistError)) {
+          throw e;
+        }
+      }
+    } else {
 
-    const config = validateObject(schema, parsers[ext](content));
+      const id = basename(filename, extname(filename));
 
-    if (config instanceof Error) {
-      throw new Error(`Error reading config file ${configFilePath}: ${config.message}`);
+      if (id in result) {
+        continue;
+      }
+
+      logger?.debug("Read dir config %s of id %s from %s", dir, id, fullPath);
+      const config = getConfig(schema, fullPath);
+      result[id] = config;
     }
 
-    if (config) {
-      m[basename(filename, "." + ext)] = config;
-    }
+  }
 
-    return m;
-  }, {});
+  return result;
 }
 
 export type GetConfigFn<T> = (baseConfigPath?: string, logger?: Logger) => T;


### PR DESCRIPTION
现在集群配置文件只能读clusters/{clusterId}.yaml，但是应该允许读clusters/{clusterId}/config.yaml。同样，应用程序除了apps/{appId}.yaml，还应该允许读apps/{appId}/config.yaml。如果两个文件同时存在，优先读后者。

这是为了同时为了兼容之前的配置以及未来的扩展性，例如

- 支持只有某个集群能用的应用配置
- 给交互式应用增加图标文件