### PR TITLE
fix(portal-web): 修改已创建的交互式应用页面checkbox居中显示

### DIFF
--- a/.changeset/pink-news-chew.md
+++ b/.changeset/pink-news-chew.md
@@ -1,0 +1,5 @@
+---
+"@scow/portal-web": patch
+---
+
+修改已创建的交互式应用页面刷新 checkbox 为居中显示

--- a/apps/portal-web/src/pageComponents/app/AppSessionsTable.tsx
+++ b/apps/portal-web/src/pageComponents/app/AppSessionsTable.tsx
@@ -202,14 +202,15 @@ export const AppSessionsTable: React.FC<Props> = () => {
               <Button loading={isLoading} onClick={reload}>刷新</Button>
             </Space>
           </Form.Item>
-          <Checkbox
-            checked={checked}
-            disabled={disabled}
-            onChange={onChange}
-            style={{ lineHeight: "40px", marginLeft: "10px" }}
-          >
-            10s自动刷新
-          </Checkbox>
+          <Form.Item>
+            <Checkbox
+              checked={checked}
+              disabled={disabled}
+              onChange={onChange}
+            >
+              10s自动刷新
+            </Checkbox>
+          </Form.Item>
         </Form>
       </FilterFormContainer>
       <Table


### PR DESCRIPTION
修改前
![image](https://github.com/PKUHPC/SCOW/assets/43978285/a0932bf9-eff4-42c5-9468-a87a0bb3e301)

修改后本地测试
![image](https://github.com/PKUHPC/SCOW/assets/43978285/cb4d8921-3d24-4e7f-943e-7e8110dc12a0)

