### PR TITLE
feat(portal): 交互式应用部分需要记录用户之前填或者选的内容

### DIFF
--- a/.changeset/mean-pillows-hide.md
+++ b/.changeset/mean-pillows-hide.md
@@ -1,0 +1,8 @@
+---
+"@scow/portal-server": patch
+"@scow/portal-web": patch
+"@scow/config": patch
+"@scow/grpc-api": patch
+---
+
+优化创建交互式应用页面：在用户家目录下的 apps/app[Id]路径下存入上一次提交记录；创建了查找上一次提交记录的 API 接口，每次创建交互式应用时查找上一次提交记录，如果有则与当前集群下配置对比选择填入相应的值。

--- a/apps/portal-server/src/clusterops/api/app.ts
+++ b/apps/portal-server/src/clusterops/api/app.ts
@@ -81,10 +81,7 @@ export interface GetAppLastSubmissionRequest {
 }
 
 export type GetAppLastSubmissionReply = {
-  code: "OK"
-  lastSubmissionInfo: SubmissionInfo;
-} | {
-  code: "NOT_FOUND"
+  lastSubmissionInfo?: SubmissionInfo;
 }
 
 export type ConnectToAppReply =

--- a/apps/portal-server/src/clusterops/api/app.ts
+++ b/apps/portal-server/src/clusterops/api/app.ts
@@ -61,6 +61,32 @@ export interface ConnectToAppRequest {
   sessionId: string;
 }
 
+export interface SubmissionInfo {
+  userId: string;
+  cluster: string;
+  appId: string;
+  appName: string;
+  account: string;
+  partition?: string;
+  qos?: string;
+  coreCount: number;
+  maxTime: number;
+  submitTime?: string;
+  customAttributes: { [key: string]: string };
+}
+
+export interface GetAppLastSubmissionRequest {
+  userId: string;
+  appId: string;
+}
+
+export type GetAppLastSubmissionReply = {
+  code: "OK"
+  lastSubmissionInfo: SubmissionInfo;
+} | {
+  code: "NOT_FOUND"
+}
+
 export type ConnectToAppReply =
   | { code: "NOT_FOUND" } // sessionId is not found
   | { code: "UNAVAILABLE" } // the app is not available to connect yet
@@ -76,4 +102,5 @@ export interface AppOps {
   createApp(req: CreateAppRequest, logger: Logger): Promise<CreateAppReply>;
   listAppSessions(req: GetAppSessionsRequest, logger: Logger): Promise<GetAppSessionsReply>;
   connectToApp(req: ConnectToAppRequest, logger: Logger): Promise<ConnectToAppReply>;
+  getAppLastSubmission(req: GetAppLastSubmissionRequest, logger: Logger): Promise<GetAppLastSubmissionReply>;
 }

--- a/apps/portal-server/src/clusterops/slurm/app.ts
+++ b/apps/portal-server/src/clusterops/slurm/app.ts
@@ -223,13 +223,13 @@ export const slurmAppOps = (cluster: string): AppOps => {
         const sftp = await ssh.requestSFTP();
         const file = join(portalConfig.appLastSubmissionDir, appId, APP_LAST_SUBMISSION_INFO);
 
-        if (!await sftpExists(sftp, file)) { return { code: "NOT_FOUND" }; }
+        if (!await sftpExists(sftp, file)) { return { lastSubmissionInfo: undefined }; }
 
         const content = await sftpReadFile(sftp)(file);
         logger.info("getAppLastSubmission to %s", content);
         const data = JSON.parse(content.toString()) as SubmissionInfo;
 
-        return { code: "OK", lastSubmissionInfo: data };
+        return { lastSubmissionInfo: data };
       });
     },
 

--- a/apps/portal-server/src/clusterops/slurm/app.ts
+++ b/apps/portal-server/src/clusterops/slurm/app.ts
@@ -224,9 +224,7 @@ export const slurmAppOps = (cluster: string): AppOps => {
         const file = join(portalConfig.appLastSubmissionDir, appId, APP_LAST_SUBMISSION_INFO);
 
         if (!await sftpExists(sftp, file)) { return { lastSubmissionInfo: undefined }; }
-
         const content = await sftpReadFile(sftp)(file);
-        logger.info("getAppLastSubmission to %s", content);
         const data = JSON.parse(content.toString()) as SubmissionInfo;
 
         return { lastSubmissionInfo: data };

--- a/apps/portal-server/src/services/app.ts
+++ b/apps/portal-server/src/services/app.ts
@@ -233,6 +233,26 @@ export const appServiceServer = plugin((server) => {
       return [{ apps: Object.keys(apps).map((x) => ({ id: x, name: apps[x].name })) }];
     },
 
+    getAppLastSubmission: async ({ request, logger }) => {
+
+      const { userId, cluster, appId } = request;
+      const clusterops = getClusterOps(cluster);
+
+      if (!clusterops) { throw clusterNotFound(cluster); }
+
+      const reply = await clusterops.app.getAppLastSubmission({
+        userId, appId,
+      }, logger);
+
+      if (reply.code === "NOT_FOUND") {
+        throw <ServiceError> { code: Status.NOT_FOUND, message: `Last Submission of ${appId} is not found.` };
+      }
+
+      return [{
+        lastSubmissionInfo: reply.lastSubmissionInfo,
+      }];
+    },
+
   });
 
 });

--- a/apps/portal-server/src/services/app.ts
+++ b/apps/portal-server/src/services/app.ts
@@ -244,10 +244,6 @@ export const appServiceServer = plugin((server) => {
         userId, appId,
       }, logger);
 
-      if (reply.code === "NOT_FOUND") {
-        throw <ServiceError> { code: Status.NOT_FOUND, message: `Last Submission of ${appId} is not found.` };
-      }
-
       return [{
         lastSubmissionInfo: reply.lastSubmissionInfo,
       }];

