### PR TITLE
feat(auth): 模仿用户功能

### DIFF
--- a/.changeset/lemon-spoons-allow.md
+++ b/.changeset/lemon-spoons-allow.md
@@ -1,0 +1,7 @@
+---
+"@scow/auth": patch
+"@scow/cli": patch
+"@scow/docs": patch
+---
+
+认证系统支持测试用户功能

--- a/apps/auth/src/auth/cacheInfo.ts
+++ b/apps/auth/src/auth/cacheInfo.ts
@@ -16,13 +16,13 @@ import { FastifyRequest } from "fastify";
 import { authConfig, getAuthConfig } from "src/config/auth";
 import { config } from "src/config/env";
 
-const getTestUsers = () => {
+const getMockUsers = () => {
 
-  const configTestUsers = getAuthConfig();
+  const configMockUsers = getAuthConfig();
 
-  const envTestUsers = parseKeyValue(config.TEST_USERS);
+  const envMockUsers = parseKeyValue(config.MOCK_USERS);
 
-  return { ...configTestUsers.testUsers, ...envTestUsers };
+  return { ...configMockUsers.mockUsers, ...envMockUsers };
 };
 
 /**
@@ -30,11 +30,11 @@ const getTestUsers = () => {
  */
 export async function cacheInfo(identityId: string, req: FastifyRequest): Promise<string> {
 
-  const testUsers = getTestUsers();
+  const mockUsers = getMockUsers();
 
-  if (testUsers[identityId]) {
-    req.log.info("Rewrite test user %s to user %s", identityId, testUsers[identityId]);
-    identityId = testUsers[identityId];
+  if (mockUsers[identityId]) {
+    req.log.info("Rewrite mock user %s to user %s", identityId, mockUsers[identityId]);
+    identityId = mockUsers[identityId];
   }
 
   const token = randomUUID();

--- a/apps/auth/src/auth/cacheInfo.ts
+++ b/apps/auth/src/auth/cacheInfo.ts
@@ -10,23 +10,28 @@
  * See the Mulan PSL v2 for more details.
  */
 
+import { parseKeyValue } from "@scow/lib-config";
 import { randomUUID } from "crypto";
 import { FastifyRequest } from "fastify";
-import { authConfig } from "src/config/auth";
+import { authConfig, getAuthConfig } from "src/config/auth";
 import { config } from "src/config/env";
 
-const testUsers: Record<string, string> = config.TEST_USERS.split(",").reduce((prev, curr) => {
-  const [from, to] = curr.split("=");
-  if (from && to) {
-    prev[from.trim()] = to.trim();
-  }
-  return prev;
-}, {});
+const getTestUsers = () => {
+
+  const configTestUsers = getAuthConfig();
+
+  const envTestUsers = parseKeyValue(config.TEST_USERS);
+
+  return { ...configTestUsers.testUsers, ...envTestUsers };
+};
 
 /**
  * 生成一个UUID，将此UUID以及对应的用户identityId保存到redis中，并返回token
  */
 export async function cacheInfo(identityId: string, req: FastifyRequest): Promise<string> {
+
+  const testUsers = getTestUsers();
+
   if (testUsers[identityId]) {
     req.log.info("Rewrite test user %s to user %s", identityId, testUsers[identityId]);
     identityId = testUsers[identityId];

--- a/apps/auth/src/config/auth.ts
+++ b/apps/auth/src/config/auth.ts
@@ -129,6 +129,10 @@ export const AuthConfigSchema = Type.Object({
   ldap: Type.Optional(LdapConfigSchema),
   ssh: Type.Optional(SshConfigSchema),
   allowedCallbackHostnames: Type.Array(Type.String({ description: "信任的回调域名" }), { default: []}),
+  testUsers: Type.Optional(Type.Record(
+    Type.String(), Type.String(),
+    { description: "测试用户，如果登录的用户的ID为某个key，则改为以对应的value的用户登录。修改此配置无需重启认证系统" },
+  )),
   captcha: Type.Object({
     enabled: Type.Boolean({ description: "验证码功能是否启用", default: false }),
   }, { default: {} }),
@@ -138,10 +142,10 @@ export type AuthConfigSchema = Static<typeof AuthConfigSchema>;
 
 export const AUTH_CONFIG_FILE = "auth";
 
-export const authConfig = getConfigFromFile(AuthConfigSchema, AUTH_CONFIG_FILE, DEFAULT_CONFIG_BASE_PATH);
+export const getAuthConfig = () => {
+  const config = getConfigFromFile(AuthConfigSchema, AUTH_CONFIG_FILE, DEFAULT_CONFIG_BASE_PATH);
 
-// validate the config
-function validateConfig(config: AuthConfigSchema) {
+  // validate
   if (config.authType === "ldap") {
     if (!config.ldap) {
       throw new Error("authType is set to ldap, but ldap config is not set");
@@ -169,8 +173,10 @@ function validateConfig(config: AuthConfigSchema) {
   }
 
   if (config.authType === AuthType.ssh && !config.ssh) {
-    throw new Error("authType is set to ldap, but ldap config is not set");
+    throw new Error("authType is set to ssh, but ssh config is not set");
   }
-}
 
-validateConfig(authConfig);
+  return config;
+};
+
+export const authConfig = getAuthConfig();

--- a/apps/auth/src/config/auth.ts
+++ b/apps/auth/src/config/auth.ts
@@ -129,9 +129,9 @@ export const AuthConfigSchema = Type.Object({
   ldap: Type.Optional(LdapConfigSchema),
   ssh: Type.Optional(SshConfigSchema),
   allowedCallbackHostnames: Type.Array(Type.String({ description: "信任的回调域名" }), { default: []}),
-  testUsers: Type.Optional(Type.Record(
+  mockUsers: Type.Optional(Type.Record(
     Type.String(), Type.String(),
-    { description: "测试用户，如果登录的用户的ID为某个key，则改为以对应的value的用户登录。修改此配置无需重启认证系统" },
+    { description: "模仿用户，如果登录的用户的ID为某个key，则改为以对应的value的用户登录。修改此配置无需重启认证系统" },
   )),
   captcha: Type.Object({
     enabled: Type.Boolean({ description: "验证码功能是否启用", default: false }),

--- a/apps/auth/src/config/env.ts
+++ b/apps/auth/src/config/env.ts
@@ -36,7 +36,10 @@ export const config = envConfig({
 
   AUTH_TYPE: str({ desc: "认证类型。将会覆写配置文件", choices: Object.values(AuthType), default: undefined }),
 
-  TEST_USERS: str({ desc: "测试用户，如果这些用户登录，将其ID改为另一个ID。格式：原用户ID=新用户ID,原用户ID=新用户ID。", default: "" }),
+  TEST_USERS: str({
+    desc: "测试用户，如果这些用户登录，将其ID改为另一个ID。格式：原用户ID=新用户ID,原用户ID=新用户ID。将会添加到配置文件testUsers的末尾",
+    default: "",
+  }),
   SSH_PRIVATE_KEY_PATH: str({ desc: "SSH私钥路径", default: join(homedir(), ".ssh", "id_rsa") }),
   SSH_PUBLIC_KEY_PATH: str({ desc: "SSH公钥路径", default: join(homedir(), ".ssh", "id_rsa.pub") }),
 

--- a/apps/auth/src/config/env.ts
+++ b/apps/auth/src/config/env.ts
@@ -36,8 +36,8 @@ export const config = envConfig({
 
   AUTH_TYPE: str({ desc: "认证类型。将会覆写配置文件", choices: Object.values(AuthType), default: undefined }),
 
-  TEST_USERS: str({
-    desc: "测试用户，如果这些用户登录，将其ID改为另一个ID。格式：原用户ID=新用户ID,原用户ID=新用户ID。将会添加到配置文件testUsers的末尾",
+  MOCK_USERS: str({
+    desc: "模仿用户，如果这些用户登录，将其ID改为另一个ID。格式：原用户ID=新用户ID,原用户ID=新用户ID。将会和配置文件mockUsers对象合并",
     default: "",
   }),
   SSH_PRIVATE_KEY_PATH: str({ desc: "SSH私钥路径", default: join(homedir(), ".ssh", "id_rsa") }),

--- a/apps/cli/assets/config/auth.yml
+++ b/apps/cli/assets/config/auth.yml
@@ -99,7 +99,7 @@ authType: ssh
 # tokenTimeoutSeconds: 3600
 
 # 测试用户，如果这些用户登录，将其ID改为另一个ID。修改此配置无需重启认证系统
-# testUsers:
+# mockUsers:
 #   fromUserId1: toUserId1
 #   fromUser2: toUser2
 

--- a/apps/cli/assets/config/auth.yml
+++ b/apps/cli/assets/config/auth.yml
@@ -1,7 +1,114 @@
 # 使用认证类型为ssh
 authType: ssh
 
+# SSH认证系统配置
+# ssh:
+  # 以哪个节点为认证用户的基础。如果不设置则为第一个集群的第一个登录节点
+  # baseNode: login01
+
+# 指定使用认证类型为LDAP
+# authType: ldap
+
+# 在此部分输入LDAP的配置
+# ldap:
+#   # LDAP服务器地址。必填
+#   url: ldap://LDAP服务器地址
+
+#   # 进行LDAP操作的用户DN。默认为空
+#   # bindDN: ""
+#   # 进行LDAP操作的用户密码。默认为空
+#   # bindPassword: ""
+
+#   # 在哪个节点下搜索要登录的用户。必填。
+#   searchBase: ""
+#   # 搜索登录用户时的筛选器。必填
+#   userFilter: "(uid=*)"
+
+#   # 属性映射
+#   attrs:
+#     # LDAP中对应用户ID的属性名
+#     uid: uid
+
+#     # LDAP对应用户姓名的属性名
+#     # 此字段用于
+#     # 1. 登录时显示为用户的姓名
+#     # 2. 创建用户的时候把姓名信息填入LDAP
+#     #
+#     # 如果不设置此字段，那么
+#     # 1. 用户显示的姓名为用户的ID
+#     # 2. 创建用户时姓名信息填入LDAP
+#     # name: cn
+
+#     # LDAP中对应用户的邮箱的属性名。可不填。此字段只用于在创建用户的时候把邮件信息填入LDAP。
+#     # mail: mail
+
+#   # 添加用户的相关配置。可不填，不填的话SCOW不支持创建用户。
+#   addUser:
+#     # 增加用户节点时，把用户增加到哪个节点下
+#     userBase: "ou=People,ou={ou},o={dn}"
+
+#     # 用户的homeDirectory值。使用{{ userId }}代替新用户的用户名。默认如下
+#     homeDir: /nfs/{{ userId }}
+
+#     # LDAP增加用户时，新用户节点的DN中，第一个路径的属性的key。
+#     # 新用户节点的DN为{userIdDnKey}={用户ID},{userBase}
+#     # 如果不填写，则使用ldap.attrs.uid的值
+#     # userIdDnKey: uid
+
+#     # 如何确定新用户的组。可取的值包括：
+#     # newGroupPerUser: 给每个用户创建新的组
+#     # oneGroupForAllUsers: 不创建新的组，给所有用户设定一个固定的组
+#     groupStrategy: newGroupPerUser
+
+#     newGroupPerUser:
+#       # 用户对应的新组应该加在哪个节点下
+#       groupBase: "ou=Group,ou={ou},o={dn}"
+
+#       # 新的组节点的DN中，第一个路径的属性的key。
+#       # 新的组节点的DN为{groupIdDnKey}={用户ID},{groupBase}
+#       # 如果不填写，则使用ldap.attrs.uid的值
+#       # groupIdDnKey: uid
+
+#       # 组的节点应该额外拥有的属性值。可以使用 {{ 用户节点的属性key }}来使用用户节点的属性值
+#       # extraProps:
+#       #   greetings: hello this is group {{ userId }}
+
+#     # 如果groupStrategy设置为oneGroupForAllUsers，那么必须设置此属性
+#     oneGroupForAllUsers:
+#       # 用户的gidNumber属性的值
+#       gidNumber: 5000
+
+#     # 是否应该把新用户加到哪个LDAP组下。如果不填，则不加
+#     # addUserToLdapGroup: group
+
+#     # uid从多少开始。生成的用户的uid等于此值加上用户账户中创建的用户ID
+#     # 默认如下
+#     # uidStart: 66000
+
+#     # 用户项除了id、name和mail，还应该添加哪些属性。类型是个dict
+#     # 如果这里出现了名为uid, name或email的属性，这里的值将替代用户输入的值。
+#     # 属性值支持使用 {{ LDAP属性值key }} 格式来使用用户填入的值。
+#     # 例如：sn: "{{ cn }}"，那么添加时将会增加一个sn属性，其值为cn的属性，即为用户输入的姓名
+#     # extraProps:
+#     #   key: value
+
+# 存放token的redis地址。默认为redis:6379
+# redisUrl: redis:6379
+
+# token未使用的超时时间，单位秒。默认为3600秒（1小时）
+# tokenTimeoutSeconds: 3600
+
+# 测试用户，如果这些用户登录，将其ID改为另一个ID。修改此配置无需重启认证系统
+# testUsers:
+#   fromUserId1: toUserId1
+#   fromUser2: toUser2
+
 # 验证码配置
-#captcha:
+# captcha:
   # 是否开启验证码。默认为false
-  #enabled: false
+  # enabled: false
+
+# 登录允许回调主机名
+# allowedCallbackHostnames:
+#   - localhost
+#   - another.com

--- a/docs/docs/deploy/config/auth/config.md
+++ b/docs/docs/deploy/config/auth/config.md
@@ -28,3 +28,14 @@ allowedCallbackHostnames：
 启用登录验证码时UI界面：
 
 ![验证码登录UI](./%E9%AA%8C%E8%AF%81%E7%A0%81%E7%99%BB%E5%BD%95UI.png)
+
+## 测试用户
+
+如果登录用户的ID为某个key，那么实际将会以其对应的value的用户登录。修改此配置无需重启认证系统。
+
+```yaml title="config/auth.yml"
+testUsers:
+  # 当登录用户的ID为fromUser1，实际上以toUser1登录
+  fromUser1: toUser1
+  fromUser2: toUser2
+```

--- a/docs/docs/deploy/config/auth/config.md
+++ b/docs/docs/deploy/config/auth/config.md
@@ -29,12 +29,12 @@ allowedCallbackHostnames：
 
 ![验证码登录UI](./%E9%AA%8C%E8%AF%81%E7%A0%81%E7%99%BB%E5%BD%95UI.png)
 
-## 测试用户
+## 模仿用户
 
 如果登录用户的ID为某个key，那么实际将会以其对应的value的用户登录。修改此配置无需重启认证系统。
 
 ```yaml title="config/auth.yml"
-testUsers:
+mockUsers:
   # 当登录用户的ID为fromUser1，实际上以toUser1登录
   fromUser1: toUser1
   fromUser2: toUser2

--- a/docs/docs/refs/env/auth.md
+++ b/docs/docs/refs/env/auth.md
@@ -20,7 +20,7 @@ title: "auth"
 |`LOG_LEVEL`|字符串|日志等级|info|
 |`BASE_PATH`|字符串|认证系统部署地址的base path|/|
 |`AUTH_TYPE`|字符串|认证类型。将会覆写配置文件<br/>可选项：ldap,ssh|不设置|
-|`TEST_USERS`|字符串|测试用户，如果这些用户登录，将其ID改为另一个ID。格式：原用户ID=新用户ID,原用户ID=新用户ID。||
+|`MOCK_USERS`|字符串|模仿用户，如果这些用户登录，将其ID改为另一个ID。格式：原用户ID=新用户ID,原用户ID=新用户ID。||
 
 <!-- ENV TABLE END -->
 


### PR DESCRIPTION
认证系统配置增加模仿用户功能（mockUsers）功能。当登录用户的ID为某个模仿用户时，将登录用户改为另一个用户。

修改此配置无需重启认证系统。

这允许管理员作为任何用户身份登录SCOW。

```yaml
mockUsers:
    fromUser1: toUser1
```

此PR同时将认证系统的模板写到了cli的初始认证系统配置文件中。