### PR TITLE
fix(portal,mis): config中ENABLE_CHANGE_PASSWORD相关的类型错误

### DIFF
--- a/.changeset/many-boxes-bow.md
+++ b/.changeset/many-boxes-bow.md
@@ -1,0 +1,6 @@
+---
+"@scow/portal-web": patch
+"@scow/mis-web": patch
+---
+
+修改了 config 中 ENABLE_CHANGE_PASSWORD 与 authSupportsCreateUser 的类型属性可以为 Undefined

--- a/apps/mis-web/src/utils/config.ts
+++ b/apps/mis-web/src/utils/config.ts
@@ -37,9 +37,9 @@ export interface PublicRuntimeConfig {
   PREDEFINED_CHARGING_TYPES: string[];
   CREATE_USER_CONFIG: {
     misConfig: MisConfigSchema["createUser"],
-    authSupportsCreateUser: boolean,
+    authSupportsCreateUser: boolean | undefined,
   },
-  ENABLE_CHANGE_PASSWORD: boolean;
+  ENABLE_CHANGE_PASSWORD: boolean | undefined;
 
   ACCOUNT_NAME_PATTERN: string | undefined;
   ACCOUNT_NAME_PATTERN_MESSAGE: string | undefined;

--- a/apps/portal-web/src/utils/config.ts
+++ b/apps/portal-web/src/utils/config.ts
@@ -47,7 +47,7 @@ export interface ServerRuntimeConfig {
 }
 
 export interface PublicRuntimeConfig {
-  ENABLE_CHANGE_PASSWORD: boolean;
+  ENABLE_CHANGE_PASSWORD: boolean | undefined;
 
   ENABLE_SHELL: boolean;
 


### PR DESCRIPTION
### 问题
因为 #681 [feat(auth): 认证系统增加管理用户账户关系相关 API](https://github.com/PKUHPC/SCOW/pull/681/files#top) 时修改为capabilities的每个属性可以为undefined出现了config中类型匹配错误，导致本地5001端口无法启动
![image](https://github.com/PKUHPC/SCOW/assets/43978285/ce87b493-2112-4b3f-9f51-ae4017cbf245)
![image](https://github.com/PKUHPC/SCOW/assets/43978285/43254122-da3f-4791-891f-dab26a097a98)

本PR将下述相关接口的类型按照 #681 的功能需求修改为`boolean | undefined`
ENABLE_CHANGE_PASSWORD
CREATE_USER_CONFIG中的authSupportsCreateUser
修改后本地启动无异常
![image](https://github.com/PKUHPC/SCOW/assets/43978285/6ff5db9c-2a8e-4af1-b2f7-8509b9c66bbc)
![image](https://github.com/PKUHPC/SCOW/assets/43978285/bea47757-18a0-4a9b-ad93-0b3da8728050)
