### PR TITLE
feat(web): 自定义导航链接配置中点击导航时页面跳转动作优化

### DIFF
--- a/.changeset/angry-terms-change.md
+++ b/.changeset/angry-terms-change.md
@@ -1,0 +1,7 @@
+---
+"@scow/portal-web": patch
+"@scow/mis-web": patch
+"@scow/docs": patch
+---
+
+增加是否打开新的页面配置项，默认为 false,所有导航点击时不打开新的页面；一级导航配置 url=""时 则默认跳转次级第一个导航的 url

--- a/.changeset/healthy-cameras-hope.md
+++ b/.changeset/healthy-cameras-hope.md
@@ -1,0 +1,5 @@
+---
+"@scow/config": patch
+---
+
+在 mis.yaml 和 portal.yaml 下的 navLinks 中增加 openInNewPage 可选配置，默认为 false

--- a/apps/cli/assets/config/mis.yaml
+++ b/apps/cli/assets/config/mis.yaml
@@ -74,6 +74,9 @@ predefinedChargingTypes:
   # 链接地址
   # url: ""
 
+  # 是否打开新的页面，可选填，默认值为false
+  # openInNewPage: true
+
   # 自定义图标地址,可选填
   # iconPath: ""
 
@@ -86,5 +89,6 @@ predefinedChargingTypes:
     # 二级导航相关配置，与一级导航相同，但是不允许再设置children
     # text: ""
     # url: ""
+    # openInNewPage: true
     # iconPath: ""
     # allowedRoles: []

--- a/apps/cli/assets/config/portal.yaml
+++ b/apps/cli/assets/config/portal.yaml
@@ -58,6 +58,9 @@ shell: true
   # 链接地址
   # url: ""
 
+  # 是否打开新的页面，可选填，默认值为false
+  # openInNewPage: true
+
   # 自定义图标地址,可选填
   # iconPath: ""
 
@@ -66,5 +69,6 @@ shell: true
     # 二级导航相关配置，与一级导航相同，但是不允许再设置children
     # text: ""
     # url: ""
+    # openInNewPage: true
     # iconPath: ""
 

--- a/apps/mis-web/config/mis.yaml
+++ b/apps/mis-web/config/mis.yaml
@@ -33,7 +33,9 @@ createUser:
 #   # 链接名
 #   - text: "一级导航1"
 #     # 链接地址
-#     url: "https://hahahaha1.com/"
+#     url: ""
+#     # 是否打开新的页面，可选填，默认值为false
+#     # openInNewPage: true
 #     # 自定义图标地址,可选填
 #     # iconPath: ""
 #     # 可以看到这个链接的用户,可选填
@@ -44,6 +46,7 @@ createUser:
 #       # 二级导航相关配置，与一级导航相同，但是不允许再设置children
 #       - text: "二级导航1"
 #         url: "https://hahahaha1.1.com"
+#         # openInNewPage: true
 #         iconPath: ""
 #         allowedRoles: [accountAdmin, accountOwner]
 #       - text: "二级导航2"

--- a/apps/mis-web/src/layouts/routes.tsx
+++ b/apps/mis-web/src/layouts/routes.tsx
@@ -344,17 +344,8 @@ export const getAvailableRoutes = (user: User | undefined): NavItemProps[] => {
     const mappedNavLinkItems = publicConfig.NAV_LINKS
       .filter((link) => !link.allowedRoles
         || (link.allowedRoles.length && link.allowedRoles.some((role) => userCurrentRoles[role])))
-      .map((link) => ({
-        Icon: !link.iconPath ? LinkOutlined : (
-          <NavIcon
-            src={join(publicConfig.PUBLIC_PATH, link.iconPath)}
-          />
-        ),
-        text: link.text,
-        path: `${link.url}?token=${user.token}`,
-        clickable: true,
-        openInNewPage: true,
-        children: link.children?.filter((childLink) => !childLink.allowedRoles
+      .map((link) => {
+        const childrenLinks = link.children?.filter((childLink) => !childLink.allowedRoles
           || (childLink.allowedRoles.length &&
             childLink.allowedRoles.some((role) => userCurrentRoles[role])))
           .map((childLink) => ({
@@ -365,10 +356,25 @@ export const getAvailableRoutes = (user: User | undefined): NavItemProps[] => {
             ),
             text: childLink.text,
             path: `${childLink.url}?token=${user.token}`,
-            clickable: true,
-            openInNewPage: true,
-          }) as NavItemProps),
-      }) as NavItemProps);
+            clickable: childLink.openInNewPage,
+            openInNewPage: link.openInNewPage,
+          }) as NavItemProps);
+
+        return {
+          Icon: !link.iconPath ? LinkOutlined : (
+            <NavIcon
+              src={join(publicConfig.PUBLIC_PATH, link.iconPath)}
+            />
+          ),
+          text: link.text,
+          path: link.url ? `${link.url}?token=${user.token}`
+            : childrenLinks && childrenLinks.length > 0 ? childrenLinks[0].path : "",
+          clickable: true,
+          openInNewPage: link.openInNewPage,
+          children: childrenLinks,
+        };
+      }) as NavItemProps[];
+
 
     routes.push(...customNavLinkRoutes(mappedNavLinkItems));
   }

