### PR TITLE
fix(libs): 修复rich-error-model包不能导入的问题

### DIFF
--- a/.changeset/shaggy-garlics-pump.md
+++ b/.changeset/shaggy-garlics-pump.md
@@ -1,0 +1,5 @@
+---
+"@scow/rich-error-model": patch
+---
+
+修复 rich-error-model 包不能正常导入的问题

--- a/libs/rich-error-model/package.json
+++ b/libs/rich-error-model/package.json
@@ -5,7 +5,7 @@
   "main": "build/index.js",
   "scripts": {
     "generate": "rimraf generated && buf generate --template buf.gen.yaml https://github.com/googleapis/googleapis.git#subdir=google/rpc",
-    "build": "rimraf build && tsc",
+    "build": "rimraf build && tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
     "test": "jest"
   },
   "dependencies": {


### PR DESCRIPTION
修改rich-error-model的build脚本