### PR TITLE
feat(cli): cli中隐藏用户可配置镜像地址，默认为：mirrors.pku.edu.cn/pkuhpc-icode/scow

### DIFF
--- a/.changeset/gold-cows-smell.md
+++ b/.changeset/gold-cows-smell.md
@@ -1,0 +1,5 @@
+---
+"@scow/cli": minor
+---
+
+cli 中移除用户可配置镜像地址，统一为：mirrors.pku.edu.cn/pkuhpc-icode/scow

--- a/apps/cli/assets/install.yaml
+++ b/apps/cli/assets/install.yaml
@@ -4,9 +4,6 @@
 # 整个系统的部署路径。默认/
 # basePath: /
 
-# SCOW的镜像。默认: ghcr.io/pkuhpc/scow/scow
-# image: ghcr.io/pkuhpc/scow/scow
-
 # SCOW的镜像的tag。默认：master
 # imageTag: master
 

--- a/apps/cli/src/cmd/migrate.ts
+++ b/apps/cli/src/cmd/migrate.ts
@@ -60,7 +60,6 @@ export const migrateFromScowDeployment = (options: Props) => {
   const config: DeepPartial<InstallConfigSchema> = {
     port: common.PORT,
     basePath: common.BASE_PATH,
-    image: common.IMAGE,
     imageTag: common.IMAGE_TAG,
 
     gateway: gateway ? {

--- a/apps/cli/src/compose/index.ts
+++ b/apps/cli/src/compose/index.ts
@@ -15,7 +15,7 @@ import path from "path";
 import { LoggingOption, ServiceSpec } from "src/compose/spec";
 import { InstallConfigSchema } from "src/config/install";
 
-const IMAGE: string = "mirrors.pku.edu.cn/pkuhpc-icode";
+const IMAGE: string = "mirrors.pku.edu.cn/pkuhpc-icode/scow";
 
 function checkPathFormat(configKey: string, value: string) {
   if (value !== "/" && value.endsWith("/")) {

--- a/apps/cli/src/compose/index.ts
+++ b/apps/cli/src/compose/index.ts
@@ -32,7 +32,8 @@ function join(...segments: string[]) {
 }
 
 export const createComposeSpec = (config: InstallConfigSchema) => {
-  const scowImage = `${IMAGE}:${config.imageTag}`;
+  // 如果install.yaml没有配置image则使用默认image
+  const scowImage = `${config.image || IMAGE}:${config.imageTag}`;
 
   const BASE_PATH = config.basePath;
   checkPathFormat("basePath", BASE_PATH);

--- a/apps/cli/src/compose/index.ts
+++ b/apps/cli/src/compose/index.ts
@@ -15,6 +15,8 @@ import path from "path";
 import { LoggingOption, ServiceSpec } from "src/compose/spec";
 import { InstallConfigSchema } from "src/config/install";
 
+const IMAGE: string = "mirrors.pku.edu.cn/pkuhpc-icode";
+
 function checkPathFormat(configKey: string, value: string) {
   if (value !== "/" && value.endsWith("/")) {
     throw new Error(`Invalid config: ${configKey} should not end with '/'`);
@@ -30,7 +32,7 @@ function join(...segments: string[]) {
 }
 
 export const createComposeSpec = (config: InstallConfigSchema) => {
-  const scowImage = `${config.image}:${config.imageTag}`;
+  const scowImage = `${IMAGE}:${config.imageTag}`;
 
   const BASE_PATH = config.basePath;
   checkPathFormat("basePath", BASE_PATH);

--- a/apps/cli/src/config/install.ts
+++ b/apps/cli/src/config/install.ts
@@ -18,7 +18,6 @@ import { logger } from "src/log";
 export const InstallConfigSchema = Type.Object({
   port: Type.Integer({ description: "端口号", default: 80 }),
   basePath: Type.String({ description: "整个系统的部署路径", default: "/" }),
-  image: Type.String({ description: "镜像", default: "ghcr.io/pkuhpc/scow/scow" }),
   imageTag: Type.String({ description: "镜像tag", default: "master" }),
 
   log: Type.Object({

--- a/apps/cli/src/config/install.ts
+++ b/apps/cli/src/config/install.ts
@@ -18,6 +18,7 @@ import { logger } from "src/log";
 export const InstallConfigSchema = Type.Object({
   port: Type.Integer({ description: "端口号", default: 80 }),
   basePath: Type.String({ description: "整个系统的部署路径", default: "/" }),
+  image: Type.Optional(Type.String({ description: "镜像", default: "mirrors.pku.edu.cn/pkuhpc-icode/scow" })),
   imageTag: Type.String({ description: "镜像tag", default: "master" }),
 
   log: Type.Object({


### PR DESCRIPTION
### 目的：
现有情况下，用户通过ghcr.io拉取scow镜像，不便于scow部署信息的收集。拉取地址改为mirrors.eecser.com/pkuhpc-icode/scow可以实现该需求，故需要确保用户每次都从mirrors.pku.edu.cn/pkuhpc-icode-scow(将会代理到mirrors.eecser.com/pkuhpc-icode/scow)拉取镜像。

### 改动：
cli隐藏用户配置image镜像地址，默认镜像地址改为：mirrors.pku.edu.cn/pkuhpc-icode/scow，且生成的`install.yaml`文件中隐藏image属性（开发测试可以配置）。

cli文件已在本地集群中验证可用。