--- a/apps/portal-server/tests/app/getAppLastSubmission.test.ts
+++ b/apps/portal-server/tests/app/getAppLastSubmission.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2022 Peking University and Peking University Institute for Computing and Digital Economy
+ * SCOW is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *          http://license.coscl.org.cn/MulanPSL2
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PSL v2 for more details.
+ */
+
+import { asyncUnaryCall } from "@ddadaal/tsgrpc-client";
+import { Server } from "@ddadaal/tsgrpc-server";
+import { credentials } from "@grpc/grpc-js";
+import { AppServiceClient } from "@scow/protos/build/portal/app";
+import { createServer } from "src/app";
+
+import { connectToTestServer, createTestLastSubmissionForVscode, resetTestServer, TestSshServer } from "../file/utils";
+
+let ssh: TestSshServer;
+let server: Server;
+let client: AppServiceClient;
+
+beforeEach(async () => {
+
+  ssh = await connectToTestServer();
+  await createTestLastSubmissionForVscode(ssh);
+
+  server = await createServer();
+  await server.start();
+
+  client = new AppServiceClient(server.serverAddress, credentials.createInsecure());
+});
+
+afterEach(async () => {
+  await resetTestServer(ssh);
+  await server.close();
+});
+
+it("gets app last submission with attributes", async () => {
+
+  const appId = "vscode";
+  const userId = "test";
+  const cluster = "hpc01";
+
+  const reply = await asyncUnaryCall(client, "getAppLastSubmission", { userId, cluster, appId });
+
+  expect(reply).toEqual(
+    {
+      userId: "test123",
+      cluster: "hpc01",
+      appId: "vscode",
+      appName: "VSCode",
+      account: "a_aaaaaa",
+      partition: "compute",
+      qos: "high",
+      coreCount: 2,
+      maxTime: 10,
+      submitTime: "2021-12-22T16:16:02",
+      customAttributes: { selectVersion: "code-server/4.9.0", sbatchOptions: "--time 10" },
+    },
+  );
+});
+
+
+it("returns undefined if not exists", async () => {
+  const appId = "emacs";
+  const userId = "test";
+  const cluster = "hpc01";
+
+  const reply = await asyncUnaryCall(client, "getAppLastSubmission", { userId, cluster, appId });
+  expect(reply).toEqual({});
+});

