### PR TITLE
chore: 增加处理gRPC Rich Error Model的模块

### DIFF
--- a/libs/rich-error-model/buf.gen.yaml
+++ b/libs/rich-error-model/buf.gen.yaml
@@ -1,0 +1,15 @@
+version: v1
+plugins:
+  - name: ts-proto
+    path: node_modules/ts-proto/protoc-gen-ts_proto
+    strategy: all
+
+    out: src/generated
+    opt:
+      - unrecognizedEnum=false
+      - useDate=string
+      - oneof=unions
+      - esModuleInterop=true
+      - useOptionals=messages
+      - outputServices=grpc-js
+      - outputTypeRegistry=true

--- a/libs/rich-error-model/jest.config.js
+++ b/libs/rich-error-model/jest.config.js
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2022 Peking University and Peking University Institute for Computing and Digital Economy
+ * SCOW is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *          http://license.coscl.org.cn/MulanPSL2
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PSL v2 for more details.
+ */
+
+// jest.config.js
+const { pathsToModuleNameMapper } = require("ts-jest");
+// In the following statement, replace `./tsconfig` with the path to your `tsconfig` file
+// which contains the path mapping (ie the `compilerOptions.paths` option):
+const { compilerOptions } = require("./tsconfig");
+
+/** @type {import('@jest/types').Config.InitialOptions} */
+module.exports = {
+  rootDir: ".",
+  preset: "ts-jest",
+  moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths, { prefix: "<rootDir>/" }),
+  testMatch: [
+    "<rootDir>/tests/**/*.test.ts?(x)",
+  ],
+  coverageDirectory: "coverage",
+  testTimeout: 30000,
+  coverageReporters: ["lcov"],
+  setupFilesAfterEnv: ["jest-extended/all"],
+};

