### PR TITLE
fix(portal-web): 修复API没有正确添加base path的问题

### DIFF
--- a/.changeset/shaggy-dancers-mate.md
+++ b/.changeset/shaggy-dancers-mate.md
@@ -1,0 +1,5 @@
+---
+"@scow/portal-web": patch
+---
+
+修复 portal-web 项目 API 路径没有正确添加 base path 的问题

--- a/apps/portal-web/src/apis/api.ts
+++ b/apps/portal-web/src/apis/api.ts
@@ -50,10 +50,9 @@ import type { GetRunningJobsSchema } from "src/pages/api/job/getRunningJobs";
 import type { ListJobTemplatesSchema } from "src/pages/api/job/listJobTemplates";
 import type { SubmitJobSchema } from "src/pages/api/job/submitJob";
 import type { ChangePasswordSchema } from "src/pages/api/profile/changePassword";
+import { publicConfig } from "src/utils/config";
 
-
-
-const basePath = process.env.NEXT_PUBLIC_BASE_PATH || "";
+const basePath = publicConfig.BASE_PATH || "";
 
 
 export const api = {


### PR DESCRIPTION
#643 在生成API客户端的时候没有正确使用`pnpm client`而是使用了`npx ntar client`，使得API的base path没有取运行时的base path配置。这个PR修改了这个问题。