--- a/apps/portal-server/tests/app/getAppLastSubmission.test.ts
+++ b/apps/portal-server/tests/app/getAppLastSubmission.test.ts
@@ -26,7 +26,7 @@ let client: AppServiceClient;
 beforeEach(async () => {
 
   ssh = await connectToTestServer();
-  await createTestLastSubmissionForVscode(ssh);
+  await createTestLastSubmissionForVscode(ssh.sftp);
 
   server = await createServer();
   await server.start();

--- a/apps/portal-server/tests/app/getAppLastSubmission.test.ts
+++ b/apps/portal-server/tests/app/getAppLastSubmission.test.ts
@@ -14,9 +14,11 @@ import { asyncUnaryCall } from "@ddadaal/tsgrpc-client";
 import { Server } from "@ddadaal/tsgrpc-server";
 import { credentials } from "@grpc/grpc-js";
 import { AppServiceClient } from "@scow/protos/build/portal/app";
+import path from "path";
 import { createServer } from "src/app";
 
-import { connectToTestServer, createTestLastSubmissionForVscode, resetTestServer, TestSshServer } from "../file/utils";
+import { cluster, connectToTestServer, createTestLastSubmissionForVscode,
+  createVscodeLastSubmitFile, resetTestServer, TestSshServer, userId } from "../file/utils";
 
 let ssh: TestSshServer;
 let server: Server;
@@ -41,10 +43,11 @@ afterEach(async () => {
 it("gets app last submission with attributes", async () => {
 
   const appId = "vscode";
-  const userId = "test";
-  const cluster = "hpc01";
 
   const reply = await asyncUnaryCall(client, "getAppLastSubmission", { userId, cluster, appId });
+
+  console.log("【*******getAppLastSubmissionReply*********】");
+  console.log(reply);
 
   expect(reply).toEqual(
     {
@@ -61,14 +64,12 @@ it("gets app last submission with attributes", async () => {
       customAttributes: { selectVersion: "code-server/4.9.0", sbatchOptions: "--time 10" },
     },
   );
+
 });
 
 
 it("returns undefined if not exists", async () => {
   const appId = "emacs";
-  const userId = "test";
-  const cluster = "hpc01";
-
   const reply = await asyncUnaryCall(client, "getAppLastSubmission", { userId, cluster, appId });
   expect(reply).toEqual({});
 });

--- a/apps/portal-server/tests/app/getAppLastSubmission.test.ts
+++ b/apps/portal-server/tests/app/getAppLastSubmission.test.ts
@@ -14,11 +14,10 @@ import { asyncUnaryCall } from "@ddadaal/tsgrpc-client";
 import { Server } from "@ddadaal/tsgrpc-server";
 import { credentials } from "@grpc/grpc-js";
 import { AppServiceClient } from "@scow/protos/build/portal/app";
-import path from "path";
 import { createServer } from "src/app";
 
 import { cluster, connectToTestServer, createTestLastSubmissionForVscode,
-  createVscodeLastSubmitFile, resetTestServer, TestSshServer, userId } from "../file/utils";
+  resetTestServer, TestSshServer, userId } from "../file/utils";
 
 let ssh: TestSshServer;
 let server: Server;

--- a/apps/portal-server/tests/file/utils.ts
+++ b/apps/portal-server/tests/file/utils.ts
@@ -108,10 +108,9 @@ export async function createVscodeLastSubmitFile(sftp: SFTPWrapper, filePath: st
 }
 
 // cereate a lastSubmission base folder of app[vscode]
-export async function createTestLastSubmissionForVscode({ sftp, ssh }: TestSshServer): Promise<string> {
+export async function createTestLastSubmissionForVscode(sftp: SFTPWrapper): Promise<string> {
   const base = baseFolder();
-  await ssh.mkdir(path.join(base, "scow/apps"), undefined, sftp);
-  const appId1 = path.join(base, "vscode");
+  const appId1 = path.join(base, "scow/apps/vscode");
   console.log("【*******getAppLastSubmissionTestFilePath*********】");
   console.log(appId1);
   const testFile = await createVscodeLastSubmitFile(sftp, appId1);

--- a/apps/portal-server/tests/file/utils.ts
+++ b/apps/portal-server/tests/file/utils.ts
@@ -91,11 +91,7 @@ export async function expectGrpcThrow(promise: Promise<unknown>, expectError: (e
 
 
 // cereate a lastSubmission base folder of app[vscode]
-export async function createTestLastSubmissionForVscode({ sftp, ssh }: TestSshServer): Promise<string> {
-  const base = baseFolder();
-  await ssh.mkdir(path.join(base, "apps"), undefined, sftp);
-  const appId1 = path.join(base, "vscode");
-
+export async function createVscodeLastSubmitFile(sftp: SFTPWrapper, filePath: string) {
   const lastSubmissionInfo: SubmissionInfo = {
     userId: "test",
     cluster: "hpc01",
@@ -109,8 +105,19 @@ export async function createTestLastSubmissionForVscode({ sftp, ssh }: TestSshSe
     submitTime: "2021-12-22T16:16:02",
     customAttributes: { selectVersion: "code-server/4.9.0", sbatchOptions: "--time 10" },
   };
-  await sftpWriteFile(sftp)(join(appId1, "last_submission.json"),
+  const testFile = await sftpWriteFile(sftp)(join(filePath, "last_submission.json"),
     JSON.stringify(lastSubmissionInfo));
+  console.log("【*******getAppLastSubmissionTestFile*********】");
+  console.log(testFile);
+
+  return testFile;
+}
+
+export async function createTestLastSubmissionForVscode({ sftp, ssh }: TestSshServer): Promise<string> {
+  const base = baseFolder();
+  await ssh.mkdir(path.join(base, "scow/apps"), undefined, sftp);
+  const appId1 = path.join(base, "vscode");
+  await createVscodeLastSubmitFile(sftp, appId1);
 
   return base;
 }

--- a/apps/portal-server/tests/file/utils.ts
+++ b/apps/portal-server/tests/file/utils.ts
@@ -12,10 +12,11 @@
 
 import { ServiceError } from "@grpc/grpc-js";
 import { sftpWriteFile, sshRawConnect, sshRmrf } from "@scow/lib-ssh";
+import { SubmissionInfo } from "@scow/protos/build/portal/app";
 import { randomBytes } from "crypto";
 import FormData from "form-data";
 import { NodeSSH } from "node-ssh";
-import path from "path";
+import path, { join } from "path";
 import { rootKeyPair } from "src/config/env";
 import { SFTPWrapper } from "ssh2";
 
@@ -86,4 +87,30 @@ export function mockFileForm(size: number, filename: string) {
 
 export async function expectGrpcThrow(promise: Promise<unknown>, expectError: (error: ServiceError) => void) {
   await promise.then(() => expect("").fail("Promise resolved"), expectError);
+}
+
+
+// cereate a lastSubmission base folder of app[vscode]
+export async function createTestLastSubmissionForVscode({ sftp, ssh }: TestSshServer): Promise<string> {
+  const base = baseFolder();
+  await ssh.mkdir(path.join(base, "apps"), undefined, sftp);
+  const appId1 = path.join(base, "vscode");
+
+  const lastSubmissionInfo: SubmissionInfo = {
+    userId: "test",
+    cluster: "hpc01",
+    appId: "vscode",
+    appName: "VSCode",
+    account: "a_aaaaaa",
+    partition: "compute",
+    qos: "high",
+    coreCount: 2,
+    maxTime: 10,
+    submitTime: "2021-12-22T16:16:02",
+    customAttributes: { selectVersion: "code-server/4.9.0", sbatchOptions: "--time 10" },
+  };
+  await sftpWriteFile(sftp)(join(appId1, "last_submission.json"),
+    JSON.stringify(lastSubmissionInfo));
+
+  return base;
 }

--- a/apps/portal-server/tests/file/utils.ts
+++ b/apps/portal-server/tests/file/utils.ts
@@ -89,8 +89,6 @@ export async function expectGrpcThrow(promise: Promise<unknown>, expectError: (e
   await promise.then(() => expect("").fail("Promise resolved"), expectError);
 }
 
-
-// cereate a lastSubmission base folder of app[vscode]
 export async function createVscodeLastSubmitFile(sftp: SFTPWrapper, filePath: string) {
   const lastSubmissionInfo: SubmissionInfo = {
     userId: "test",
@@ -105,19 +103,20 @@ export async function createVscodeLastSubmitFile(sftp: SFTPWrapper, filePath: st
     submitTime: "2021-12-22T16:16:02",
     customAttributes: { selectVersion: "code-server/4.9.0", sbatchOptions: "--time 10" },
   };
-  const testFile = await sftpWriteFile(sftp)(join(filePath, "last_submission.json"),
+  return await sftpWriteFile(sftp)(join(filePath, "last_submission.json"),
     JSON.stringify(lastSubmissionInfo));
-  console.log("【*******getAppLastSubmissionTestFile*********】");
-  console.log(testFile);
-
-  return testFile;
 }
 
+// cereate a lastSubmission base folder of app[vscode]
 export async function createTestLastSubmissionForVscode({ sftp, ssh }: TestSshServer): Promise<string> {
   const base = baseFolder();
   await ssh.mkdir(path.join(base, "scow/apps"), undefined, sftp);
   const appId1 = path.join(base, "vscode");
-  await createVscodeLastSubmitFile(sftp, appId1);
+  console.log("【*******getAppLastSubmissionTestFilePath*********】");
+  console.log(appId1);
+  const testFile = await createVscodeLastSubmitFile(sftp, appId1);
+  console.log("【*******getAppLastSubmissionTestFile*********】");
+  console.log(testFile);
 
   return base;
 }

--- a/apps/portal-server/tests/file/utils.ts
+++ b/apps/portal-server/tests/file/utils.ts
@@ -11,7 +11,7 @@
  */
 
 import { ServiceError } from "@grpc/grpc-js";
-import { sftpReadFile, sftpWriteFile, sshRawConnect, sshRmrf } from "@scow/lib-ssh";
+import { sftpWriteFile, sshRawConnect, sshRmrf } from "@scow/lib-ssh";
 import { SubmissionInfo } from "@scow/protos/build/portal/app";
 import { randomBytes } from "crypto";
 import FormData from "form-data";

--- a/apps/portal-web/src/apis/api.mock.ts
+++ b/apps/portal-web/src/apis/api.mock.ts
@@ -205,18 +205,19 @@ export const mockApi: MockApi<typeof api> = {
 
   getAppLastSubmission: async () => ({
     lastSubmissionInfo: {
-      userId: "last-submission",
-      cluster: "hpc1111",
+      userId: "test123",
+      cluster: "hpc01",
       appId: "vscode",
-      appName: "vscode",
+      appName: "VSCode",
       account: "a_aaaaaa",
-      partition: "1",
-      qos: "1",
-      coreCount: 1,
+      partition: "compute",
+      qos: "high",
+      coreCount: 2,
       maxTime: 10,
       submitTime: "2021-12-22T16:16:02",
-      customAttributes: {},
+      customAttributes: { selectVersion: "code-server/4.9.0", sbatchOptions: "--time 10" },
     },
   }),
+
 };
 

--- a/apps/portal-web/src/apis/api.mock.ts
+++ b/apps/portal-web/src/apis/api.mock.ts
@@ -203,5 +203,20 @@ export const mockApi: MockApi<typeof api> = {
 
   submitJob: async () => ({ jobId: 10 }),
 
+  getAppLastSubmission: async () => ({
+    lastSubmissionInfo: {
+      userId: "last-submission",
+      cluster: "hpc1111",
+      appId: "vscode",
+      appName: "vscode",
+      account: "a_aaaaaa",
+      partition: "1",
+      qos: "1",
+      coreCount: 1,
+      maxTime: 10,
+      submitTime: "2021-12-22T16:16:02",
+      customAttributes: {},
+    },
+  }),
 };
 

--- a/apps/portal-web/src/apis/api.ts
+++ b/apps/portal-web/src/apis/api.ts
@@ -17,6 +17,7 @@ import { join } from "path";
 import type { GetClusterInfoSchema } from "src/pages/api//cluster";
 import type { ConnectToAppSchema } from "src/pages/api/app/connectToApp";
 import type { CreateAppSessionSchema } from "src/pages/api/app/createAppSession";
+import { GetAppLastSubmissionSchema } from "src/pages/api/app/getAppLastSubmission";
 import type { GetAppMetadataSchema } from "src/pages/api/app/getAppMetadata";
 import type { GetAppSessionsSchema } from "src/pages/api/app/getAppSessions";
 import type { ListAvailableAppsSchema } from "src/pages/api/app/listAvailableApps";
@@ -59,6 +60,7 @@ export const api = {
   getAppMetadata: fromApi<GetAppMetadataSchema>("GET", join(basePath, "/api/app/getAppMetadata")),
   getAppSessions: fromApi<GetAppSessionsSchema>("GET", join(basePath, "/api/app/getAppSessions")),
   listAvailableApps: fromApi<ListAvailableAppsSchema>("GET", join(basePath, "/api/app/listAvailableApps")),
+  getAppLastSubmission: fromApi<GetAppLastSubmissionSchema>("GET", join(basePath, "/api/app/getAppLastSubmission")),
   authCallback: fromApi<AuthCallbackSchema>("GET", join(basePath, "/api/auth/callback")),
   logout: fromApi<LogoutSchema>("DELETE", join(basePath, "/api/auth/logout")),
   validateToken: fromApi<ValidateTokenSchema>("GET", join(basePath, "/api/auth/validateToken")),

--- a/apps/portal-web/src/pageComponents/app/LaunchAppForm.tsx
+++ b/apps/portal-web/src/pageComponents/app/LaunchAppForm.tsx
@@ -148,8 +148,9 @@ export const LaunchAppForm: React.FC<Props> = ({ appId, attributes }) => {
             form.setFieldsValue({ ...requiredObj, ...attributesObj });
 
             // 如果上一次提交信息存在，则填入账户值
-            form.setFieldValue("account", lastSubmitData?.lastSubmissionInfo
-              ? lastSubmitData?.lastSubmissionInfo.account : undefined);
+            if (lastSubmitData.lastSubmissionInfo) {
+              form.setFieldValue("account", lastSubmitData.lastSubmissionInfo.account);
+            }
 
           }).finally(() => {
             setLoading(false);
@@ -213,7 +214,7 @@ export const LaunchAppForm: React.FC<Props> = ({ appId, attributes }) => {
           rules={[{ required: true }]}
           dependencies={["cluster"]}
         >
-          {account && <AccountSelector cluster={cluster?.id} />}
+          <AccountSelector cluster={cluster?.id} />
         </Form.Item>
 
         <Form.Item

--- a/apps/portal-web/src/pageComponents/app/LaunchAppForm.tsx
+++ b/apps/portal-web/src/pageComponents/app/LaunchAppForm.tsx
@@ -212,7 +212,7 @@ export const LaunchAppForm: React.FC<Props> = ({ appId, attributes }) => {
           rules={[{ required: true }]}
           dependencies={["cluster"]}
         >
-          <AccountSelector cluster={cluster?.id} />
+          {clusterInfoQuery.data && <AccountSelector cluster={cluster?.id} />}
         </Form.Item>
 
         <Form.Item

--- a/apps/portal-web/src/pageComponents/app/LaunchAppForm.tsx
+++ b/apps/portal-web/src/pageComponents/app/LaunchAppForm.tsx
@@ -86,7 +86,6 @@ export const LaunchAppForm: React.FC<Props> = ({ appId, attributes }) => {
 
   const cluster = Form.useWatch("cluster", form) as Cluster | undefined;
   const [currentPartitionInfo, setCurrentPartitionInfo] = useState<Partition | undefined>();
-  const account = Form.useWatch("account", form) as string | undefined;
 
   const clusterInfoQuery = useAsync({
     promiseFn: useCallback(async () => cluster
@@ -101,7 +100,8 @@ export const LaunchAppForm: React.FC<Props> = ({ appId, attributes }) => {
 
         if (cluster) { await api.getAppLastSubmission({ query: { cluster: cluster?.id, appId } })
           .then((lastSubmitData) => {
-
+            debugger;
+            console.log(lastSubmitData);
             const lastSubmitPartition = lastSubmitData?.lastSubmissionInfo?.partition;
             const lastSubmitQos = lastSubmitData?.lastSubmissionInfo?.qos;
             const lastSubmitCoreCount = lastSubmitData?.lastSubmissionInfo?.coreCount;
@@ -149,6 +149,8 @@ export const LaunchAppForm: React.FC<Props> = ({ appId, attributes }) => {
 
             // 如果上一次提交信息存在，则填入账户值
             if (lastSubmitData.lastSubmissionInfo) {
+              debugger;
+              console.log("submit-account", lastSubmitData.lastSubmissionInfo.account);
               form.setFieldValue("account", lastSubmitData.lastSubmissionInfo.account);
             }
 
@@ -198,6 +200,9 @@ export const LaunchAppForm: React.FC<Props> = ({ appId, attributes }) => {
   });
 
   const defaultClusterStore = useStore(DefaultClusterStore);
+
+  debugger;
+  console.log("accountFormValue", form.getFieldValue("acccount"));
 
   return (
     <Form form={form} onFinish={onSubmit} initialValues={{ cluster: defaultClusterStore.cluster }}>

--- a/apps/portal-web/src/pageComponents/app/LaunchAppForm.tsx
+++ b/apps/portal-web/src/pageComponents/app/LaunchAppForm.tsx
@@ -202,7 +202,7 @@ export const LaunchAppForm: React.FC<Props> = ({ appId, attributes }) => {
         <SingleClusterSelector />
       </Form.Item>
 
-      <Spin spinning={loading}>
+      <Spin spinning={loading} tip="查询上次提交记录中">
 
         <Form.Item
           label="账户"

--- a/apps/portal-web/src/pageComponents/app/LaunchAppForm.tsx
+++ b/apps/portal-web/src/pageComponents/app/LaunchAppForm.tsx
@@ -10,16 +10,17 @@
  * See the Mulan PSL v2 for more details.
  */
 
-import { App, Button, Form, Input, InputNumber, Select } from "antd";
+import { App, Button, Form, Input, InputNumber, Select, Spin } from "antd";
 import { Rule } from "antd/es/form";
 import Router from "next/router";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useState } from "react";
 import { useAsync } from "react-async";
 import { useStore } from "simstate";
 import { api } from "src/apis";
 import { SingleClusterSelector } from "src/components/ClusterSelector";
 import { AccountSelector } from "src/pageComponents/job/AccountSelector";
 import { AppCustomAttribute } from "src/pages/api/app/getAppMetadata";
+import { Partition } from "src/pages/api/cluster";
 import { DefaultClusterStore } from "src/stores/DefaultClusterStore";
 import { Cluster } from "src/utils/config";
 
@@ -38,13 +39,11 @@ interface FormFields {
   maxTime: number;
 }
 
-
 const initialValues = {
   nodeCount: 1,
   coreCount: 1,
   maxTime: 60,
 } as Partial<FormFields>;
-
 
 export const LaunchAppForm: React.FC<Props> = ({ appId, attributes }) => {
 
@@ -83,79 +82,89 @@ export const LaunchAppForm: React.FC<Props> = ({ appId, attributes }) => {
   };
 
   const cluster = Form.useWatch("cluster", form) as Cluster | undefined;
-  const partition = Form.useWatch("partition", form) as string | undefined;
-
+  const [currentPartitionInfo, setCurrentPartitionInfo] = useState<Partition | undefined>();
 
   const clusterInfoQuery = useAsync({
-    promiseFn: useCallback(async () => {
-      return cluster ? Promise.all([
-        api.getClusterInfo({ query: { cluster:  cluster?.id } }),
-        api.getAppLastSubmission({ query: { cluster: cluster?.id, appId } }),
-      ]) : undefined;
-    }, [cluster]),
-    onResolve: (data) => {
+    promiseFn: useCallback(async () => cluster
+      ? api.getClusterInfo({ query: { cluster:  cluster?.id } }) : undefined, [cluster]),
+    onResolve: async (data) => {
       if (data) {
 
-        const [clusterData, lastSubmitData] = data;
-
-        const lastSubmitPartition = lastSubmitData.lastSubmissionInfo.partition;
-        const lastSubmitQos = lastSubmitData.lastSubmissionInfo.qos;
-        const lastSubmitCoreCount = lastSubmitData.lastSubmissionInfo.coreCount;
-        const clusterPartition = clusterData.clusterInfo.slurm.partitions[0];
+        setLoading(true);
+        const clusterPartition = data.clusterInfo.slurm.partitions[0];
         const clusterPartitionCoreCount = clusterPartition.cores;
+        setCurrentPartitionInfo(clusterPartition);
 
-        // 如果存在上一次提交信息，且上一次提交信息中的分区，qos，cpu核心数满足当前集群配置，则填入上一次提交信息中的相应值
-        const seSubmitPartition = lastSubmitPartition &&
-          clusterData.clusterInfo.slurm.partitions.some((item) => { return item.name === lastSubmitPartition; });
-        const setSubmitQos = seSubmitPartition &&
-          clusterPartition.qos?.some((item) => { return item === lastSubmitQos; });
-        const setSubmitCoreCount = seSubmitPartition &&
-          lastSubmitCoreCount && clusterPartitionCoreCount && clusterPartitionCoreCount >= lastSubmitCoreCount;
-        const requiredObj = {
-          partition: seSubmitPartition ? lastSubmitPartition : clusterPartition.name,
-          qos: setSubmitQos ? lastSubmitQos : clusterPartition?.qos?.[0],
-          coreCount: setSubmitCoreCount ? lastSubmitCoreCount : initialValues.coreCount,
-          maxTime: lastSubmitData ? lastSubmitData.lastSubmissionInfo.maxTime : initialValues.maxTime,
-        };
+        const [lastSubmitDataPromise] = [cluster
+          ? api.getAppLastSubmission({ query: { cluster: cluster?.id, appId } }) : undefined];
 
-        // 如果存在上一次提交信息且上一次提交信息中的配置HTML表单与当前配置HTML表单内容相同，则填入上一次提交信息中的值
-        const attributesObj = {};
-        const lastSubmitAttributes = lastSubmitData.lastSubmissionInfo.customAttributes;
-        if (lastSubmitAttributes) {
-          attributes.forEach((attribute) => {
-            if (attribute.name in lastSubmitAttributes) {
-              switch (attribute.type) {
-              case "NUMBER":
-              case "TEXT":
-                attributesObj[attribute.name] = lastSubmitAttributes[attribute.name];
-                break;
-              case "SELECT":
-                if (attribute.select!.some((optionItem) => optionItem.value === lastSubmitAttributes[attribute.name])) {
+        await Promise.allSettled([lastSubmitDataPromise]).then(([lastSubmitDataResult]) => {
+
+          const lastSubmitData = lastSubmitDataResult.status === "fulfilled" ? lastSubmitDataResult.value : undefined;
+          const lastSubmitPartition = lastSubmitData?.lastSubmissionInfo?.partition;
+          const lastSubmitQos = lastSubmitData?.lastSubmissionInfo?.qos;
+          const lastSubmitCoreCount = lastSubmitData?.lastSubmissionInfo?.coreCount;
+
+          // 如果存在上一次提交信息，且上一次提交信息中的分区，qos，cpu核心数满足当前集群配置，则填入上一次提交信息中的相应值
+          const setSubmitPartition = lastSubmitPartition &&
+          data.clusterInfo.slurm.partitions.some((item) => { return item.name === lastSubmitPartition; });
+          const setSubmitQos = setSubmitPartition &&
+            clusterPartition.qos?.some((item) => { return item === lastSubmitQos; });
+          const setSubmitCoreCount = setSubmitPartition &&
+            lastSubmitCoreCount && clusterPartitionCoreCount && clusterPartitionCoreCount >= lastSubmitCoreCount;
+
+          const requiredObj = {
+            partition: setSubmitPartition ? lastSubmitPartition : clusterPartition.name,
+            qos: setSubmitQos ? lastSubmitQos : clusterPartition?.qos?.[0],
+            coreCount: setSubmitCoreCount ? lastSubmitCoreCount : initialValues.coreCount,
+            maxTime: lastSubmitData?.lastSubmissionInfo
+              ? lastSubmitData.lastSubmissionInfo.maxTime : initialValues.maxTime,
+          };
+
+          // 如果存在上一次提交信息且上一次提交信息中的配置HTML表单与当前配置HTML表单内容相同，则填入上一次提交信息中的值
+          const attributesObj = {};
+          const lastSubmitAttributes = lastSubmitData?.lastSubmissionInfo?.customAttributes;
+          if (lastSubmitAttributes) {
+            attributes.forEach((attribute) => {
+              if (attribute.name in lastSubmitAttributes) {
+                switch (attribute.type) {
+                case "NUMBER":
+                case "TEXT":
                   attributesObj[attribute.name] = lastSubmitAttributes[attribute.name];
+                  break;
+                case "SELECT":
+                  if (attribute.select!.some((optionItem) =>
+                    optionItem.value === lastSubmitAttributes[attribute.name])) {
+                    attributesObj[attribute.name] = lastSubmitAttributes[attribute.name];
+                  }
+                  break;
+                default:
+                  break;
                 }
-                break;
               }
-            }
-          });
-        }
-        form.setFieldsValue({ ...requiredObj, ...attributesObj });
+            });
+          }
+          form.setFieldsValue({ ...requiredObj, ...attributesObj });
+
+          // 如果上一次提交信息存在，则填入账户值；如果不存在，不对表单中账户进行操作
+          if (lastSubmitData?.lastSubmissionInfo) {
+            form.setFieldValue("account", lastSubmitData?.lastSubmissionInfo.account);
+          }
+
+        }).finally(() => {
+          setLoading(false);
+        });
       }
     },
   });
 
-  const currentPartitionInfo = useMemo(() =>
-    clusterInfoQuery.data
-      ? clusterInfoQuery.data[0].clusterInfo.slurm.partitions.find((x) => x.name === partition)
-      : undefined,
-  [clusterInfoQuery.data, partition],
-  );
-
-  useEffect(() => {
-    if (currentPartitionInfo) {
-      form.setFieldValue("qos", currentPartitionInfo.qos?.[0]);
-    }
-  }, [currentPartitionInfo]);
-
+  const handlePartitionChange = (partition) => {
+    const partitionInfo = clusterInfoQuery.data
+      ? clusterInfoQuery.data.clusterInfo.slurm.partitions.find((x) => x.name === partition)
+      : undefined;
+    form.setFieldValue("qos", partitionInfo?.qos?.[0]);
+    setCurrentPartitionInfo(partitionInfo);
+  };
 
   const customFormItems = attributes.map((item, index) => {
 
@@ -195,60 +204,64 @@ export const LaunchAppForm: React.FC<Props> = ({ appId, attributes }) => {
         <SingleClusterSelector />
       </Form.Item>
 
-      <Form.Item
-        label="账户"
-        name="account"
-        rules={[{ required: true }]}
-        dependencies={["cluster"]}
-      >
-        <AccountSelector cluster={cluster?.id} />
-      </Form.Item>
+      <Spin spinning={loading}>
 
-      <Form.Item
-        label="分区"
-        name="partition"
-        dependencies={["cluster"]}
-        rules={[{ required: true }]}
-      >
-        <Select
-          loading={clusterInfoQuery.isLoading}
-          disabled={!currentPartitionInfo}
-          options={clusterInfoQuery.data
-            ? clusterInfoQuery.data[0].clusterInfo.slurm.partitions
-              .map((x) => ({ label: x.name, value: x.name }))
-            : []
-          }
-        />
-      </Form.Item>
+        <Form.Item
+          label="账户"
+          name="account"
+          rules={[{ required: true }]}
+          dependencies={["cluster"]}
+        >
+          <AccountSelector cluster={cluster?.id} />
+        </Form.Item>
 
-      <Form.Item
-        label="QOS"
-        name="qos"
-        dependencies={["cluster", "partition"]}
-        rules={[{ required: true }]}
-      >
-        <Select
-          disabled={(!currentPartitionInfo?.qos) || currentPartitionInfo.qos.length === 0}
-          options={currentPartitionInfo?.qos?.map((x) => ({ label: x, value: x }))}
-        />
-      </Form.Item>
+        <Form.Item
+          label="分区"
+          name="partition"
+          dependencies={["cluster"]}
+          rules={[{ required: true }]}
+        >
+          <Select
+            disabled={!currentPartitionInfo}
+            options={clusterInfoQuery.data
+              ? clusterInfoQuery.data.clusterInfo.slurm.partitions
+                .map((x) => ({ label: x.name, value: x.name }))
+              : []
+            }
+            onChange={handlePartitionChange}
+          />
+        </Form.Item>
 
-      <Form.Item
-        label="CPU核心数"
-        name="coreCount"
-        dependencies={["cluster", "partition"]}
-        rules={[
-          { required: true, type: "integer", max: currentPartitionInfo?.cores },
-        ]}
-      >
-        <InputNumber min={1} />
-      </Form.Item>
+        <Form.Item
+          label="QOS"
+          name="qos"
+          dependencies={["cluster"]}
+          rules={[{ required: true }]}
+        >
+          <Select
+            disabled={(!currentPartitionInfo?.qos) || currentPartitionInfo.qos.length === 0}
+            options={currentPartitionInfo?.qos?.map((x) => ({ label: x, value: x }))}
+          />
+        </Form.Item>
 
-      <Form.Item label="最长运行时间" name="maxTime" rules={[{ required: true }]}>
-        <InputNumber min={1} step={1} addonAfter={"分钟"} />
-      </Form.Item>
+        <Form.Item
+          label="CPU核心数"
+          name="coreCount"
+          dependencies={["cluster"]}
+          rules={[
+            { required: true, type: "integer", max: currentPartitionInfo?.cores },
+          ]}
+        >
+          <InputNumber min={1} />
+        </Form.Item>
 
-      {customFormItems}
+        <Form.Item label="最长运行时间" name="maxTime" rules={[{ required: true }]}>
+          <InputNumber min={1} step={1} addonAfter={"分钟"} />
+        </Form.Item>
+
+        {customFormItems}
+
+      </Spin>
 
       <Form.Item>
         <Button type="primary" htmlType="submit" loading={loading}>

--- a/apps/portal-web/src/pageComponents/app/LaunchAppForm.tsx
+++ b/apps/portal-web/src/pageComponents/app/LaunchAppForm.tsx
@@ -100,8 +100,6 @@ export const LaunchAppForm: React.FC<Props> = ({ appId, attributes }) => {
 
         if (cluster) { await api.getAppLastSubmission({ query: { cluster: cluster?.id, appId } })
           .then((lastSubmitData) => {
-            debugger;
-            console.log(lastSubmitData);
             const lastSubmitPartition = lastSubmitData?.lastSubmissionInfo?.partition;
             const lastSubmitQos = lastSubmitData?.lastSubmissionInfo?.qos;
             const lastSubmitCoreCount = lastSubmitData?.lastSubmissionInfo?.coreCount;
@@ -149,8 +147,6 @@ export const LaunchAppForm: React.FC<Props> = ({ appId, attributes }) => {
 
             // 如果上一次提交信息存在，则填入账户值
             if (lastSubmitData.lastSubmissionInfo) {
-              debugger;
-              console.log("submit-account", lastSubmitData.lastSubmissionInfo.account);
               form.setFieldValue("account", lastSubmitData.lastSubmissionInfo.account);
             }
 
@@ -200,9 +196,6 @@ export const LaunchAppForm: React.FC<Props> = ({ appId, attributes }) => {
   });
 
   const defaultClusterStore = useStore(DefaultClusterStore);
-
-  debugger;
-  console.log("accountFormValue", form.getFieldValue("acccount"));
 
   return (
     <Form form={form} onFinish={onSubmit} initialValues={{ cluster: defaultClusterStore.cluster }}>

--- a/apps/portal-web/src/pageComponents/job/AccountSelector.tsx
+++ b/apps/portal-web/src/pageComponents/job/AccountSelector.tsx
@@ -12,7 +12,7 @@
 
 import { ReloadOutlined } from "@ant-design/icons";
 import { Button, Input, Select, Tooltip } from "antd";
-import { useCallback } from "react";
+import { useCallback, useEffect } from "react";
 import { useAsync } from "react-async";
 import { useStore } from "simstate";
 import { api } from "src/apis";
@@ -34,12 +34,15 @@ export const AccountSelector: React.FC<Props> = ({ cluster, onChange, value }) =
   const { data, isLoading, reload } = useAsync({
     promiseFn,
     watch: userStore.user,
-    onResolve: ({ accounts }) => {
-      if (!value || !accounts.includes(value)) {
-        onChange?.(accounts[0]);
-      }
-    },
   });
+
+  useEffect(() => {
+    if (data && data.accounts) {
+      if (!value || !data.accounts.includes(value)) {
+        onChange?.(data.accounts[0]);
+      }
+    }
+  }, [data, value]);
 
   return (
     <Input.Group compact>

--- a/apps/portal-web/src/pageComponents/job/AccountSelector.tsx
+++ b/apps/portal-web/src/pageComponents/job/AccountSelector.tsx
@@ -37,7 +37,11 @@ export const AccountSelector: React.FC<Props> = ({ cluster, onChange, value }) =
   });
 
   useEffect(() => {
+    debugger;
+    console.log("useEffect-accountValue", value);
+    console.log("useEffect-data", data);
     if (data && data.accounts) {
+      console.log("useEffect-if-accounts-accountValue", value);
       if (!value || !data.accounts.includes(value)) {
         onChange?.(data.accounts[0]);
       }

--- a/apps/portal-web/src/pageComponents/job/AccountSelector.tsx
+++ b/apps/portal-web/src/pageComponents/job/AccountSelector.tsx
@@ -37,11 +37,8 @@ export const AccountSelector: React.FC<Props> = ({ cluster, onChange, value }) =
   });
 
   useEffect(() => {
-    debugger;
-    console.log("useEffect-accountValue", value);
-    console.log("useEffect-data", data);
-    if (data && data.accounts) {
-      console.log("useEffect-if-accounts-accountValue", value);
+
+    if (data && data.accounts.length) {
       if (!value || !data.accounts.includes(value)) {
         onChange?.(data.accounts[0]);
       }

--- a/apps/portal-web/src/pages/api/app/getAppLastSubmission.ts
+++ b/apps/portal-web/src/pages/api/app/getAppLastSubmission.ts
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2022 Peking University and Peking University Institute for Computing and Digital Economy
+ * SCOW is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *          http://license.coscl.org.cn/MulanPSL2
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PSL v2 for more details.
+ */
+
+import { asyncUnaryCall } from "@ddadaal/tsgrpc-client";
+import { status } from "@grpc/grpc-js";
+import { AppServiceClient, SubmissionInfo } from "@scow/protos/build/portal/app";
+import { authenticate } from "src/auth/server";
+import { getClient } from "src/utils/client";
+import { route } from "src/utils/route";
+import { handlegRPCError } from "src/utils/server";
+
+export interface GetAppLastSubmissionSchema {
+  method: "GET";
+
+  query: {
+    cluster: string;
+    appId: string;
+  }
+
+  responses: {
+    200: {
+      lastSubmissionInfo: SubmissionInfo;
+    };
+    400: {
+      message: string;
+    };
+    404: {
+      code: "APP_NOT_FOUND"
+    };
+  }
+}
+
+const auth = authenticate(() => true);
+
+export default /* #__PURE__*/route<GetAppLastSubmissionSchema>("GetAppLastSubmissionSchema", async (req, res) => {
+
+  const info = await auth(req, res);
+
+  if (!info) { return; }
+
+  const { cluster, appId } = req.query;
+  const client = getClient(AppServiceClient);
+
+  return asyncUnaryCall(client, "getAppLastSubmission", {
+    userId: info.identityId, cluster, appId,
+  }).then(({ lastSubmissionInfo }) => ({ 200: { lastSubmissionInfo: lastSubmissionInfo! } }), handlegRPCError({
+    [status.NOT_FOUND]: () => ({ 404: { code: "APP_NOT_FOUND" } as const }),
+  }));
+
+});

--- a/apps/portal-web/src/pages/api/app/getAppLastSubmission.ts
+++ b/apps/portal-web/src/pages/api/app/getAppLastSubmission.ts
@@ -11,12 +11,10 @@
  */
 
 import { asyncUnaryCall } from "@ddadaal/tsgrpc-client";
-import { status } from "@grpc/grpc-js";
 import { AppServiceClient, SubmissionInfo } from "@scow/protos/build/portal/app";
 import { authenticate } from "src/auth/server";
 import { getClient } from "src/utils/client";
 import { route } from "src/utils/route";
-import { handlegRPCError } from "src/utils/server";
 
 export interface GetAppLastSubmissionSchema {
   method: "GET";
@@ -28,13 +26,7 @@ export interface GetAppLastSubmissionSchema {
 
   responses: {
     200: {
-      lastSubmissionInfo: SubmissionInfo;
-    };
-    400: {
-      message: string;
-    };
-    404: {
-      code: "APP_NOT_FOUND"
+      lastSubmissionInfo?: SubmissionInfo;
     };
   }
 }
@@ -52,8 +44,5 @@ export default /* #__PURE__*/route<GetAppLastSubmissionSchema>("GetAppLastSubmis
 
   return asyncUnaryCall(client, "getAppLastSubmission", {
     userId: info.identityId, cluster, appId,
-  }).then(({ lastSubmissionInfo }) => ({ 200: { lastSubmissionInfo: lastSubmissionInfo! } }), handlegRPCError({
-    [status.NOT_FOUND]: () => ({ 404: { code: "APP_NOT_FOUND" } as const }),
-  }));
-
+  }).then(({ lastSubmissionInfo }) => ({ 200: { lastSubmissionInfo: lastSubmissionInfo } }));
 });

--- a/dev/vagrant/config/apps/vscode.yaml
+++ b/dev/vagrant/config/apps/vscode.yaml
@@ -23,3 +23,23 @@ web:
     path: /login
     formData:
       password: "{{ PASSWORD }}"
+
+
+# 配置HTML表单，用户可以指定code-server版本
+attributes:
+  - type: select
+    name: selectVersion
+    label: 选择版本
+    required: true  # 用户必须选择一个版本
+    placeholder: 选择code-server的版本  # 提示信息
+    select:
+      - value: code-server/4.8.0
+        label: version 4.8.0
+      - value: code-server/4.9.0
+        label: version 4.9.0
+
+  - type: text
+    name: sbatchOptions
+    label: 其他sbatch参数
+    required: false
+    placeholder: "比如：--gpus gres:2 --time 10"

--- a/libs/config/src/portal.ts
+++ b/libs/config/src/portal.ts
@@ -56,6 +56,9 @@ export const PortalConfigSchema = Type.Object({
 
   turboVNCPath: Type.String({ description: "TurboVNC的安装路径", default: "/opt/TurboVNC" }),
 
+  appLastSubmissionDir: Type.String({
+    description: "提交交互式应用上一次填写信息的默认工作目录。相对于用户的家目录", default: "scow/apps" }),
+
 });
 
 const PORTAL_CONFIG_NAME = "portal";

--- a/protos/portal/app.proto
+++ b/protos/portal/app.proto
@@ -136,6 +136,30 @@ message ListAvailableAppsResponse {
   repeated App apps = 1;
 }
 
+message SubmissionInfo {
+  string user_id = 1;
+  string cluster = 2;
+  string app_id = 3;
+  string app_name =4;
+  string account = 5;
+  optional string partition = 6;
+  optional string qos = 7;
+  uint32 core_count = 8;
+  uint32 max_time = 9;
+  google.protobuf.Timestamp submit_time = 10;
+  map<string, string> custom_attributes = 11;
+}
+
+message GetAppLastSubmissionRequest {
+  string user_id = 1;
+  string cluster = 2;
+  string app_id = 3;
+}
+
+message GetAppLastSubmissionResponse {
+  SubmissionInfo last_submission_info = 1;
+}
+
 service AppService {
   rpc ConnectToApp(ConnectToAppRequest) returns (ConnectToAppResponse);
 
@@ -146,4 +170,6 @@ service AppService {
   rpc GetAppMetadata(GetAppMetadataRequest) returns (GetAppMetadataResponse);
 
   rpc ListAvailableApps(ListAvailableAppsRequest) returns (ListAvailableAppsResponse);
+
+  rpc GetAppLastSubmission(GetAppLastSubmissionRequest) returns (GetAppLastSubmissionResponse);
 }

--- a/protos/portal/app.proto
+++ b/protos/portal/app.proto
@@ -157,7 +157,7 @@ message GetAppLastSubmissionRequest {
 }
 
 message GetAppLastSubmissionResponse {
-  SubmissionInfo last_submission_info = 1;
+  optional SubmissionInfo last_submission_info = 1;
 }
 
 service AppService {


### PR DESCRIPTION
# 做了什么
1.增加了用于保存交互式应用上一次提交记录的家目录路径
`../scow/apps/[appId]/last_submission.json`
2.增加了提取上一次提交记录的GET的API接口
3.修改了本地vagrant集群vscode.yaml文件配置，增加了自定义的配置HTML表单
因为目前本地vagrant没有部署相应应用，如果后期会实装应用的话，版本号可能会有影响，如果有需要将改回
```
attributes:
  - type: select
    name: selectVersion
    label: 选择版本
    required: true  # 用户必须选择一个版本
    placeholder: 选择code-server的版本  # 提示信息
    select:
      - value: code-server/4.8.0
        label: version 4.8.0
      - value: code-server/4.9.0
        label: version 4.9.0

  - type: text
    name: sbatchOptions
    label: 其他sbatch参数
    required: false
    placeholder: "比如：--gpus gres:2 --time 10"
```

### 打开创建交互式应用时的填入逻辑

1. 打开创建交互式应用页面，表单填入默认集群

1. 按默认集群查找该集群下是否有上一次提交记录，如果没有则填入系统默认值，如果有进行以下判断填入表单

1. 判断上一次提交信息中的分区是否仍在当前集群配置下

> -    如果是
> 
> >    将上一次的分区值填入表单
> >    继续判断qos, cpu核心数是否仍满足当前集群配置
> >    如果满足，填入上一次的填入值
> >    如果不满足，填入当前配置下的默认值
> 
> -    如果否
> 
> >    填入当前集群的分区,qos,cpu核心数的默认值

4. 填入账户，按照之前的账户逻辑判断账户是否仍然在用户的账户列表中来显示

5.  填入最长运行时间

6.  判断上一次提交信息中的配置html表单列表是否与当前集群下的配置html表单列表项目相同

> -    如果是
> 
> 
> >    判断表单属性是否仍为NUMBER,TEXT,如果是填入上一次的值
> >    判断表单属性是否仍为SELECT
> >    如果是
> >    继续判断上一次填入的选项是否仍然在当前配置选项中
> >    如果是填入上一次的值
> >    如果否填入该SELECT选项的默认值
> 
>    
> 
> -    如果否
> 
> >    按当前配置html表单的默认值填入


目前时间节点用户可以在创建交互式应用时切换集群，当用户切换集群时，在新的集群下重新查找表单，如果有按上述步骤重新判断填入值
如果用户默认集群下有上一次提交记录，切换集群后没有上一次提交记录，重新按照切换后的集群默认值填入表单

### 实装后
用户创建交互式应用后会在相应家目录/scow/apps/app[appId]下存入last_submission.json文件
<img width="743" alt="image" src="https://user-images.githubusercontent.com/43978285/236622845-d472f554-2ce3-4843-9d45-00d81df6d238.png">
![image](https://user-images.githubusercontent.com/43978285/236622818-9d46c70a-8f1a-4077-b8e0-15a60aed84a8.png)
再度打开同一应用时，会查找是否存在last_submission.json按填写逻辑填写表单
<img width="964" alt="image" src="https://user-images.githubusercontent.com/43978285/236623705-0b4ab84c-80a2-491d-aba6-bb7558c2ddea.png">
![chrome-capture-2023-4-6](https://user-images.githubusercontent.com/43978285/236624116-173cdb9e-9549-4709-83db-f0cad878a517.gif)
当上一次提交记录中的账户被修改过，会按账户下拉表单的第一项填写表单
当上一次提交记录中的集群配置被变更过，会按当前集群默认配置填写表单
当从上面示例的账户a_defgh下移除用户demo_admin后===>会按照新的账户列表下拉表单第一项a_cdefg展示账户
当从上面示例的集群配置变更为新的不包含high的compute分区后===>会按照新的集群的默认配置low展示集群分区
<img width="946" alt="image" src="https://user-images.githubusercontent.com/43978285/236713568-f266af0c-8f77-4f95-aee5-6b008988c90c.png">
![账户及集群分区内容变更时](https://user-images.githubusercontent.com/43978285/236713592-d3bf12cc-1a34-4c16-906c-10e12a644837.gif)








