### PR TITLE
feat(mis): 增加仅在 scow 数据库新增用户的 API

### DIFF
--- a/.changeset/lazy-brooms-dream.md
+++ b/.changeset/lazy-brooms-dream.md
@@ -1,0 +1,6 @@
+---
+"@scow/mis-server": patch
+"@scow/grpc-api": patch
+---
+
+增加仅在 scow 数据库新增用户的 API

--- a/apps/mis-server/src/services/user.ts
+++ b/apps/mis-server/src/services/user.ts
@@ -392,7 +392,7 @@ export const userServiceServer = plugin((server) => {
             message: `Error creating user with userId ${identityId} in database.` };
         });
 
-      await callHook("userCreated", { tenantName, userId: user.userId }, logger);
+      await callHook("userAdded", { tenantName, userId: user.userId }, logger);
 
       return [{
         id: user.id,

--- a/apps/mis-server/src/services/user.ts
+++ b/apps/mis-server/src/services/user.ts
@@ -320,6 +320,10 @@ export const userServiceServer = plugin((server) => {
       return [{}];
     },
 
+    /**
+     * 新增用户，在数据库中增加用户后调用auth服务在ldap中增加该用户，
+     * 并将公钥插入用户的authorized_keys
+     */
     createUser: async ({ request, em, logger }) => {
       const { name, tenantName, email, identityId, password } = request;
       const user = await createUserInDatabase(identityId, name, email, tenantName, server.logger, em)
@@ -368,7 +372,11 @@ export const userServiceServer = plugin((server) => {
       }];
     },
 
-    createUserOnlyInDatabase: async ({ request, em, logger }) => {
+    /**
+     * 仅在数据库中增加用户数据，用于结合自定义认证系统新增用户，
+     * 与createUser的区别在于不需要password，不调用auth服务，暂不将公钥插入用户authorized_keys
+     */
+    addUser: async ({ request, em, logger }) => {
       const { name, tenantName, email, identityId } = request;
       const user = await createUserInDatabase(identityId, name, email, tenantName, server.logger, em)
         .catch((e) => {

--- a/apps/mis-server/tests/admin/user.test.ts
+++ b/apps/mis-server/tests/admin/user.test.ts
@@ -80,6 +80,23 @@ it("creates user", async () => {
   );
 });
 
+it("creates user only in database", async () => {
+
+  const name = "123";
+  const userId = "2";
+  const email = "test@test.com";
+
+  await asyncClientCall(client, "createUserOnlyInDatabase",
+    { name, identityId: userId, email, tenantName: tenant.name });
+
+  const em = server.ext.orm.em.fork();
+
+  const user = await em.findOneOrFail(User, { userId });
+
+  expect(user.name).toBe(name);
+
+});
+
 it("cannot create user if userId exists", async () => {
   const name = "123";
   const userId = "2";

--- a/apps/mis-server/tests/admin/user.test.ts
+++ b/apps/mis-server/tests/admin/user.test.ts
@@ -80,13 +80,13 @@ it("creates user", async () => {
   );
 });
 
-it("creates user only in database", async () => {
+it("add user only in database", async () => {
 
   const name = "123";
   const userId = "2";
   const email = "test@test.com";
 
-  await asyncClientCall(client, "createUserOnlyInDatabase",
+  await asyncClientCall(client, "addUser",
     { name, identityId: userId, email, tenantName: tenant.name });
 
   const em = server.ext.orm.em.fork();

--- a/protos/hook/hook.proto
+++ b/protos/hook/hook.proto
@@ -49,6 +49,11 @@ message UserCreated {
   string tenant_name = 2;
 }
 
+message UserAdded {
+  string user_id = 1;
+  string tenant_name = 2;
+}
+
 message AccountPaid {
   string account_name = 1;
   common.Money amount = 2;
@@ -73,8 +78,9 @@ message OnEventRequest {
     UserBlockedInAccount user_blocked_in_account = 5;
     UserUnblockedInAccount user_unblocked_in_account = 6;
     UserCreated user_created = 7;
-    AccountPaid account_paid = 8;
-    TenantPaid tenant_paid = 9;
+    UserAdded user_added = 8;
+    AccountPaid account_paid = 9;
+    TenantPaid tenant_paid = 10;
   }
 }
 message OnEventResponse {

--- a/protos/server/user.proto
+++ b/protos/server/user.proto
@@ -165,6 +165,17 @@ message CreateUserResponse {
   bool created_in_auth = 2;
 }
 
+message CreateUserOnlyInDatabaseRequest {
+  string tenant_name = 1;
+  string identity_id = 2;
+  string name = 3;
+  string email = 4;
+}
+
+message CreateUserOnlyInDatabaseResponse {
+  uint32 id = 1;
+}
+
 message DeleteUserRequest {
   string tenant_name = 1;
   string user_id = 2;
@@ -323,6 +334,7 @@ service UserService {
   rpc QueryUsedStorageQuota(QueryUsedStorageQuotaRequest)
       returns (QueryUsedStorageQuotaResponse);
   rpc CreateUser(CreateUserRequest) returns (CreateUserResponse);
+  rpc CreateUserOnlyInDatabase(CreateUserOnlyInDatabaseRequest) returns (CreateUserOnlyInDatabaseResponse);
   rpc DeleteUser(DeleteUserRequest) returns (DeleteUserResponse);
   rpc AddUserToAccount(AddUserToAccountRequest) returns (AddUserToAccountResponse);
   rpc RemoveUserFromAccount(RemoveUserFromAccountRequest)

--- a/protos/server/user.proto
+++ b/protos/server/user.proto
@@ -333,8 +333,15 @@ service UserService {
   rpc GetUserStatus(GetUserStatusRequest) returns (GetUserStatusResponse);
   rpc QueryUsedStorageQuota(QueryUsedStorageQuotaRequest)
       returns (QueryUsedStorageQuotaResponse);
+
+  //新增用户，在数据库中增加用户，然后调用auth服务在ldap中增加该用户，
+  //并将公钥插入用户的authorized_keys
   rpc CreateUser(CreateUserRequest) returns (CreateUserResponse);
+
+  //仅在数据库中增加用户数据，用于结合自定义认证系统新增scow用户，
+  //与createUser的区别在于不需要password，不调用auth服务，暂不将公钥插入用户authorized_keys
   rpc AddUser(AddUserRequest) returns (AddUserResponse);
+
   rpc DeleteUser(DeleteUserRequest) returns (DeleteUserResponse);
   rpc AddUserToAccount(AddUserToAccountRequest) returns (AddUserToAccountResponse);
   rpc RemoveUserFromAccount(RemoveUserFromAccountRequest)

--- a/protos/server/user.proto
+++ b/protos/server/user.proto
@@ -165,14 +165,14 @@ message CreateUserResponse {
   bool created_in_auth = 2;
 }
 
-message CreateUserOnlyInDatabaseRequest {
+message AddUserRequest {
   string tenant_name = 1;
   string identity_id = 2;
   string name = 3;
   string email = 4;
 }
 
-message CreateUserOnlyInDatabaseResponse {
+message AddUserResponse {
   uint32 id = 1;
 }
 
@@ -334,7 +334,7 @@ service UserService {
   rpc QueryUsedStorageQuota(QueryUsedStorageQuotaRequest)
       returns (QueryUsedStorageQuotaResponse);
   rpc CreateUser(CreateUserRequest) returns (CreateUserResponse);
-  rpc CreateUserOnlyInDatabase(CreateUserOnlyInDatabaseRequest) returns (CreateUserOnlyInDatabaseResponse);
+  rpc AddUser(AddUserRequest) returns (AddUserResponse);
   rpc DeleteUser(DeleteUserRequest) returns (DeleteUserResponse);
   rpc AddUserToAccount(AddUserToAccountRequest) returns (AddUserToAccountResponse);
   rpc RemoveUserFromAccount(RemoveUserFromAccountRequest)


### PR DESCRIPTION
mis-server增加一个API：addUser，用于创建用户时仅在scow的数据库中新增用户的场景，如实现自定义认证系统时不需要往LDAP增加用户，外部系统可以调用此API往scow数据库中增加新用户。与createUser的区别在于不需要password，不调用auth服务，暂不将公钥插入用户authorized_keys