### PR TITLE
feat(auth): 认证系统/validateToken API修改为/public/validateToken

### DIFF
--- a/.changeset/fast-flowers-begin.md
+++ b/.changeset/fast-flowers-begin.md
@@ -1,0 +1,7 @@
+---
+"@scow/auth": minor
+"@scow/lib-auth": minor
+"@scow/docs": minor
+---
+
+认证系统 GET /validateToken 改为 GET /public/validateToken

--- a/apps/auth/src/routes/validateToken.ts
+++ b/apps/auth/src/routes/validateToken.ts
@@ -43,7 +43,7 @@ export const validateTokenRoute = fp(async (f) => {
     Querystring: Static<typeof QuerystringSchema>
     Responses: Static<typeof ResponsesSchema>,
   }>(
-    "/validateToken",
+    "/public/validateToken",
     {
       schema: {
         querystring: QuerystringSchema,

--- a/docs/docs/integration/auth/impl.md
+++ b/docs/docs/integration/auth/impl.md
@@ -44,7 +44,7 @@ SCOW中使用`identityId`标识一个用户，并同时使用此`identityId`作�
 
 如果您在后端使用类似OAuth2的认证系统，这些认证系统登录完成后会给一个token用于跟踪用户状态并重定向到您指定的回调地址。对于这些系统，您应该自己实现一个单独的回调地址（且这些回调地址的URL必须以`/public`为前缀以使用户可以直接访问），在这些地址的处理函数中获取认证系统给予的token，并使用token进行后续的处理（例如生成自己的token，将这些token映射到用户等）。处理完成后，再回调到`callbackUrl`指定的URL。
 
-### GET /validateToken
+### GET /public/validateToken
 
 验证token，返回对应的用户ID。SCOW将会在每次需要验证的请求发生时，使用登录时获取的token请求此API，所以请保证此API的性能。
 

--- a/libs/auth/src/validateToken.ts
+++ b/libs/auth/src/validateToken.ts
@@ -17,7 +17,7 @@ export interface UserInfo {
 }
 
 export async function validateToken(authUrl: string, token: string, logger?: Logger): Promise<UserInfo | undefined> {
-  const resp = await fetch(authUrl + "/validateToken?token=" + token, {
+  const resp = await fetch(authUrl + "/public/validateToken?token=" + token, {
     method: "GET",
   });
 

--- a/libs/auth/tests/validateToken.test.ts
+++ b/libs/auth/tests/validateToken.test.ts
@@ -31,7 +31,7 @@ it("raises correct request", async () => {
   await validateToken(authUrl, validToken);
 
   expect(fetch).toHaveBeenCalledWith(
-    authUrl + "/validateToken?token=" + validToken,
+    authUrl + "/public/validateToken?token=" + validToken,
     { method: "GET" },
   );
 });


### PR DESCRIPTION
将认证系统的[GET /validateToken]增加public前缀，使任何人可以访问此API。主要用于方便第三方开发。

这个API是根据token访问用户信息，如果一个用户已经有了token，那么它本来就应该可以访问用户信息。事实上目前mis/portal-web均已有API Route包装了认证系统的GET /validateToken，本来就已经大家都可以访问了。

# 不兼容的更改

已有的认证系统实现应尽快修改GET /validateToken为GET /public/validateToken。