### PR TITLE
fix(libs): 修复构建镜像时rich-error-model包存在的问题

### DIFF
--- a/.changeset/nine-mangos-behave.md
+++ b/.changeset/nine-mangos-behave.md
@@ -1,0 +1,5 @@
+---
+"@scow/rich-error-model": patch
+---
+
+修复构建镜像时 rich-error-model 包内容不能正常被复制的问题

--- a/libs/rich-error-model/package.json
+++ b/libs/rich-error-model/package.json
@@ -8,6 +8,10 @@
     "build": "rimraf build && tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
     "test": "jest"
   },
+  "files": [
+    "build",
+    "!**/*.map"
+  ],
   "dependencies": {
     "@grpc/grpc-js": "1.8.15",
     "long": "5.2.3",


### PR DESCRIPTION
copyDist脚本在构建镜像时不能正常运行，原因是rich-error-model包的package.json中缺少files字段

这个pr补充了这个字段