--- a/apps/mis-web/src/utils/config.ts
+++ b/apps/mis-web/src/utils/config.ts
@@ -63,6 +63,7 @@ export type Cluster = { id: string; name: string; }
 export type NavLink = {
   text: string;
   url: string;
+  openInNewPage?: boolean;
   iconPath?: string;
   allowedRoles?: string[];
   children?: Omit<NavLink, "children">[];

--- a/apps/portal-web/config/portal.yaml
+++ b/apps/portal-web/config/portal.yaml
@@ -60,7 +60,9 @@ shell: true
 #   # 链接名
 #   - text: "一级导航1"
 #     # 链接地址
-#     url: "https://hahahaha1.com/"
+#     url: ""
+#     # 是否打开新的页面，可选填，默认值为false
+#     # openInNewPage: true
 #     # 自定义图标地址,可选填
 #     # iconPath: ""
 #     # 二级导航,可选填
@@ -68,10 +70,13 @@ shell: true
 #       # 二级导航相关配置，与一级导航相同，但是不允许再设置children
 #       - text: "二级导航1"
 #         url: "https://hahahaha1.1.com"
+#         # openInNewPage: true
 #         iconPath: ""
 #       - text: "二级导航2"
 #         url: "https://hahahaha1.2.com"
+#         # openInNewPage: true
 #   - text: "一级导航2"
 #     url: "https://hahahaha2.com"
+#     # openInNewPage: true
 #     children: []
 

--- a/apps/portal-web/src/layouts/routes.tsx
+++ b/apps/portal-web/src/layouts/routes.tsx
@@ -135,9 +135,11 @@ export const userRoutes: (
           />
         ),
         text: link.text,
-        path: `${link.url}?token=${user.token}`,
+        path: link.url ? `${link.url}?token=${user.token}`
+          : link.children?.length && link.children?.length > 0
+            ? `${link.children[0].url}?token=${user.token}` : "",
         clickable: true,
-        openInNewPage: true,
+        openInNewPage: link.openInNewPage,
         children: link.children?.length ? link.children?.map((childLink) => ({
           Icon: !childLink.iconPath ? LinkOutlined : (
             <NavIcon
@@ -147,7 +149,7 @@ export const userRoutes: (
           text: childLink.text,
           path: `${childLink.url}?token=${user.token}`,
           clickable: true,
-          openInNewPage: true,
+          openInNewPage: childLink.openInNewPage,
         } as NavItemProps)) : [],
       }) as NavItemProps) : []),
   ];

--- a/apps/portal-web/src/utils/config.ts
+++ b/apps/portal-web/src/utils/config.ts
@@ -85,6 +85,7 @@ export type Cluster = { id: string; name: string; }
 export type NavLink = {
   text: string;
   url: string;
+  openInNewPage?: boolean;
   iconPath?: string;
   children?: Omit<NavLink, "children">[];
 }

--- a/dev/vagrant/config/mis.yaml
+++ b/dev/vagrant/config/mis.yaml
@@ -52,7 +52,9 @@ createUser:
 #   # 链接名
 #   - text: "一级导航1"
 #     # 链接地址
