### PR TITLE
feat(portal-web): 交互式应用列表状态筛选改为勾选只展示未结束的作业

### DIFF
--- a/.changeset/red-candles-sleep.md
+++ b/.changeset/red-candles-sleep.md
@@ -1,0 +1,5 @@
+---
+"@scow/portal-web": patch
+---
+
+portal-web 交互式应用列表状态筛选改为勾选只展示未结束的作业

--- a/apps/portal-web/src/pageComponents/app/AppSessionsTable.tsx
+++ b/apps/portal-web/src/pageComponents/app/AppSessionsTable.tsx
@@ -15,7 +15,7 @@ import { compareDateTime, formatDateTime } from "@scow/lib-web/build/utils/datet
 import { compareNumber } from "@scow/lib-web/build/utils/math";
 import { queryToString } from "@scow/lib-web/build/utils/querystring";
 import type { AppSession } from "@scow/protos/build/portal/app";
-import { App, Button, Checkbox, Form, Popconfirm, Select, Space, Table, TableColumnsType, Tooltip } from "antd";
+import { App, Button, Checkbox, Form, Popconfirm, Space, Table, TableColumnsType, Tooltip } from "antd";
 import type { CheckboxChangeEvent } from "antd/es/checkbox";
 import { useRouter } from "next/router";
 import { join } from "path";
@@ -30,13 +30,6 @@ import { ConnectTopAppLink } from "src/pageComponents/app/ConnectToAppLink";
 import { AppsStore } from "src/stores/AppsStore";
 import { DefaultClusterStore } from "src/stores/DefaultClusterStore";
 import { publicConfig } from "src/utils/config";
-
-const filterStates = {
-  RUNNING: "运行中",
-  PENDING: "排队中",
-};
-
-type State = keyof typeof filterStates;
 
 interface Props {
 }
@@ -57,7 +50,7 @@ export const AppSessionsTable: React.FC<Props> = () => {
 
   const [connectivityRefreshToken, setConnectivityRefreshToken] = useState(false);
 
-  const [appSessionState, setAppSessionState] = useState<State>("RUNNING");
+  const [statusChecked, setStatusChecked] = useState(false);
 
   const { data, isLoading, reload } = useAsync({
     promiseFn: useCallback(async () => {
@@ -228,24 +221,18 @@ export const AppSessionsTable: React.FC<Props> = () => {
               10s自动刷新
             </Checkbox>
           </Form.Item>
-          <Form.Item label="状态">
-            <Select
-              style={{ minWidth: "100px" }}
-              value={appSessionState}
-              allowClear
-              onChange={(value) => setAppSessionState(value)}
+          <Form.Item>
+            <Checkbox
+              checked={statusChecked}
+              onChange={(e) => setStatusChecked(e.target.checked)}
             >
-              {Object.keys(filterStates).map((key) => (
-                <Select.Option key={key} value={key}>
-                  {filterStates[key]}
-                </Select.Option>
-              ))}
-            </Select>
+              只展示未结束的作业
+            </Checkbox>
           </Form.Item>
         </Form>
       </FilterFormContainer>
       <Table
-        dataSource={appSessionState ? data?.filter((x) => x.state === appSessionState) : data}
+        dataSource={statusChecked ? data?.filter((x) => (x.state === "RUNNING" || x.state === "PENDING")) : data}
         columns={columns}
         rowKey={(record) => record.sessionId}
         loading={!data && isLoading}

--- a/apps/portal-web/src/pageComponents/app/AppSessionsTable.tsx
+++ b/apps/portal-web/src/pageComponents/app/AppSessionsTable.tsx
@@ -50,7 +50,7 @@ export const AppSessionsTable: React.FC<Props> = () => {
 
   const [connectivityRefreshToken, setConnectivityRefreshToken] = useState(false);
 
-  const [statusChecked, setStatusChecked] = useState(false);
+  const [onlyNotEnded, setOnlyNotEnded] = useState(false);
 
   const { data, isLoading, reload } = useAsync({
     promiseFn: useCallback(async () => {
@@ -223,8 +223,8 @@ export const AppSessionsTable: React.FC<Props> = () => {
           </Form.Item>
           <Form.Item>
             <Checkbox
-              checked={statusChecked}
-              onChange={(e) => setStatusChecked(e.target.checked)}
+              checked={onlyNotEnded}
+              onChange={(e) => setOnlyNotEnded(e.target.checked)}
             >
               只展示未结束的作业
             </Checkbox>
@@ -232,7 +232,7 @@ export const AppSessionsTable: React.FC<Props> = () => {
         </Form>
       </FilterFormContainer>
       <Table
-        dataSource={statusChecked ? data?.filter((x) => (x.state === "RUNNING" || x.state === "PENDING")) : data}
+        dataSource={onlyNotEnded ? data?.filter((x) => x.state !== "ENDED") : data}
         columns={columns}
         rowKey={(record) => record.sessionId}
         loading={!data && isLoading}


### PR DESCRIPTION
交互式应用列表状态单选进行中和排队中改为勾选是否只展示未结束的作业，默认不勾选，展示所有作业

![image](https://github.com/PKUHPC/SCOW/assets/130351655/1ee5a24a-1ada-4a71-bbc3-d2d1d8f37bdd)
