### PR TITLE
fix(portal-web): 单节点CPU数和单节点GPU数显示为总数

### DIFF
--- a/.changeset/pink-flies-pay.md
+++ b/.changeset/pink-flies-pay.md
@@ -1,0 +1,5 @@
+---
+"@scow/portal-web": patch
+---
+
+修复单节点 CPU 核心数以及 GPU 卡数显示为总数的 bug

--- a/apps/portal-web/src/pageComponents/app/LaunchAppForm.tsx
+++ b/apps/portal-web/src/pageComponents/app/LaunchAppForm.tsx
@@ -326,13 +326,13 @@ export const LaunchAppForm: React.FC<Props> = ({ appId, attributes }) => {
                 {
                   required: true,
                   type: "integer",
-                  max: currentPartitionInfo?.gpus,
+                  max: currentPartitionInfo?.gpus / currentPartitionInfo.nodes,
                 },
               ]}
             >
               <InputNumber
                 min={1}
-                max={currentPartitionInfo?.gpus}
+                max={currentPartitionInfo?.gpus / currentPartitionInfo.nodes}
                 {...inputNumberFloorConfig}
               />
             </Form.Item>
@@ -342,12 +342,16 @@ export const LaunchAppForm: React.FC<Props> = ({ appId, attributes }) => {
               name="coreCount"
               dependencies={["cluster", "partition"]}
               rules={[
-                { required: true, type: "integer", max: currentPartitionInfo?.cores },
+                { required: true,
+                  type: "integer",
+                  max: currentPartitionInfo ?
+                    currentPartitionInfo.cores / currentPartitionInfo.nodes : undefined },
               ]}
             >
               <InputNumber
                 min={1}
-                max={currentPartitionInfo?.cores}
+                max={currentPartitionInfo ?
+                  currentPartitionInfo.cores / currentPartitionInfo.nodes : undefined }
                 {...inputNumberFloorConfig}
               />
             </Form.Item>

--- a/apps/portal-web/src/pageComponents/job/SubmitJobForm.tsx
+++ b/apps/portal-web/src/pageComponents/job/SubmitJobForm.tsx
@@ -293,13 +293,13 @@ export const SubmitJobForm: React.FC<Props> = ({ initial = initialValues }) => {
                 {
                   required: true,
                   type: "integer",
-                  max: currentPartitionInfo?.gpus,
+                  max: currentPartitionInfo?.gpus / currentPartitionInfo.nodes,
                 },
               ]}
             >
               <InputNumber
                 min={1}
-                max={currentPartitionInfo?.gpus}
+                max={currentPartitionInfo?.gpus / currentPartitionInfo.nodes}
                 {...inputNumberFloorConfig}
               />
             </Form.Item>
@@ -312,13 +312,13 @@ export const SubmitJobForm: React.FC<Props> = ({ initial = initialValues }) => {
                 {
                   required: true,
                   type: "integer",
-                  max: currentPartitionInfo?.cores,
+                  max: currentPartitionInfo ? currentPartitionInfo.cores / currentPartitionInfo.nodes : undefined,
                 },
               ]}
             >
               <InputNumber
                 min={1}
-                max={currentPartitionInfo?.cores}
+                max={currentPartitionInfo ? currentPartitionInfo.cores / currentPartitionInfo.nodes : undefined}
                 {...inputNumberFloorConfig}
               />
             </Form.Item>


### PR DESCRIPTION
<img width="795" alt="image" src="https://github.com/PKUHPC/SCOW/assets/98016770/751a120e-5dbd-401b-9088-e1672d826f68">
<img width="773" alt="image" src="https://github.com/PKUHPC/SCOW/assets/98016770/d141712b-a7a8-49a2-93e7-8b5ad6f97f74">
在提交作业和交互式应用时，单节点核心数可选择的上限为整个分区的核心总数，这个pr修复这个bug，现在可选择的核心数上限为核心总数除以节点总数