-#     url: "https://hahahaha1.com/"
+#     url: ""
+#     # 是否打开新的页面，可选填，默认值为false
+#     # openInNewPage: true
 #     # 图标路径，可选填
 #     iconPath: ""
 #     # 可以看到这个链接的用户,可选填
@@ -63,22 +65,33 @@ createUser:
 #       # 二级导航相关配置，与一级导航相同，但是不允许再设置children
 #       - text: "二级导航1"
 #         url: "https://hahahaha1.1.com"
+#         # openInNewPage: true
 #         iconPath: ""
 #         # allowedRoles: [tenantFinance]
 #       - text: "二级导航2"
 #         url: "https://hahahaha1.2.com"
+#         # openInNewPage: true
 #         iconPath: ""
 #         # allowedRoles: [tenantAdmin, platformAdmin]
+#       - text: "二级导航3"
+#         url: "https://hahahaha1.3.com"
+#         # openInNewPage: true
+#         iconPath: ""
+#         allowedRoles: [user]
+#         # allowedRoles: [tenantAdmin, platformAdmin]
 #   - text: "一级导航2"
-#     url: "https://hahahaha2.com"
+#     url: ""
+#     # openInNewPage: true
 #     iconPath: ""
 #     allowedRoles: [user]
 #     children: []
 #   - text: "一级导航3"
 #     url: "https://hahahaha3.com"
+#     # openInNewPage: true
 #     iconPath: ""
 #     #allowedRoles: [user]
 #     children:
 #       - text: "三级导航1"
 #         url: "https://hahahaha3.1.com"
+#         # openInNewPage: true
 #         iconPath: ""

--- a/dev/vagrant/config/portal.yaml
+++ b/dev/vagrant/config/portal.yaml
@@ -59,7 +59,9 @@ shell: true
 #   # 链接名
 #   - text: "一级导航1"
 #     # 链接地址
-#     url: "https://hahahaha1.com/"
+#     url: ""
+#     # 是否打开新的页面，可选填，默认值为false
+#     # openInNewPage: true
 #     # 图标路径，可选填
 #     iconPath: ""
 #     # 二级导航,可选填
@@ -67,11 +69,14 @@ shell: true
 #       # 二级导航相关配置，与一级导航相同，但是不允许再设置children
 #       - text: "二级导航1"
 #         url: "https://hahahaha1.1.com"
+#         # openInNewPage: true
 #         iconPath: ""
 #       - text: "二级导航2"
 #         url: "https://hahahaha1.2.com"
+#         # openInNewPage: true
 #         iconPath: ""
 #   - text: "一级导航2"
 #     url: "https://hahahaha2.com"
+#     # openInNewPage: true
 #     iconPath: ""
 #     children: []

--- a/docs/docs/deploy/config/customization/custom-navlinks.md
+++ b/docs/docs/deploy/config/customization/custom-navlinks.md
@@ -24,6 +24,8 @@ navLinks:
   - text: ""
     # 链接地址
     url: ""
+    # 是否打开新的页面，可选填，默认值为false
+    # openInNewPage: true
     # 图标路径，可选填
     iconPath: ""
     # 二级导航,可选填
@@ -45,6 +47,8 @@ navLinks:
   - text: ""
     # 链接地址
     url: ""
+    # 是否打开新的页面，可选填，默认值为false
+    # openInNewPage: true
     # 图标路径，可选填
     iconPath: ""
     # 可以看到这个链接的用户,可选填
@@ -55,6 +59,7 @@ navLinks:
       # 二级导航相关配置，与一级导航相同，但是不允许再设置children
       - text: ""
         url: ""
+        openInNewPage:
         iconPath: ""
         allowedRoles: []
 ```
@@ -66,7 +71,7 @@ navLinks:
 ```yaml title="config/portal.yaml"
 navLinks:
   - text: "一级导航1"
-    url: "https://hahahaha1.com/"
+    url: ""
     iconPath: "/desktop.jpg"
     children:
       - text: "二级导航1"
@@ -83,6 +88,7 @@ navLinks:
     iconPath: "/earth.svg"
   - text: "一级导航3"
     url: "https://hahahaha3.com"
