### PR TITLE
feat(mis): 管理平台新增平台信息页面

### DIFF
--- a/.changeset/shiny-bears-retire.md
+++ b/.changeset/shiny-bears-retire.md
@@ -1,0 +1,5 @@
+---
+"@scow/grpc-api": patch
+---
+
+新增 getAdminInfo api 获取平台信息

--- a/.changeset/thin-cows-confess.md
+++ b/.changeset/thin-cows-confess.md
@@ -1,0 +1,6 @@
+---
+"@scow/mis-server": patch
+"@scow/mis-web": patch
+---
+
+管理平台新增平台信息页面

--- a/apps/mis-server/src/services/admin.ts
+++ b/apps/mis-server/src/services/admin.ts
@@ -19,6 +19,8 @@ import { updateBlockStatusInSlurm } from "src/bl/block";
 import { importUsers, ImportUsersData } from "src/bl/importUsers";
 import { Account } from "src/entities/Account";
 import { StorageQuota } from "src/entities/StorageQuota";
+import { Tenant } from "src/entities/Tenant";
+import { PlatformRole, User } from "src/entities/User";
 import { UserAccount, UserRole } from "src/entities/UserAccount";
 
 export const adminServiceServer = plugin((server) => {
@@ -190,5 +192,18 @@ export const adminServiceServer = plugin((server) => {
       return [{}];
     },
 
+    getAdminInfo: async ({ em }) => {
+      const userCount = await em.count(User, {});
+      const accountCount = await em.count(Account, {});
+      const tenantCount = await em.count(Tenant, {});
+      const platformAdmins = await em.find(User, { platformRoles: { $like: `%${PlatformRole.PLATFORM_ADMIN}%` } });
+
+      return [{
+        platformAdmins: platformAdmins.map((x) => ({ userId: x.userId, userName: x.name })),
+        tenantCount,
+        accountCount,
+        userCount,
+      }];
+    },
   });
 });

--- a/apps/mis-server/tests/admin/getAdminInfo.test.ts
+++ b/apps/mis-server/tests/admin/getAdminInfo.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2022 Peking University and Peking University Institute for Computing and Digital Economy
+ * SCOW is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *          http://license.coscl.org.cn/MulanPSL2
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PSL v2 for more details.
+ */
+
+import { asyncClientCall } from "@ddadaal/tsgrpc-client";
+import { Server } from "@ddadaal/tsgrpc-server";
+import { ChannelCredentials } from "@grpc/grpc-js";
+import { SqlEntityManager } from "@mikro-orm/mysql";
+import { AdminServiceClient, GetAdminInfoResponse } from "@scow/protos/build/server/admin";
+import { createServer } from "src/app";
+import { Tenant } from "src/entities/Tenant";
+import { PlatformRole, User } from "src/entities/User";
+import { DEFAULT_TENANT_NAME } from "src/utils/constants";
+import { insertInitialData } from "tests/data/data";
+import { dropDatabase } from "tests/data/helpers";
+
+let server: Server;
+let em: SqlEntityManager;
+let client: AdminServiceClient;
+
+beforeEach(async () => {
+
+  server = await createServer();
+  await server.start();
+
+  client = new AdminServiceClient(server.serverAddress, ChannelCredentials.createInsecure());
+  em = server.ext.orm.em.fork();
+  await insertInitialData(em);
+
+});
+
+afterEach(async () => {
+  await dropDatabase(server.ext.orm);
+  await server.close();
+});
+
+it("get admin info", async () => {
+
+  const tenant = await em.findOneOrFail(Tenant, { name: DEFAULT_TENANT_NAME });
+  const adminUser = new User({
+    name: "admin", userId: "admin_user", email: "admin@admin.com", tenant,
+    platformRoles: [PlatformRole.PLATFORM_ADMIN],
+  });
+  await em.persistAndFlush(adminUser);
+
+  const info = await asyncClientCall(client, "getAdminInfo", {});
+
+  expect(info).toEqual({
+    platformAdmins: [adminUser].map((x) => ({ userId: x.userId, userName: x.name })),
+    tenantCount: 2,
+    accountCount: 3,
+    userCount: 4,
+  } as GetAdminInfoResponse);
+
+});

--- a/apps/mis-web/src/layouts/routes.tsx
+++ b/apps/mis-web/src/layouts/routes.tsx
@@ -28,8 +28,13 @@ export const platformAdminRoutes: (platformRoles: PlatformRole[]) => NavItemProp
     Icon: UserOutlined,
     text: "平台管理",
     path: "/admin",
