### PR TITLE
feat(mis-web, portal-web):  门户和管理系统添加 footer 展示 SCOW 版本和 github 跳转链接

### DIFF
--- a/.changeset/loud-books-tie.md
+++ b/.changeset/loud-books-tie.md
@@ -1,0 +1,7 @@
+---
+"@scow/portal-web": patch
+"@scow/mis-web": patch
+"@scow/lib-web": patch
+---
+
+门户和管理系统添加 footer 展示 SCOW 版本和 github 跳转链接

--- a/apps/mis-web/config.js
+++ b/apps/mis-web/config.js
@@ -91,6 +91,8 @@ const buildRuntimeConfig = async (phase, basePath) => {
 
   const commonConfig = getCommonConfig(configBasePath, console);
 
+  const versionTag = readVersionFile()?.tag;
+
   /**
    * @type {import ("./src/utils/config").ServerRuntimeConfig}
    */
@@ -132,6 +134,8 @@ const buildRuntimeConfig = async (phase, basePath) => {
     PASSWORD_PATTERN_MESSAGE: commonConfig.passwordPattern?.errorMessage,
 
     BASE_PATH: basePath,
+
+    VERSION_TAG: versionTag,
   };
 
   if (!building) {

--- a/apps/mis-web/src/layouts/BaseLayout.tsx
+++ b/apps/mis-web/src/layouts/BaseLayout.tsx
@@ -21,9 +21,10 @@ import { publicConfig } from "src/utils/config";
 
 interface Props {
   footerText: string;
+  versionTag: string | undefined;
 }
 
-export const BaseLayout = ({ footerText, children }: PropsWithChildren<Props>) => {
+export const BaseLayout = ({ footerText, versionTag, children }: PropsWithChildren<Props>) => {
 
   const userStore = useStore(UserStore);
 
@@ -35,6 +36,7 @@ export const BaseLayout = ({ footerText, children }: PropsWithChildren<Props>) =
       user={userStore.user}
       routes={routes}
       footerText={footerText}
+      versionTag={versionTag}
       basePath={publicConfig.BASE_PATH}
       headerRightContent={(
         <>

--- a/apps/mis-web/src/pages/_app.tsx
+++ b/apps/mis-web/src/pages/_app.tsx
@@ -133,7 +133,7 @@ function MyApp({ Component, pageProps, extra }: Props) {
             <GlobalStyle />
             <FailEventHandler />
             <TopProgressBar />
-            <BaseLayout footerText={footerText}>
+            <BaseLayout footerText={footerText} versionTag={publicConfig.VERSION_TAG}>
               <Component {...pageProps} />
             </BaseLayout>
           </AntdConfigProvider>

--- a/apps/mis-web/src/utils/config.ts
+++ b/apps/mis-web/src/utils/config.ts
@@ -49,7 +49,9 @@ export interface PublicRuntimeConfig {
 
   PORTAL_URL: string | undefined;
 
-  PUBLIC_PATH: string | undefined;
+  PUBLIC_PATH: string | undefined
+
+  VERSION_TAG: string | undefined;
 }
 
 export const runtimeConfig: ServerRuntimeConfig = getConfig().serverRuntimeConfig;

--- a/apps/mis-web/src/utils/config.ts
+++ b/apps/mis-web/src/utils/config.ts
@@ -49,7 +49,7 @@ export interface PublicRuntimeConfig {
 
   PORTAL_URL: string | undefined;
 
-  PUBLIC_PATH: string | undefined
+  PUBLIC_PATH: string | undefined;
 
   VERSION_TAG: string | undefined;
 }

--- a/apps/portal-web/config.js
+++ b/apps/portal-web/config.js
@@ -11,11 +11,13 @@
  */
 
 // @ts-check
+/* eslint-disable @typescript-eslint/no-var-requires */
 
 const { envConfig, str, bool, parseKeyValue } = require("@scow/lib-config");
 const { join } = require("path");
 const { homedir } = require("os");
-const { PHASE_DEVELOPMENT_SERVER, PHASE_PRODUCTION_BUILD, PHASE_PRODUCTION_SERVER, PHASE_TEST } = require("next/constants");
+const { PHASE_DEVELOPMENT_SERVER, PHASE_PRODUCTION_BUILD,
+  PHASE_PRODUCTION_SERVER, PHASE_TEST } = require("next/constants");
 
 const { readVersionFile } = require("@scow/utils/build/version");
 const { getCapabilities } = require("@scow/lib-auth");
@@ -102,6 +104,8 @@ const buildRuntimeConfig = async (phase, basePath) => {
   const portalConfig = getPortalConfig(configPath, console);
   const commonConfig = getCommonConfig(configPath, console);
 
+  const versionTag = readVersionFile()?.tag;
+
   /**
    * @type {import("./src/utils/config").ServerRuntimeConfig}
    */
@@ -155,6 +159,8 @@ const buildRuntimeConfig = async (phase, basePath) => {
     CLIENT_MAX_BODY_SIZE: config.CLIENT_MAX_BODY_SIZE,
 
     PUBLIC_PATH: config.PUBLIC_PATH,
+
+    VERSION_TAG: versionTag,
   };
 
   if (!building && !testenv) {

--- a/apps/portal-web/src/layouts/BaseLayout.tsx
+++ b/apps/portal-web/src/layouts/BaseLayout.tsx
@@ -24,9 +24,10 @@ import { publicConfig } from "src/utils/config";
 
 interface Props {
   footerText: string;
+  versionTag: string | undefined;
 }
 
-export const BaseLayout = ({ footerText, children }: PropsWithChildren<Props>) => {
+export const BaseLayout = ({ footerText, versionTag, children }: PropsWithChildren<Props>) => {
 
   const userStore = useStore(UserStore);
   const defaultClusterStore = useStore(DefaultClusterStore);
@@ -42,6 +43,7 @@ export const BaseLayout = ({ footerText, children }: PropsWithChildren<Props>) =
       user={userStore.user}
       routes={routes}
       footerText={footerText}
+      versionTag={versionTag}
       basePath={publicConfig.BASE_PATH}
       headerRightContent={(
         <>

--- a/apps/portal-web/src/pages/_app.tsx
+++ b/apps/portal-web/src/pages/_app.tsx
@@ -138,7 +138,7 @@ function MyApp({ Component, pageProps, extra }: Props) {
             <GlobalStyle />
             <FailEventHandler />
             <TopProgressBar />
-            <BaseLayout footerText={footerText}>
+            <BaseLayout footerText={footerText} versionTag={publicConfig.VERSION_TAG}>
               <Component {...pageProps} />
             </BaseLayout>
           </AntdConfigProvider>

--- a/apps/portal-web/src/utils/config.ts
+++ b/apps/portal-web/src/utils/config.ts
@@ -72,6 +72,8 @@ export interface PublicRuntimeConfig {
 
   PUBLIC_PATH: string;
 
+  VERSION_TAG: string | undefined;
+
 }
 
 export const runtimeConfig: ServerRuntimeConfig = getConfig().serverRuntimeConfig;

--- a/libs/web/src/layouts/base/BaseLayout.tsx
+++ b/libs/web/src/layouts/base/BaseLayout.tsx
@@ -52,6 +52,7 @@ const StyledLayout = styled(Layout)`
 
 type Props = PropsWithChildren<{
   footerText: string;
+  versionTag: string | undefined;
   routes: NavItemProps[];
   logout: (() => void) | undefined;
   user: UserInfo | undefined;
@@ -60,7 +61,7 @@ type Props = PropsWithChildren<{
 }>;
 
 export const BaseLayout: React.FC<PropsWithChildren<Props>> = ({
-  children, footerText, routes, user, logout,
+  children, footerText, versionTag, routes, user, logout,
   headerRightContent, basePath,
 }) => {
 
@@ -105,7 +106,7 @@ export const BaseLayout: React.FC<PropsWithChildren<Props>> = ({
           <Content>
             {children}
           </Content>
-          <Footer text={footerText} />
+          <Footer text={footerText} versionTag={versionTag}/>
         </ContentPart>
       </StyledLayout>
     </Root>

--- a/libs/web/src/layouts/base/Footer.tsx
+++ b/libs/web/src/layouts/base/Footer.tsx
@@ -41,7 +41,7 @@ export const Footer: React.FC<Props> = ({ text, versionTag }) => {
             SCOW
           </a>
           &nbsp;
-          <a href={versionTagLink}>
+          <a href={versionTagLink} target="_blank">
             {versionTag || ""}
           </a>
         </span>

--- a/libs/web/src/layouts/base/Footer.tsx
+++ b/libs/web/src/layouts/base/Footer.tsx
@@ -41,7 +41,9 @@ export const Footer: React.FC<Props> = ({ text, versionTag }) => {
             SCOW
           </a>
           &nbsp;
-          <a href={versionTagLink}>{versionTag || ""}</a>
+          <a href={versionTagLink}>
+            {versionTag || ""}
+          </a>
         </span>
       </FooterContainer>
       <Divider style={{ marginTop: 0, marginBottom: 10 }} />

--- a/libs/web/src/layouts/base/Footer.tsx
+++ b/libs/web/src/layouts/base/Footer.tsx
@@ -55,7 +55,6 @@ export const Footer: React.FC<Props> = ({ text, versionTag }) => {
           </>
         )
       }
-
     </>
   );
 };

--- a/libs/web/src/layouts/base/Footer.tsx
+++ b/libs/web/src/layouts/base/Footer.tsx
@@ -48,7 +48,6 @@ export const Footer: React.FC<Props> = ({ text, versionTag }) => {
         </span>
       </FooterContainer>
     </>
-
   );
 };
 

--- a/libs/web/src/layouts/base/Footer.tsx
+++ b/libs/web/src/layouts/base/Footer.tsx
@@ -28,13 +28,24 @@ interface Props {
 }
 
 export const Footer: React.FC<Props> = ({ text, versionTag }) => {
+
+  const scowGithubLink = versionTag
+    ? `https://github.com/PKUHPC/SCOW/tree/${versionTag}`
+    : "https://github.com/PKUHPC/SCOW";
+
   return (
     <>
       <FooterContainer
         dangerouslySetInnerHTML={{ __html: text }} />
       <Divider style={{ marginTop: 0, marginBottom: 10 }} />
       <FooterContainer>
-        <span>Powered by <a href="https://github.com/" target="_blank">SCOW</a> {versionTag || ""}</span>
+        <span>Powered by&nbsp;
+          <a href={scowGithubLink} target="_blank">
+            SCOW
+          </a>
+          &nbsp;
+          {versionTag || ""}
+        </span>
       </FooterContainer>
     </>
 

--- a/libs/web/src/layouts/base/Footer.tsx
+++ b/libs/web/src/layouts/base/Footer.tsx
@@ -46,9 +46,16 @@ export const Footer: React.FC<Props> = ({ text, versionTag }) => {
           </a>
         </span>
       </FooterContainer>
-      <Divider style={{ marginTop: 0, marginBottom: 10 }} />
-      <FooterContainer
-        dangerouslySetInnerHTML={{ __html: text }} />
+      {
+        text && (
+          <>
+            <Divider style={{ marginTop: 0, marginBottom: 10 }} />
+            <FooterContainer
+              dangerouslySetInnerHTML={{ __html: text }} />
+          </>
+        )
+      }
+
     </>
   );
 };

--- a/libs/web/src/layouts/base/Footer.tsx
+++ b/libs/web/src/layouts/base/Footer.tsx
@@ -29,24 +29,24 @@ interface Props {
 
 export const Footer: React.FC<Props> = ({ text, versionTag }) => {
 
-  const scowGithubLink = versionTag
-    ? `https://github.com/PKUHPC/SCOW/tree/${versionTag}`
-    : "https://github.com/PKUHPC/SCOW";
+  const versionTagLink = versionTag
+    ? `https://github.com/PKUHPC/SCOW/releases/tag/${versionTag}`
+    : "";
 
   return (
     <>
-      <FooterContainer
-        dangerouslySetInnerHTML={{ __html: text }} />
-      <Divider style={{ marginTop: 0, marginBottom: 10 }} />
       <FooterContainer>
         <span>Powered by&nbsp;
-          <a href={scowGithubLink} target="_blank">
+          <a href="https://github.com/PKUHPC/SCOW" target="_blank">
             SCOW
           </a>
           &nbsp;
-          {versionTag || ""}
+          <a href={versionTagLink}>{versionTag || ""}</a>
         </span>
       </FooterContainer>
+      <Divider style={{ marginTop: 0, marginBottom: 10 }} />
+      <FooterContainer
+        dangerouslySetInnerHTML={{ __html: text }} />
     </>
   );
 };

--- a/libs/web/src/layouts/base/Footer.tsx
+++ b/libs/web/src/layouts/base/Footer.tsx
@@ -10,6 +10,7 @@
  * See the Mulan PSL v2 for more details.
  */
 
+import { Divider } from "antd";
 import styled from "styled-components";
 
 const FooterContainer = styled.div`
@@ -23,11 +24,20 @@ const FooterContainer = styled.div`
 
 interface Props {
   text: string;
+  versionTag: string | undefined;
 }
 
-export const Footer: React.FC<Props> = ({ text }) => {
+export const Footer: React.FC<Props> = ({ text, versionTag }) => {
   return (
-    <FooterContainer dangerouslySetInnerHTML={{ __html: text }} />
+    <>
+      <FooterContainer
+        dangerouslySetInnerHTML={{ __html: text }} />
+      <Divider style={{ marginTop: 0, marginBottom: 10 }} />
+      <FooterContainer>
+        <span>Powered by <a href="https://github.com/" target="_blank">SCOW</a> {versionTag || ""}</span>
+      </FooterContainer>
+    </>
+
   );
 };
 


### PR DESCRIPTION
改动：
管理系统和门户系统增加统一Footer，展示github地址链接和版本信息，此Footer放在用户自定义Footer之上，用分割线分开

没有自定义footer：
![image](https://github.com/PKUHPC/SCOW/assets/130351655/9cefae86-e8bb-4e9b-a508-dcd993036024)

有自定义footer：

![image](https://github.com/PKUHPC/SCOW/assets/130351655/13ba20ad-c8ae-42da-8088-8f30a1063356)

