### PR TITLE
fix(web): 去掉 web 端多余的逗号

### DIFF
--- a/.changeset/dirty-spoons-visit.md
+++ b/.changeset/dirty-spoons-visit.md
@@ -1,0 +1,6 @@
+---
+"@scow/portal-web": major
+"@scow/mis-web": major
+---
+
+去掉 web 端多余的逗号

--- a/.changeset/dirty-spoons-visit.md
+++ b/.changeset/dirty-spoons-visit.md
@@ -1,6 +1,6 @@
 ---
-"@scow/portal-web": major
-"@scow/mis-web": major
+"@scow/portal-web": patch
+"@scow/mis-web": patch
 ---
 
 去掉 web 端多余的逗号

--- a/apps/mis-web/src/pages/_document.tsx
+++ b/apps/mis-web/src/pages/_document.tsx
@@ -28,7 +28,7 @@ export default class MyDocument extends Document {
           enhanceApp: (App) => (props) =>
             sheet.collectStyles(
               <StyleProvider cache={antdCache}>
-                <App {...props} />,
+                <App {...props} />
               </StyleProvider>,
             ),
         });

--- a/apps/portal-web/src/pages/_document.tsx
+++ b/apps/portal-web/src/pages/_document.tsx
@@ -28,7 +28,7 @@ export default class MyDocument extends Document {
           enhanceApp: (App) => (props) =>
             sheet.collectStyles(
               <StyleProvider cache={antdCache}>
-                <App {...props} />,
+                <App {...props} />
               </StyleProvider>,
             ),
         });


### PR DESCRIPTION
原本 apps/portal-web/src/pages/_document.tsx 及 apps/portal-web/src/pages/_document.tsx文件中的组件里多写了一个逗号，现去掉
![3](https://github.com/PKUHPC/SCOW/assets/25954437/6a4cf9c2-1c2b-4998-883a-357ae8296f9c)