+    openInNewPage: true
     iconPath: "/icon-test.png"
     children: []
 ```
@@ -96,7 +102,7 @@ navLinks:
 ```yaml title="config/mis.yaml"
 navLinks:
   - text: "一级导航1"
-    url: "https://hahahaha1.com/"
+    url: ""
     iconPath: "/icon-test.png"
     children:
       - text: "二级导航1"
@@ -124,16 +130,11 @@ navLinks:
 | ------------------------- | -------------------- | ------------------ | ---------- | ---------------------------------------------------------------------------------------- |
 | `navLinks`                | /                    | /                 |/           |/                                                                                          |
 | `text`                    | 字符串                | `portal`，`mis`    | 是         | 链接名称，SCOW导航栏上显示的名称                                                            |
-| `url`                     | 字符串                | `portal`，`mis`    | 是         | 链接地址，自定义导航链接地址，跳转时会在后面加入查询参数`?token={用来跟踪登录用户的状态的token}`  |
+| `url`                     | 字符串                | `portal`，`mis`    | 是         | 链接地址，自定义导航链接地址，跳转时会在后面加入查询参数`?token={用来跟踪登录用户的状态的token}`。一级导航链接地址设置为空字符串时，将自动跳转至次级导航栏的第一项导航的链接地址。  |
+| `openInNewPage`           | 布尔类型               | `portal`，`mis`    | 否         | 可以选填。如不设置，默认值为`false`，不打开新的页面。如果设置为`true`，则会在新的页面打开该导航链接。  |
 | `iconPath`                     | 字符串           | `portal`，`mis`    | 否         | 图标路径，用户上传到[公共文件](./public-files.md)下的自定义导航链接图标路径。可选填，如未填写则显示系统默认导航链接图标。  |
-| `allowedRoles`            |  用户角色字符串列表    | `mis`             |否           | 管理系统指定可以看到该导航链接的角色列表，用户角色类型包括  `user`, `accountUser`, `accountAdmin`, `accountOwner`, `tenantFinance`, `tenantAdmin`, `platformAdmin`, `platformFinance` 。如果没有指定，则不再限定用户角色，即所有用户都可以看到该导航链接。  |
+| `allowedRoles`            |  用户角色字符串列表    | `mis`             |否           | 管理系统指定可以看到该导航链接的角色列表，用户角色类型包括  `user`, `accountUser`, `accountAdmin`, `accountOwner`, `tenantFinance`, `tenantAdmin`, `platformAdmin`, `platformFinance` （用户角色详解请看下方角色配置说明）。如果没有指定，则不再限定用户角色，即所有用户都可以看到该导航链接。  |
 | `children`                |  导航内容的列表    | `portal`，`mis`   | 否          | 二级导航列表，内容包括该系统下一级导航的所有内容，内容类型以及是否必填与一级导航内容完全相同，但是不允许再继续设置chilidren，不允许继续添加三级导航。如果没有指定，则没有可以显示的二级导航链接。    |
-
-:::tip
-
-如果您想更加详细的了解系统用户模型，请参考[用户模型](../../../info/mis/business/users.md)。
-
-:::
 
 ### 自定义图标配置说明
 

--- a/docs/docs/deploy/config/mis/intro.md
+++ b/docs/docs/deploy/config/mis/intro.md
@@ -114,6 +114,9 @@ predefinedChargingTypes:
   # 链接地址
   # url: ""
 
+  # 是否打开新的页面，可选填，默认值为false
+  # openInNewPage: true
+
   # 自定义图标地址,可选填
   # iconPath: ""
 
@@ -126,6 +129,7 @@ predefinedChargingTypes:
     # 二级导航相关配置，与一级导航相同，但是不允许再设置children
     # text: ""
     # url: ""
+    # openInNewPage: true
     # iconPath: ""
     # allowedRoles: []
 ```

--- a/docs/docs/deploy/config/portal/intro.md
+++ b/docs/docs/deploy/config/portal/intro.md
@@ -91,6 +91,9 @@ shell: true
   # 链接地址
   # url: ""
 
+  # 是否打开新的页面，可选填，默认值为false
+  # openInNewPage: true
+
   # 自定义图标地址,可选填
   # iconPath: ""
 
@@ -99,6 +102,7 @@ shell: true
     # 二级导航相关配置，与一级导航相同，但是不允许再设置children
     # text: ""
     # url: ""
+    # openInNewPage: true
     # iconPath: ""
 ```
 

