### PR TITLE
ci: github worflow新增push PKU repository

### DIFF
--- a/.github/workflows/test-build-publish.yaml
+++ b/.github/workflows/test-build-publish.yaml
@@ -14,7 +14,8 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 env:
   GITHUB_CR: ghcr.io
-  PKU_CR: mirrors6.eecser.com
+  PKU_CR: mirrors.eecser.com
+  PKU_PROJECT_NAME: pkuhpc-icode
   # ALIYUN_CR: registry.cn-hangzhou.aliyuncs.com
   # ALIYUN_PROJECT_NAME: scow
 
@@ -124,17 +125,6 @@ jobs:
           name: scow-cli-arm64
           path: apps/cli/exe/cli-arm64
 
-  curl:
-    needs: test-version-packages
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Run Curl
-        run: curl ${{ env.PKU_CR }}
-      - name: Display Curl Result
-        run: |
-          echo "Curl Result:"
-          echo "${{ steps.run-ping.outputs.stdout }}"
 
   build-images:
     needs: test-version-packages
@@ -184,7 +174,7 @@ jobs:
         with:
           images: |
             ${{ env.GITHUB_CR }}/${{ github.repository }}/${{ matrix.name }}
-            ${{ env.PKU_CR }}/${{ matrix.name }}
+            ${{ env.PKU_CR }}/${{ env.PKU_PROJECT_NAME }}/${{ matrix.name }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v4

--- a/.github/workflows/test-build-publish.yaml
+++ b/.github/workflows/test-build-publish.yaml
@@ -14,6 +14,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 env:
   GITHUB_CR: ghcr.io
+  PKU_CR: mirrors.eecser.com
   # ALIYUN_CR: registry.cn-hangzhou.aliyuncs.com
   # ALIYUN_PROJECT_NAME: scow
 
@@ -158,12 +159,20 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Log in to the PKU registry
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc
+        with:
+          registry: ${{ env.PKU_CR }}
+          username: ${{ secrets.PKUREGISTRY_USERNAME }}
+          password: ${{ secrets.PKUREGISTRY_PASSWORD }}
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
         with:
           images: |
             ${{ env.GITHUB_CR }}/${{ github.repository }}/${{ matrix.name }}
+            ${{ env.PKU_CR }}/${{ matrix.name }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v4

--- a/.github/workflows/test-build-publish.yaml
+++ b/.github/workflows/test-build-publish.yaml
@@ -132,9 +132,9 @@ jobs:
       - name: Run Curl
         run: curl ${{ env.PKU_CR }}
       - name: Display Curl Result
-      run: |
-        echo "Curl Result:"
-        echo "${{ steps.run-ping.outputs.stdout }}"
+        run: |
+          echo "Curl Result:"
+          echo "${{ steps.run-ping.outputs.stdout }}"
 
   build-images:
     needs: test-version-packages

--- a/.github/workflows/test-build-publish.yaml
+++ b/.github/workflows/test-build-publish.yaml
@@ -124,6 +124,18 @@ jobs:
           name: scow-cli-arm64
           path: apps/cli/exe/cli-arm64
 
+  curl:
+    needs: test-version-packages
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Run Curl
+        run: curl ${{ env.PKU_CR }}
+       - name: Display Curl Result
+        run: |
+          echo "Curl Result:"
+          echo "${{ steps.run-ping.outputs.stdout }}"
+
   build-images:
     needs: test-version-packages
     runs-on: ubuntu-latest

--- a/.github/workflows/test-build-publish.yaml
+++ b/.github/workflows/test-build-publish.yaml
@@ -14,7 +14,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 env:
   GITHUB_CR: ghcr.io
-  PKU_CR: mirrors.eecser.com
+  PKU_CR: mirrors6.eecser.com
   # ALIYUN_CR: registry.cn-hangzhou.aliyuncs.com
   # ALIYUN_PROJECT_NAME: scow
 

--- a/.github/workflows/test-build-publish.yaml
+++ b/.github/workflows/test-build-publish.yaml
@@ -131,10 +131,10 @@ jobs:
     steps:
       - name: Run Curl
         run: curl ${{ env.PKU_CR }}
-       - name: Display Curl Result
-        run: |
-          echo "Curl Result:"
-          echo "${{ steps.run-ping.outputs.stdout }}"
+      - name: Display Curl Result
+      run: |
+        echo "Curl Result:"
+        echo "${{ steps.run-ping.outputs.stdout }}"
 
   build-images:
     needs: test-version-packages


### PR DESCRIPTION
改动：
1. 在现有的workflow下，在Test, Build and Publish Projects内的build images job里新增使用账号密码docker login 到PKU_CR：`mirrors.eecser.com`，此账号密码保存在github secrets内，key分别为`PKUREGISTRY_USERNAME`和`PKUREGISTRY_PASSWORD`。
2. 将build好的image上传至`mirrors.eecser.com/pkuhpc-icode/xxx: {tag}`下
3. 通过`mirror.pku.edu.cn/pkuhpc-icode/xxx: {tag}`可以拉到最新push到`mirrors.eecser.com/pkuhpc-icode/xxx: {tag}`的镜像

自测：
已在58集群拉取到该image
![image](https://github.com/PKUHPC/SCOW/assets/130351655/859c9764-4f09-4673-9a7d-c81056b9e903)


关于push的速度问题： 经测试偶尔时间达到将近十多分钟，可以考虑后续只对release或者合master的image 推到该仓库，其他pr的image继续使用github的仓库即可。
