### PR TITLE
fix(portal-server): 交互式任务脚本里执行script.sh不能使用source的方式

### DIFF
--- a/.changeset/early-moles-rescue.md
+++ b/.changeset/early-moles-rescue.md
@@ -1,0 +1,6 @@
+---
+"@scow/portal-server": patch
+"@scow/portal-web": patch
+---
+
+修改交互式脚本执行 scirpt.sh 和 xstartup 问题，增加#!/bin/bash -l，增加 script.sh 可执行权限

--- a/apps/portal-server/assets/slurm/server_entry.sh
+++ b/apps/portal-server/assets/slurm/server_entry.sh
@@ -17,4 +17,4 @@ export HOST=$(hostname)
 
 source before.sh
 
-source script.sh
+bash -l script.sh

--- a/apps/portal-server/src/clusterops/slurm/app.ts
+++ b/apps/portal-server/src/clusterops/slurm/app.ts
@@ -57,6 +57,7 @@ const SERVER_SESSION_INFO = "server_session_info.json";
 const VNC_SESSION_INFO = "VNC_SESSION_INFO";
 
 const APP_LAST_SUBMISSION_INFO = "last_submission.json";
+const BIN_BASH_SCRIPT_HEADER = "#!/bin/bash -l\n";
 
 export const slurmAppOps = (cluster: string): AppOps => {
 
@@ -155,7 +156,6 @@ export const slurmAppOps = (cluster: string): AppOps => {
           customAttributesExport = customAttributesExport + envItem + "\n";
         }
 
-        const binBashScript = "#!/bin/bash -l\n";
         if (appConfig.type === "web") {
           let customForm = String.raw`\"HOST\":\"$HOST\",\"PORT\":$PORT`;
           for (const key in appConfig.web!.connect.formData) {
@@ -171,7 +171,7 @@ export const slurmAppOps = (cluster: string): AppOps => {
           const beforeScript = runtimeVariables + customAttributesExport + appConfig.web!.beforeScript + sessionInfo;
           await sftpWriteFile(sftp)(join(workingDirectory, "before.sh"), beforeScript);
 
-          const webScript = binBashScript + appConfig.web!.script;
+          const webScript = BIN_BASH_SCRIPT_HEADER + appConfig.web!.script;
           const scriptPath = join(workingDirectory, "script.sh");
           await sftpWriteFile(sftp)(scriptPath, webScript);
           await sftpChmod(sftp)(scriptPath, "755");
@@ -200,7 +200,7 @@ export const slurmAppOps = (cluster: string): AppOps => {
           await sftpWriteFile(sftp)(join(workingDirectory, "before.sh"), beforeScript);
 
           const xstartupPath = join(workingDirectory, "xstartup");
-          const xstartupScript = binBashScript + appConfig.vnc!.xstartup;
+          const xstartupScript = BIN_BASH_SCRIPT_HEADER + appConfig.vnc!.xstartup;
           await sftpWriteFile(sftp)(xstartupPath, xstartupScript);
           await sftpChmod(sftp)(xstartupPath, "755");
 

--- a/apps/portal-web/assets/slurm/server_entry.sh
+++ b/apps/portal-web/assets/slurm/server_entry.sh
@@ -12,4 +12,4 @@ export HOST=$(hostname)
 
 source before.sh
 
-source script.sh
+bash -l script.sh


### PR DESCRIPTION
此PR通过在`script.sh`和`xstartup`脚本加上`#!/bin/bash -l`，`script.sh`增加可执行权限，更改`scirpt.sh`执行方式为`bash -l `
解决了source执行无法获取profile中变量的问题


- 修改前

手动更改计算机节点profile中环境变量
![image](https://github.com/PKUHPC/SCOW/assets/43978285/7b204730-e772-4f16-8c7e-1354fd3cc3e3)
web/vnc应用都无法获取到变更后的环境变量
![image](https://github.com/PKUHPC/SCOW/assets/43978285/a61ef336-3458-4b8e-971d-acf57dde1816)
![image](https://github.com/PKUHPC/SCOW/assets/43978285/5c6eb057-9b8a-4936-95d1-70e2837be810)、

- 修改后

> web应用
> `script.sh`脚本增加权限
> ![image](https://github.com/PKUHPC/SCOW/assets/43978285/d14a8182-e927-43ba-b117-4419f6efaadd)
> script.sh脚本首行自动加入`#!/bin/bash -l  `
> ![image](https://github.com/PKUHPC/SCOW/assets/43978285/290780de-7822-4efe-8a2c-9fd6e2ea9172)
> 可以正常获取到计算机节点上Profile中变更的环境变量
> ![image](https://github.com/PKUHPC/SCOW/assets/43978285/43d7fcf9-832f-4481-8108-de0aac48fe24)

> vnc应用
> `xstartup`脚本首行自动加入#`!/bin/bash -l  `
> ![image](https://github.com/PKUHPC/SCOW/assets/43978285/db281688-bf27-4a89-85b3-4f7f589c5980)
> 可以正常获取到计算机节点上Profile中变更的环境变量
> ![image](https://github.com/PKUHPC/SCOW/assets/43978285/b3c1a529-fae6-4330-913c-be69d44c40e6)


