### PR TITLE
fix(portal-web): 修复 formatSize 公共函数传参单位统一问题

### DIFF
--- a/.changeset/quiet-feet-poke.md
+++ b/.changeset/quiet-feet-poke.md
@@ -1,0 +1,5 @@
+---
+"@scow/portal-web": patch
+---
+
+修改 formatSize 公共函数传参单位统一问题

--- a/apps/portal-web/src/pageComponents/filemanager/FileTable.tsx
+++ b/apps/portal-web/src/pageComponents/filemanager/FileTable.tsx
@@ -95,7 +95,7 @@ export const FileTable: React.FC<Props> = (
         ? ""
         : (
           <Tooltip title={Math.round((size) / 1024).toLocaleString() + "KB"} placement="topRight">
-            <span>{formatSize(size)}</span>
+            <span>{formatSize(Math.round(size / 1024))}</span>
           </Tooltip>
         ),
       sorter: (a, b) => {

--- a/apps/portal-web/src/utils/format.ts
+++ b/apps/portal-web/src/utils/format.ts
@@ -13,7 +13,7 @@
 const DEFAULT_UNIT_MAP = ["KB", "MB", "GB", "TB", "PB"];
 
 /**
- * 传入size的单位应为unitMap的最小单位，默认传入KB
+ * @description 传入size的单位应为unitMap的最小单位，默认传入KB
  * @param size
  * @param unitMap
  * @returns

--- a/apps/portal-web/src/utils/format.ts
+++ b/apps/portal-web/src/utils/format.ts
@@ -12,6 +12,12 @@
 
 const DEFAULT_UNIT_MAP = ["KB", "MB", "GB", "TB", "PB"];
 
+/**
+ * 传入size的单位应为unitMap的最小单位，默认传入KB
+ * @param size
+ * @param unitMap
+ * @returns
+ */
 export const formatSize = (size: number, unitMap: string[] = DEFAULT_UNIT_MAP): string => {
 
   const CARRY = 1024;
@@ -22,18 +28,17 @@ export const formatSize = (size: number, unitMap: string[] = DEFAULT_UNIT_MAP): 
   }
 
   let carryCount = 0;
-  let decimalSize = Math.round(size / CARRY);
 
-  while (decimalSize > CARRY) {
-    decimalSize = decimalSize / CARRY;
+  while (size > CARRY) {
+    size = size / CARRY;
     carryCount++;
   }
 
-  if (decimalSize >= 1000) {
-    decimalSize = decimalSize / CARRY;
+  if (size >= 1000) {
+    size = size / CARRY;
     carryCount++;
   }
 
-  const fixedNumber = decimalSize < 9.996 ? 2 : (decimalSize < 99.95 ? 1 : 0);
-  return `${decimalSize.toFixed(fixedNumber)} ${unitMap[carryCount]}`;
+  const fixedNumber = size < 9.996 ? 2 : (size < 99.95 ? 1 : 0);
+  return `${size.toFixed(fixedNumber)} ${unitMap[carryCount]}`;
 };


### PR DESCRIPTION
### 问题
提交作业页面的总内存容量展示与文件管理的文件大小展示的公用函数formatSize，在使用时提交作业页面传的size单位为MB, unitMap以MB开始。而文件管理使用时size的单位是B, unitMap以KB开始，所以造成其中一个展示单位出现问题。

### 修改
此次修改将传参的size和unitMap的起始单位保持一致，加上注释便于使用时更好的理解

![image](https://github.com/PKUHPC/SCOW/assets/130351655/359115f4-6f42-44ad-a0f8-1ef21075e8d3)