-    clickable: false,
+    clickToPath: "/admin/info",
     children: [
+      {
+        Icon: InfoOutlined,
+        text: "平台信息",
+        path: "/admin/info",
+      },
       ...(platformRoles.includes(PlatformRole.PLATFORM_ADMIN) ? [
         {
           Icon: UserOutlined,

--- a/apps/mis-web/src/pages/admin/info.tsx
+++ b/apps/mis-web/src/pages/admin/info.tsx
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2022 Peking University and Peking University Institute for Computing and Digital Economy
+ * SCOW is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *          http://license.coscl.org.cn/MulanPSL2
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PSL v2 for more details.
+ */
+
+import { asyncClientCall } from "@ddadaal/tsgrpc-client";
+import type { GetAdminInfoResponse } from "@scow/protos/build/server/admin";
+import { AdminServiceClient } from "@scow/protos/build/server/admin";
+import { Descriptions, Tag } from "antd";
+import { GetServerSideProps, NextPage } from "next";
+import { USE_MOCK } from "src/apis/useMock";
+import { ssrAuthenticate, SSRProps } from "src/auth/server";
+import { UnifiedErrorPage } from "src/components/errorPages/UnifiedErrorPage";
+import { PageTitle } from "src/components/PageTitle";
+import { PlatformRole } from "src/models/User";
+import { getClient } from "src/utils/client";
+import { Head } from "src/utils/head";
+
+type Info = GetAdminInfoResponse
+
+type Props = SSRProps<Info, 500>
+
+export const PlatformInfoPage: NextPage<Props> = (props) => {
+
+  if ("error" in props) {
+    return <UnifiedErrorPage code={props.error} />;
+  }
+
+  const { platformAdmins, tenantCount, accountCount, userCount } = props;
+
+
+  return (
+    <div>
+      <Head title="平台信息" />
+      <PageTitle titleText={"平台信息"} />
+      <Descriptions bordered column={1}>
+        <Descriptions.Item label="平台管理员">
+          {
+            platformAdmins.map(({ userId, userName }) => (
+              <Tag key={userId}>
+                {userName} (ID: {userId})
+              </Tag>
+            ))
+          }
+        </Descriptions.Item>
+        <Descriptions.Item label="租户数量">
+          {tenantCount}
+        </Descriptions.Item>
+        <Descriptions.Item label="账户数量">
+          {accountCount}
+        </Descriptions.Item>
+        <Descriptions.Item label="用户数量">
+          {userCount}
+        </Descriptions.Item>
+      </Descriptions>
+    </div>
+  );
+};
+
+export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
+
+  const auth = ssrAuthenticate(
+    (i) => i.platformRoles.includes(PlatformRole.PLATFORM_ADMIN || PlatformRole.PLATFORM_FINANCE),
+  );
+
+  const info = await auth(ctx.req);
+
+  if (typeof info === "number") {
+    return { props: { error: info } };
+  }
+
+  if (USE_MOCK) {
+    return { props: {
+      platformAdmins: [{ userId: "demo_admin", userName: "demo_admin" }],
+      tenantCount: 10,
+      accountCount: 20,
+      userCount: 100,
+    } };
+  }
+
+  const client = getClient(AdminServiceClient);
+  return await asyncClientCall(client, "getAdminInfo", {})
+    .then((response) => ({ props: response }))
+    .catch(() => ({ props: { error: 500 as const } }));
+};
+
+export default PlatformInfoPage;

--- a/protos/server/admin.proto
+++ b/protos/server/admin.proto
@@ -22,6 +22,11 @@ enum ChangeStorageQuotaMode {
   SET = 2;
 }
 
+message PlatFormAdminInfo {
+  string user_id = 1;
+  string user_name = 2;
+}
+
 message ChangeStorageQuotaRequest {
   string user_id = 1;
   string cluster = 2;
@@ -122,6 +127,16 @@ message UpdateBlockStatusRequest{
 message UpdateBlockStatusResponse{
 }
 
+message GetAdminInfoRequest {
+}
+
+message GetAdminInfoResponse {
+  repeated PlatFormAdminInfo platform_admins = 1;
+  uint64 tenant_count = 2;
+  uint64 account_count = 3;
+  uint64 user_count = 4;
+}
+
 service AdminService {
   rpc ChangeStorageQuota(ChangeStorageQuotaRequest)
       returns (ChangeStorageQuotaResponse);
@@ -134,4 +149,5 @@ service AdminService {
   rpc FetchJobs(FetchJobsRequest) returns (FetchJobsResponse);
   rpc UpdateBlockStatus(UpdateBlockStatusRequest)
     returns (UpdateBlockStatusResponse);
+  rpc GetAdminInfo(GetAdminInfoRequest) returns (GetAdminInfoResponse);
 }


### PR DESCRIPTION
**改动**

管理平台的平台管理tab新增子菜单平台信息：

![image](https://github.com/PKUHPC/SCOW/assets/130351655/dd8f026b-9b65-4ca9-9940-4da21ba58ad4)

新增平台信息页面展示平台管理员，租户数量，账户数量以及用户数量
![image](https://github.com/PKUHPC/SCOW/assets/130351655/ca9fe797-4e62-460e-860f-0abbb185b1e6)

新增getAdminInfo api 获取平台信息
