### PR TITLE
chore: 更新更新日志的格式

### DIFF
--- a/.changeset/angry-chicken-tan.md
+++ b/.changeset/angry-chicken-tan.md
@@ -1,0 +1,7 @@
+---
+"@scow/cli": patch
+"@scow/config": patch
+"@scow/grpc-api": patch
+---
+
+测试

--- a/.changeset/angry-chicken-tan.md
+++ b/.changeset/angry-chicken-tan.md
@@ -1,7 +1,0 @@
----
-"@scow/cli": patch
-"@scow/config": patch
-"@scow/grpc-api": patch
----
-
-测试

--- a/scripts/version.mjs
+++ b/scripts/version.mjs
@@ -134,7 +134,7 @@ const changelogContent = `# v${rootPackageJson.version}
 
 发布于：${new Date().toLocaleString("zh-CN", { timeZone: "Asia/Shanghai" })}
 
-SCOW API版本：${scowApiVersion} ([查看变更](#scow-api-和-hook-(grpc-api))))
+SCOW API版本：${scowApiVersion} ([查看变更](#scow-api和hook-grpc-api))
 
 配置文件版本：${configVersion} ([查看变更](#配置文件))
 

--- a/scripts/version.mjs
+++ b/scripts/version.mjs
@@ -134,26 +134,18 @@ const changelogContent = `# v${rootPackageJson.version}
 
 发布于：${new Date().toLocaleString("zh-CN", { timeZone: "Asia/Shanghai" })}
 