--- a/libs/config/src/mis.ts
+++ b/libs/config/src/mis.ts
@@ -113,11 +113,13 @@ export const MisConfigSchema = Type.Object({
     Type.Object({
       text: Type.String({ description: "一级导航名称" }),
       url: Type.String({ description: "一级导航链接" }),
+      openInNewPage: Type.Optional(Type.Boolean({ description:"一级导航是否默认在新页面打开", default: false })),
       iconPath: Type.Optional(Type.String({ description: "一级导航链接显示图标路径" })),
       allowedRoles: Type.Optional(Type.Array(Type.String(), { description: "可以看到这个链接的用户" })),
       children: Type.Optional(Type.Array(Type.Object({
         text: Type.String({ description: "二级导航名称" }),
         url: Type.String({ description: "二级导航链接" }),
+        openInNewPage: Type.Optional(Type.Boolean({ description:"二级导航是否默认在新页面打开", default: false })),
         iconPath: Type.Optional(Type.String({ description: "二级导航链接显示图标路径" })),
         allowedRoles: Type.Optional(Type.Array(Type.String(), { description: "可以看到这个链接的用户" })),
       }))),

--- a/libs/config/src/portal.ts
+++ b/libs/config/src/portal.ts
@@ -63,10 +63,12 @@ export const PortalConfigSchema = Type.Object({
     Type.Object({
       text: Type.String({ description: "一级导航名称" }),
       url: Type.String({ description: "一级导航链接" }),
+      openInNewPage: Type.Optional(Type.Boolean({ description:"一级导航是否默认在新页面打开", default: false })),
       iconPath: Type.Optional(Type.String({ description: "一级导航链接显示图标路径" })),
       children: Type.Optional(Type.Array(Type.Object({
         text: Type.String({ description: "二级导航名称" }),
         url: Type.String({ description: "二级导航链接" }),
+        openInNewPage: Type.Optional(Type.Boolean({ description:"二级导航是否默认在新页面打开", default: false })),
         iconPath: Type.Optional(Type.String({ description: "二级导航链接显示图标路径" })),
       }))),
     }),


### PR DESCRIPTION
### 实现了什么

1.在mis.yaml和portal.yaml中增加可选配置项 `openInNewPage`
   如没有配置则默认值为false,点击导航时不会在新的页面打开
   如配置`openInNewPage: true`, 则配置的导航栏被点击时会在新的页面打开链接

2.一级导航下的`url`配置为空字符串时` url:“”`，则会直接跳转到可以阅览的次级导航栏的第一个导航链接

eg:如mis.yaml下进行以下配置，
```
navLinks:
  - text: "一级导航1"
    url: ""
    iconPath: ""
    children:
      - text: "二级导航1"
        url: "https://hahahaha1.1.com"
        iconPath: ""
      - text: "二级导航2"
        url: "https://hahahaha1.2.com"
        iconPath: ""
      - text: "二级导航3"
        url: "https://hahahaha1.3.com"
        iconPath: ""
        allowedRoles: [user]
  - text: "一级导航2"
    url: ""
    iconPath: ""
    children:
      - text: "二级导航2-1"
        url: "https://hahahaha2.1.com"
        iconPath: ""
        allowedRoles: [user]
      - text: "二级导航2-2"
        url: "https://hahahaha2.2.com"
      - text: "二级导航2-3"
        url: "https://hahahaha2.3.com"
        iconPath: ""
```
则当前用户可以阅览的导航链接为
![image](https://github.com/PKUHPC/SCOW/assets/43978285/7dfd4af4-60ca-4edc-9bda-6965ca7733c5)
![image](https://github.com/PKUHPC/SCOW/assets/43978285/d9bc57ba-bd0e-4043-84eb-a6b9918b8373)
点击`一级导航1`跳转时在本页面打开，跳转链接为`https://hahahaha1.1.com/?token=xxxxx`
点击`一级导航2`跳转时在本页面打开，跳转链接为`https://hahahaha2.2.com/?token=xxxxx`