--- a/libs/rich-error-model/package.json
+++ b/libs/rich-error-model/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@scow/rich-error-model",
+  "version": "1.0.0",
+  "description": "",
+  "main": "build/index.js",
+  "scripts": {
+    "generate": "rimraf generated && buf generate --template buf.gen.yaml https://github.com/googleapis/googleapis.git#subdir=google/rpc",
+    "build": "rimraf build && tsc",
+    "test": "jest"
+  },
+  "dependencies": {
+    "@grpc/grpc-js": "1.8.14",
+    "long": "5.2.3",
+    "protobufjs": "7.2.3"
+  },
+  "devDependencies": {
+    "ts-proto": "1.147.3",
+    "@ddadaal/tsgrpc-server": "0.19.2",
+    "@ddadaal/tsgrpc-common": "0.2.3",
+    "@ddadaal/tsgrpc-client": "0.17.5",
+    "@scow/protos": "workspace:*"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/libs/rich-error-model/src/create.ts
+++ b/libs/rich-error-model/src/create.ts
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2022 Peking University and Peking University Institute for Computing and Digital Economy
+ * SCOW is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *          http://license.coscl.org.cn/MulanPSL2
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PSL v2 for more details.
+ */
+
+import { Metadata, status, StatusObject } from "@grpc/grpc-js";
+import { encodeErrorDetails, ErrorDetail } from "src/errorDetail";
+
+import { Status } from "./generated/status";
+
+export class DetailedError extends Error implements StatusObject {
+
+  code: status;
+  details: string;
+  metadata: Metadata;
+
+  constructor(
+    error: {
+      code: status,
+      message: string,
+      details: ErrorDetail[],
+    },
+    options?: ErrorOptions,
+  ) {
+    super(error.message, options);
+    this.code = error.code;
+    this.details = error.message;
+
+    const status = Status.fromPartial({
+      code: error.code,
+      message: error.message,
+      details: encodeErrorDetails(error.details),
+    });
+
+    this.metadata = new Metadata();
+    this.metadata.set("grpc-status-details-bin", Buffer.from(Status.encode(status).finish()));
+  }
+}
+

--- a/libs/rich-error-model/src/errorDetail.ts
+++ b/libs/rich-error-model/src/errorDetail.ts
@@ -1,0 +1,114 @@
+/**
+ * Copyright (c) 2022 Peking University and Peking University Institute for Computing and Digital Economy
+ * SCOW is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *          http://license.coscl.org.cn/MulanPSL2
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PSL v2 for more details.
+ */
+
+import {
+  BadRequest,
+  BadRequest_FieldViolation,
+  DebugInfo,
+  ErrorInfo,
+  Help,
+  LocalizedMessage,
+  PreconditionFailure,
+  PreconditionFailure_Violation,
+  QuotaFailure,
+  QuotaFailure_Violation,
+  ResourceInfo,
+  RetryInfo,
+} from "src/generated/error_details";
+import { Any } from "src/generated/google/protobuf/any";
+
+export const KnownMessages = [
+  BadRequest,
+  BadRequest_FieldViolation,
+  DebugInfo,
+  ErrorInfo,
+  Help,
+  LocalizedMessage,
+  PreconditionFailure,
+  PreconditionFailure_Violation,
+  QuotaFailure,
+  QuotaFailure_Violation,
+  ResourceInfo,
+  RetryInfo,
+] as const;
+
+export type ErrorDetail =
+  | BadRequest
+  | BadRequest_FieldViolation
+  | DebugInfo
+  | ErrorInfo
+  | Help
+  | LocalizedMessage
+  | PreconditionFailure
+  | PreconditionFailure_Violation
+  | QuotaFailure
+  | QuotaFailure_Violation
+  | ResourceInfo
+  | RetryInfo
+  | Any;
+
+export {
+  BadRequest,
+  BadRequest_FieldViolation,
+  DebugInfo,
+  ErrorInfo,
+  Help,
+  LocalizedMessage,
+  PreconditionFailure,
+  PreconditionFailure_Violation,
+  QuotaFailure,
+  QuotaFailure_Violation,
+  ResourceInfo,
+  RetryInfo,
+};
+
+export function decodeErrorDetails(details: Any[]): ErrorDetail[] {
+  return details.map((value) => {
+    const messageType = KnownMessages.find((type) =>
+      value.typeUrl.endsWith(`/${type.$type}`),
+    );
+
+    if (messageType == null) {
+      return value;
+    }
+
+    return messageType.decode(value.value);
+  });
+}
+
+export function encodeErrorDetails(details: ErrorDetail[]): Any[] {
+  return details.map((value) => {
+    if (value.$type === Any.$type) {
+      return value;
+    }
+
+    const messageType = KnownMessages.find((type) => type.$type === value.$type);
+
+    if (messageType == null) {
+      throw new Error(`Unknown error details type: ${value.$type}`);
+    }
+
+    return Any.fromPartial({
+      typeUrl: `type.googleapis.com/${value.$type}`,
+      value: messageType.encode(value as any).finish(),
+    });
+  });
+}
+
+export const errorDetailsToJson = (details: ErrorDetail[]) => {
+  return {
+    errors: details.map((value) => {
+      const messageType = KnownMessages.find((type) => type.$type === value.$type);
+      return messageType ? messageType.toJSON(value as any) : value;
+    }),
+  };
+};

--- a/libs/rich-error-model/src/index.ts
+++ b/libs/rich-error-model/src/index.ts
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) 2022 Peking University and Peking University Institute for Computing and Digital Economy
+ * SCOW is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *          http://license.coscl.org.cn/MulanPSL2
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PSL v2 for more details.
+ */
+
+export * from "./create";
+export * from "./errorDetail";
+export * from "./parse";

--- a/libs/rich-error-model/src/parse.ts
+++ b/libs/rich-error-model/src/parse.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2022 Peking University and Peking University Institute for Computing and Digital Economy
+ * SCOW is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *          http://license.coscl.org.cn/MulanPSL2
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PSL v2 for more details.
+ */
+
+import { Metadata } from "@grpc/grpc-js";
+import { decodeErrorDetails } from "src/errorDetail";
+import { Status } from "src/generated/status";
+
+export const parseErrorDetails = (metadata: Metadata) => {
+
+  const data = metadata.get("grpc-status-details-bin");
+
+  const status = data.map((x) => Status.decode(Buffer.from(x)));
+
+  return decodeErrorDetails(status.flatMap((x) => x.details));
+};
+
+

