### PR TITLE
fix(web): 登录信息关闭浏览器后即失效

### DIFF
--- a/.changeset/eight-crews-hang.md
+++ b/.changeset/eight-crews-hang.md
@@ -1,0 +1,6 @@
+---
+"@scow/portal-web": patch
+"@scow/mis-web": patch
+---
+
+浏览器关闭后，用户登录 cookie 失效

--- a/apps/mis-web/src/auth/cookie.ts
+++ b/apps/mis-web/src/auth/cookie.ts
@@ -26,7 +26,6 @@ export function getTokenFromCookie(ctx?: ParseCookieContext): string | undefined
 
 function setCookieWithAge(ctx: SetCookieContext, key: string, value: string) {
   setCookie(ctx, key, value, {
-    maxAge: 30 * 24 * 60 * 60,
     path: COOKIE_PATH,
   });
 }

--- a/apps/portal-web/src/auth/cookie.ts
+++ b/apps/portal-web/src/auth/cookie.ts
@@ -26,7 +26,6 @@ export function getTokenFromCookie(ctx?: ParseCookieContext): string | undefined
 
 function setCookieWithAge(ctx: SetCookieContext, key: string, value: string) {
   setCookie(ctx, key, value, {
-    maxAge: 30 * 24 * 60 * 60,
     path: COOKIE_PATH,
   });
 }


### PR DESCRIPTION
关闭浏览器后，登录cookie即失效。token的失效规则没有变化（`tokenTimeoutSeconds`配置）。