### PR TITLE
fix(potal-web): 修复 dev container 和本地 vagrant 开发模式下集群配置不一致问题

### DIFF
--- a/.changeset/few-students-hug.md
+++ b/.changeset/few-students-hug.md
@@ -1,0 +1,5 @@
+---
+"@scow/portal-web": patch
+---
+
+修复 dev container 和本地 vagrant 开发模式下集群配置不一致问题

--- a/apps/portal-web/package.json
+++ b/apps/portal-web/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "cross-env NEXT_PUBLIC_USE_MOCK=1 TS_NODE_PROJECT=tsconfig.server.json node --watch -r ts-node/register -r tsconfig-paths/register server/index.ts",
-    "dev:server": "cross-env NEXT_PUBLIC_USE_MOCK=1 TS_NODE_PROJECT=tsconfig.server.json node --watch -r ts-node/register -r tsconfig-paths/register server/index.ts",
+    "dev:server": "cross-env NEXT_PUBLIC_USE_MOCK=0 TS_NODE_PROJECT=tsconfig.server.json node --watch -r ts-node/register -r tsconfig-paths/register server/index.ts",
     "serve": "node build/server/index.js",
     "build": "pnpm prepareDev && npm run build:next && npm run build:ts",
     "build:next": "next build",


### PR DESCRIPTION
### 问题和改动
NEXT_PUBLIC_USE_MOCK = 1时，portal-web的集群配置路径会选择本项目下的config文件而不是/dev/vagrant/clusters。 会导致cluster配置和本地vagrant不一致，将其修复为NEXT_PUBLIC_USE_MOCK = 0；