--- a/libs/rich-error-model/tests/global.d.ts
+++ b/libs/rich-error-model/tests/global.d.ts
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) 2022 Peking University and Peking University Institute for Computing and Digital Economy
+ * SCOW is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *          http://license.coscl.org.cn/MulanPSL2
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PSL v2 for more details.
+ */
+
+import "jest-extended";

--- a/libs/rich-error-model/tests/server.test.ts
+++ b/libs/rich-error-model/tests/server.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) 2022 Peking University and Peking University Institute for Computing and Digital Economy
+ * SCOW is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *          http://license.coscl.org.cn/MulanPSL2
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PSL v2 for more details.
+ */
+
+import { asyncUnaryCall } from "@ddadaal/tsgrpc-client";
+import { Server } from "@ddadaal/tsgrpc-server";
+import { ChannelCredentials, ServiceError, status } from "@grpc/grpc-js";
+import { HookServiceClient, HookServiceServer, HookServiceService } from "@scow/protos/build/hook/hook";
+
+import { DetailedError, ErrorInfo, LocalizedMessage, parseErrorDetails } from "../src";
+
+let server: Server;
+
+const errorMessage = "The expected error message";
+
+const errorInfo = () => ErrorInfo.create({ domain: "test.com", reason: "123", metadata: { test1: "test" } });
+const localizedMessage = () => LocalizedMessage.create({ locale: "zh-CN", message: "123" });
+
+function createServer() {
+  const server = new Server({
+    host: "localhost", port: 0,
+  });
+
+  server.addService<HookServiceServer>(HookServiceService, {
+    onEvent: async ({ request }) => {
+
+      if (request.event?.$case === "userAdded") {
+        throw new DetailedError({
+          code: status.ALREADY_EXISTS,
+          message: errorMessage,
+          details: [errorInfo(), localizedMessage()],
+        });
+      }
+      if (request.event?.$case === "accountBlocked") {
+        throw new Error("Normal error");
+      }
+
+      return [{}];
+    },
+  });
+
+  return server;
+}
+
+beforeEach(async () => {
+  server = createServer();
+
+  await server.start();
+});
+
+afterEach(async () => {
+  await server.close();
+});
+
+const createClient = () => new HookServiceClient("127.0.0.1:" + server.port, ChannelCredentials.createInsecure());
+
+it("throws and catches ErrorDetails", async () => {
+
+  try {
+
+    await asyncUnaryCall(createClient(), "onEvent", {
+      metadata: { time: new Date().toISOString() },
+      event: { $case: "userAdded", userAdded: { tenantName: "123", userId: "123" } },
+    });
+
+    expect("").fail("should not pass");
+  } catch (e) {
+
+    const ex = e as ServiceError;
+
+    const errors = parseErrorDetails(ex.metadata);
+    expect(ex.details).toBe(errorMessage);
+
+    expect(errors).toIncludeAllMembers([
+      errorInfo(), localizedMessage(),
+    ]);
+  }
+});
+
+it("does not interfere with normal error", async () => {
+  try {
+
+    await asyncUnaryCall(createClient(), "onEvent", {
+      metadata: { time: new Date().toISOString() },
+      event: { $case: "accountBlocked", accountBlocked: { accountName: "123", tenantName: "123" } },
+    });
+
+    expect("").fail("should not pass");
+  }
+  catch (e) {
+    const ex = e as ServiceError;
+    expect(ex.details).toBe("Normal error");
+    const errors = parseErrorDetails(ex.metadata);
+    expect(errors).toHaveLength(0);
+  }
+});
+
+

--- a/libs/rich-error-model/tsconfig.build.json
+++ b/libs/rich-error-model/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "src/**/*.ts",
+  ],
+}