-SCOW API版本：${scowApiVersion} ([查看变更](#scow-api-和-hook))
+SCOW API版本：${scowApiVersion} ([查看变更](#scow-api-和-hook-(grpc-api))))
 
 配置文件版本：${configVersion} ([查看变更](#配置文件))
 
 ${generateContent("portal-web", "门户系统前端")}
-
 ${generateContent("portal-server", "门户系统后端")}
-
 ${generateContent("mis-web", "管理系统前端")}
-
 ${generateContent("mis-server", "管理系统后端")}
-
 ${generateContent("auth", "认证系统")}
-
 ${generateContent("cli", "CLI")}
-
 ${generateContent("gateway", "网关")}
-
 ${generateContent("grpc-api", "SCOW API和Hook")}
-
 ${generateContent("config", "配置文件")}
 `;
 

--- a/scripts/version.mjs
+++ b/scripts/version.mjs
@@ -97,9 +97,11 @@ const getChangesetLine = (line) =>
   `- ${line.content}` +
   ` ([${line.gitCommit.substring(0, 8)}](https://github.com/PKUHPC/SCOW/commit/${line.gitCommit}))`;
 
-const generateContent = (scowPackage) => {
+const generateContent = (scowPackage, title) => {
 
   const packageChanges = changes[scowPackage];
+
+  if (packageChanges.length === 0) { return ""; }
 
   // categories changes by type
 
@@ -109,7 +111,7 @@ const generateContent = (scowPackage) => {
     changesByType[change.type].push(change);
   }
 
-  let content = "";
+  let content = `## ${title} (${scowPackage}) \n\n`;
   if (changesByType.major.length > 0) {
     content += "### 重大更新\n" + changesByType.major.map(getChangesetLine).join("\n") + "\n\n";
   }
@@ -136,41 +138,23 @@ SCOW API版本：${scowApiVersion} ([查看变更](#scow-api-和-hook))
 
 配置文件版本：${configVersion} ([查看变更](#配置文件))
 
-## 门户系统前端 (portal-web)
+${generateContent("portal-web", "门户系统前端")}
 
-${generateContent("portal-web")}
+${generateContent("portal-server", "门户系统后端")}
 
-## 门户系统后端 (portal-server)
+${generateContent("mis-web", "管理系统前端")}
 
-${generateContent("portal-server")}
+${generateContent("mis-server", "管理系统后端")}
 
-## 管理系统前端（mis-web)
+${generateContent("auth", "认证系统")}
 
-${generateContent("mis-web")}
+${generateContent("cli", "CLI")}
 
-## 管理系统服务器 (mis-server)
+${generateContent("gateway", "网关")}
 
-${generateContent("mis-server")}
+${generateContent("grpc-api", "SCOW API和Hook")}
 
-## 认证系统 (auth)
-
-${generateContent("auth")}
-
-## CLI (cli)
-
-${generateContent("cli")}
-
-## 网关 (gateway)
-
-${generateContent("gateway")}
-
-## SCOW API和Hook
-
-${generateContent("grpc-api")}
-
-## 配置文件
-
-${generateContent("config")}
+${generateContent("config", "配置文件")}
 `;
 
 const CHANGELOG_BASE_PATH = "changelogs";

--- a/scripts/version.mjs
+++ b/scripts/version.mjs
@@ -38,6 +38,7 @@ const changes = {
   "cli": [],
   "gateway": [],
   "grpc-api": [],
+  "config": [],
 };
 
 for (const file of files) {
@@ -124,9 +125,16 @@ const generateContent = (scowPackage) => {
   return content.trim();
 };
 
+const scowApiVersion = readPackageJson("protos/package.json").version;
+const configVersion = readPackageJson("libs/config/package.json").version;
+
 const changelogContent = `# v${rootPackageJson.version}
 
 发布于：${new Date().toLocaleString("zh-CN", { timeZone: "Asia/Shanghai" })}
+
+SCOW API版本：${scowApiVersion} ([查看变更](#scow-api-和-hook))
+
+配置文件版本：${configVersion} ([查看变更](#配置文件))
 
 ## 门户系统前端 (portal-web)
 
@@ -159,6 +167,10 @@ ${generateContent("gateway")}
 ## SCOW API和Hook
 
 ${generateContent("grpc-api")}
+
+## 配置文件
+
+${generateContent("config")}
 `;
 
 const CHANGELOG_BASE_PATH = "changelogs";

--- a/scripts/version.mjs
+++ b/scripts/version.mjs
@@ -101,7 +101,7 @@ const generateContent = (scowPackage, title) => {
 
   const packageChanges = changes[scowPackage];
 
-  if (packageChanges.length === 0) { return "\n"; }
+  if (packageChanges.length === 0) { return ""; }
 
   // categories changes by type
 
@@ -124,7 +124,7 @@ const generateContent = (scowPackage, title) => {
     content += "### 小型更新\n" + changesByType.patch.map(getChangesetLine).join("\n") + "\n\n";
   }
 
-  return content.trim();
+  return content.trim() + "\n";
 };
 
 const scowApiVersion = readPackageJson("protos/package.json").version;

--- a/scripts/version.mjs
+++ b/scripts/version.mjs
@@ -124,7 +124,7 @@ const generateContent = (scowPackage, title) => {
     content += "### 小型更新\n" + changesByType.patch.map(getChangesetLine).join("\n") + "\n\n";
   }
 
-  return content.trim() + "\n";
+  return content.trim() + "\n\n";
 };
 
 const scowApiVersion = readPackageJson("protos/package.json").version;
@@ -138,15 +138,16 @@ SCOW API版本：${scowApiVersion} ([查看变更](#scow-api和hook-grpc-api))
 
 配置文件版本：${configVersion} ([查看变更](#配置文件-config))
 
-${generateContent("portal-web", "门户系统前端")}
-${generateContent("portal-server", "门户系统后端")}
-${generateContent("mis-web", "管理系统前端")}
-${generateContent("mis-server", "管理系统后端")}
-${generateContent("auth", "认证系统")}
-${generateContent("cli", "CLI")}
-${generateContent("gateway", "网关")}
-${generateContent("grpc-api", "SCOW API和Hook")}
-${generateContent("config", "配置文件")}
+${generateContent("portal-web", "门户系统前端")
+ + generateContent("portal-server", "门户系统后端")
+ + generateContent("mis-web", "管理系统前端")
+ + generateContent("mis-server", "管理系统后端")
+ + generateContent("auth", "认证系统")
+ + generateContent("cli", "CLI")
+ + generateContent("gateway", "网关")
+ + generateContent("grpc-api", "SCOW API和Hook")
+ + generateContent("config", "配置文件")
+}
 `;
 
 const CHANGELOG_BASE_PATH = "changelogs";

--- a/scripts/version.mjs
+++ b/scripts/version.mjs
@@ -101,7 +101,7 @@ const generateContent = (scowPackage, title) => {
 
   const packageChanges = changes[scowPackage];
 
-  if (packageChanges.length === 0) { return ""; }
+  if (packageChanges.length === 0) { return "\n"; }
 
   // categories changes by type
 

--- a/scripts/version.mjs
+++ b/scripts/version.mjs
@@ -140,17 +140,17 @@ const changelogContent = `# v${rootPackageJson.version}
 
 发布于：${new Date().toLocaleString("zh-CN", { timeZone: "Asia/Shanghai" })}
 
-# 配置文件更新
+# 配置文件
 
 配置文件版本：${configVersion}
 
 ${generateContent("config")}
-# SCOW API和Hook更新
+# SCOW API和Hook
 
 SCOW API版本：${scowApiVersion}
 
 ${generateContent("grpc-api")}
-# SCOW更新
+# SCOW
 
 ${generateContent("portal-web", "门户系统前端")
  + generateContent("portal-server", "门户系统后端")

--- a/scripts/version.mjs
+++ b/scripts/version.mjs
@@ -97,6 +97,12 @@ const getChangesetLine = (line) =>
   `- ${line.content}` +
   ` ([${line.gitCommit.substring(0, 8)}](https://github.com/PKUHPC/SCOW/commit/${line.gitCommit}))`;
 
+/**
+ * Generate changelog content for a package
+ * @param {string} scowPackage the package name
+ * @param {string | undefined} title title. if not set, no title is shown
+ * @returns changelog content
+ */
 const generateContent = (scowPackage, title) => {
 
   const packageChanges = changes[scowPackage];
@@ -111,7 +117,7 @@ const generateContent = (scowPackage, title) => {
     changesByType[change.type].push(change);
   }
 
-  let content = `## ${title} (${scowPackage}) \n\n`;
+  let content = title ? `## ${title} (${scowPackage}) \n\n` : "";
   if (changesByType.major.length > 0) {
     content += "### 重大更新\n" + changesByType.major.map(getChangesetLine).join("\n") + "\n\n";
   }
@@ -134,9 +140,19 @@ const changelogContent = `# v${rootPackageJson.version}
 
 发布于：${new Date().toLocaleString("zh-CN", { timeZone: "Asia/Shanghai" })}
 
-SCOW API版本：${scowApiVersion} ([查看变更](#scow-api和hook-grpc-api))
+# 配置文件更新
 
-配置文件版本：${configVersion} ([查看变更](#配置文件-config))
+配置文件版本：${configVersion}
+
+${generateContent("config")}
+
+# SCOW API和Hook更新
+
+SCOW API版本：${scowApiVersion}
+
+${generateContent("grpc-api")}
+
+# SCOW更新
 
 ${generateContent("portal-web", "门户系统前端")
  + generateContent("portal-server", "门户系统后端")
@@ -145,8 +161,6 @@ ${generateContent("portal-web", "门户系统前端")
  + generateContent("auth", "认证系统")
  + generateContent("cli", "CLI")
  + generateContent("gateway", "网关")
- + generateContent("grpc-api", "SCOW API和Hook")
- + generateContent("config", "配置文件")
 }
 `;
 

--- a/scripts/version.mjs
+++ b/scripts/version.mjs
@@ -148,6 +148,7 @@ ${generateContent("config")}
 # SCOW API和Hook更新
 
 SCOW API版本：${scowApiVersion}
+
 ${generateContent("grpc-api")}
 # SCOW更新
 

--- a/scripts/version.mjs
+++ b/scripts/version.mjs
@@ -136,7 +136,7 @@ const changelogContent = `# v${rootPackageJson.version}
 
 SCOW API版本：${scowApiVersion} ([查看变更](#scow-api和hook-grpc-api))
 
-配置文件版本：${configVersion} ([查看变更](#配置文件))
+配置文件版本：${configVersion} ([查看变更](#配置文件-config))
 
 ${generateContent("portal-web", "门户系统前端")}
 ${generateContent("portal-server", "门户系统后端")}

--- a/scripts/version.mjs
+++ b/scripts/version.mjs
@@ -145,13 +145,10 @@ const changelogContent = `# v${rootPackageJson.version}
 配置文件版本：${configVersion}
 
 ${generateContent("config")}
-
 # SCOW API和Hook更新
 
 SCOW API版本：${scowApiVersion}
-
 ${generateContent("grpc-api")}
-
 # SCOW更新
 
 ${generateContent("portal-web", "门户系统前端")


### PR DESCRIPTION
新格式为：

```markdown
# v0.5.1

发布于：2023/5/9 11:53:59

# 配置文件

配置文件版本：0.2.1

### 小型更新
- 测试 ([e42cd135](https://github.com/PKUHPC/SCOW/commit/e42cd13536a922d49fa018114e51f0e28f33512a))


# SCOW API和Hook

SCOW API版本：0.3.1

### 小型更新
- 测试 ([e42cd135](https://github.com/PKUHPC/SCOW/commit/e42cd13536a922d49fa018114e51f0e28f33512a))


# SCOW

## CLI (cli) 

### 小型更新
- 测试 ([e42cd135](https://github.com/PKUHPC/SCOW/commit/e42cd13536a922d49fa018114e51f0e28f33512a))



```