### PR TITLE
fix(mis): 租户信息管理员 id 展示 userId 修复

### DIFF
--- a/.changeset/tall-hats-exercise.md
+++ b/.changeset/tall-hats-exercise.md
@@ -1,0 +1,5 @@
+---
+"@scow/mis-server": patch
+---
+
+租户信息管理员 id 展示 userId 修复

--- a/apps/mis-server/src/services/tenant.ts
+++ b/apps/mis-server/src/services/tenant.ts
@@ -39,12 +39,12 @@ export const tenantServiceServer = plugin((server) => {
       const accountCount = await em.count(Account, { tenant });
       const userCount = await em.count(User, { tenant });
       const admins = await em.find(User, { tenant, tenantRoles: { $like: `%${TenantRole.TENANT_ADMIN}%` } }, {
-        fields: ["id", "userId", "name"],
+        fields: ["userId", "name"],
       });
 
       return [{
         accountCount,
-        admins: admins.map((a) => ({ id: a.id + "", userId: a.userId, userName: a.name })),
+        admins: admins.map((a) => ({ userId: a.userId, userName: a.name })),
         userCount,
         balance: decimalToMoney(tenant.balance),
       }];

--- a/apps/mis-server/src/services/tenant.ts
+++ b/apps/mis-server/src/services/tenant.ts
@@ -39,12 +39,12 @@ export const tenantServiceServer = plugin((server) => {
       const accountCount = await em.count(Account, { tenant });
       const userCount = await em.count(User, { tenant });
       const admins = await em.find(User, { tenant, tenantRoles: { $like: `%${TenantRole.TENANT_ADMIN}%` } }, {
-        fields: ["id", "name"],
+        fields: ["id", "userId", "name"],
       });
 
       return [{
         accountCount,
-        admins: admins.map((a) => ({ userId: a.id + "", userName: a.name })),
+        admins: admins.map((a) => ({ id: a.id + "", userId: a.userId, userName: a.name })),
         userCount,
         balance: decimalToMoney(tenant.balance),
       }];

--- a/apps/mis-server/tests/tenant/tenant.test.ts
+++ b/apps/mis-server/tests/tenant/tenant.test.ts
@@ -48,7 +48,7 @@ it("gets tenant info", async () => {
     accountCount: 2,
     userCount: 2,
     balance: decimalToMoney(data.tenant.balance),
-    admins: [data.userA].map((x) => ({ userId: x.id + "", userName: x.name })),
+    admins: [data.userA].map((x) => ({ userId: x.userId, userName: x.name })),
   } as GetTenantInfoResponse);
 });
 


### PR DESCRIPTION
租户信息展示的是数据库user自增id， 此处pr改为user_id

![image](https://github.com/PKUHPC/SCOW/assets/130351655/4eee0926-93b1-46e0-a0c4-3bb5ff544e0c)