--- a/libs/rich-error-model/tsconfig.json
+++ b/libs/rich-error-model/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "build",
+    "baseUrl": "./",
+    "paths": {
+      "src/*": [
+        "src/*"
+      ],
+      "tests/*": [
+        "tests/*"
+      ]
+    }
+  },
+  "include": [
+    "src/**/*.ts",
+    "tests/**/*.ts",
+    "generated/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 importers:
 
   .:
@@ -923,6 +927,34 @@ importers:
         specifier: 7.2.3
         version: 7.2.3
     devDependencies:
+      ts-proto:
+        specifier: 1.147.3
+        version: 1.147.3
+
+  libs/rich-error-model:
+    dependencies:
+      '@grpc/grpc-js':
+        specifier: 1.8.14
+        version: 1.8.14
+      long:
+        specifier: 5.2.3
+        version: 5.2.3
+      protobufjs:
+        specifier: 7.2.3
+        version: 7.2.3
+    devDependencies:
+      '@ddadaal/tsgrpc-client':
+        specifier: 0.17.5
+        version: 0.17.5(@grpc/grpc-js@1.8.14)
+      '@ddadaal/tsgrpc-common':
+        specifier: 0.2.3
+        version: 0.2.3
+      '@ddadaal/tsgrpc-server':
+        specifier: 0.19.2
+        version: 0.19.2(@grpc/grpc-js@1.8.14)
+      '@scow/protos':
+        specifier: workspace:*
+        version: link:../protos
       ts-proto:
         specifier: 1.147.3
         version: 1.147.3

--- a/turbo.json
+++ b/turbo.json
@@ -5,9 +5,24 @@
       "persistent": true,
       "cache": false
     },
+    "generate": {
+      "dependsOn": [
+        "^generate"
+      ],
+      "inputs": [
+        "node_modules/@scow/grpc-api/**/*.proto",
+        "protos/**/*.proto",
+        "buf.gen.yaml"
+      ],
+      "outputs": [
+        "generated",
+        "src/generated"
+      ]
+    },
     "build": {
       "dependsOn": [
-        "^build"
+        "^build",
+        "generate"
       ],
       "outputs": [
         ".next/**",
@@ -32,26 +47,6 @@
         "src/**/*.ts",
         "test/**/*.ts",
         "test/**/*.tsx"
-      ]
-    },
-    "@scow/protos#generate": {
-      "inputs": [
-        "node_modules/@scow/grpc-api/**/*.proto",
-        "buf.gen.yaml"
-      ],
-      "outputs": [
-        "generated/**"
-      ]
-    },
-    "@scow/protos#build": {
-      "dependsOn": [
-        "^@scow/protos#generate"
-      ],
-      "inputs": [
-        "generated/**"
-      ],
-      "outputs": [
-        "build/**"
       ]
     },
     "//#lint:ts": {


### PR DESCRIPTION
增加`@scow/rich-error-model`包以帮助处理gRPC Rich Error Model。

用法参考libs/rich-error-model/tests/server.test.ts。

# 创建Rich Error Model

```ts
import { ErrorInfo, LocalizedMessage } from "@scow/rich-error-model";

ErrorInfo.create({ domain: "test.com", reason: "123", metadata: { test1: "test" } });
LocalizedMessage.create({ locale: "zh-CN", message: "123" });
```

# 服务器里抛出错误

```ts
import { DetailedError } from "@scow/rich-error-model";

throw new DetailedError({
  code: status.ALREADY_EXISTS,
  message: errorMessage,
  details: [errorInfo(), localizedMessage()],
});
```

# 客户端解析错误

```ts
import { parseErrorDetails } from "@scow/rich-error-model";
try {
  await asyncUnaryCall(createClient(), "onEvent", {
    metadata: { time: new Date().toISOString() },
    event: { $case: "userAdded", userAdded: { tenantName: "123", userId: "123" } },
  });
} catch (e) {
  const ex = e as ServiceError;
  const errors = parseErrorDetails(ex.metadata);
}
```
