### PR TITLE
fix(portal): 提交交互式应用任务失败提示信息不完全

### DIFF
--- a/.changeset/good-boats-collect.md
+++ b/.changeset/good-boats-collect.md
@@ -1,0 +1,6 @@
+---
+"@scow/portal-server": patch
+"@scow/portal-web": patch
+---
+
+利用 grpc rich-error-model 重构创建交互式应用错误处理，并添加错误信息展示窗口

--- a/apps/portal-server/src/clusterops/app.ts
+++ b/apps/portal-server/src/clusterops/app.ts
@@ -113,7 +113,8 @@ export const appOps = (cluster: string): AppOps => {
           const reply = await asyncClientCall(client.job, "submitJob", request).catch((e) => {
             const ex = e as ServiceError;
             const errors = parseErrorDetails(ex.metadata);
-            if (errors[0] && errors[0].$type === "google.rpc.ErrorInfo" && errors[0].reason === "SBATCH_FAILED") {
+            if (errors[0] && errors[0].$type === "google.rpc.ErrorInfo"
+              && errors[0].reason === "SBATCH_FAILED" && Array.isArray(e.details)) {
               throw <ServiceError> {
                 code: Status.INTERNAL,
                 message: "sbatch failed",

--- a/apps/portal-web/package.json
+++ b/apps/portal-web/package.json
@@ -42,6 +42,7 @@
     "@scow/lib-web": "workspace:*",
     "@scow/protos": "workspace:*",
     "@scow/utils": "workspace:*",
+    "@scow/rich-error-model": "workspace:*",
     "@sinclair/typebox": "0.28.15",
     "@ant-design/cssinjs": "1.10.1",
     "@uiw/codemirror-theme-github": "4.21.3",

--- a/apps/portal-web/src/pageComponents/app/LaunchAppForm.tsx
+++ b/apps/portal-web/src/pageComponents/app/LaunchAppForm.tsx
@@ -83,8 +83,6 @@ export const LaunchAppForm: React.FC<Props> = ({ clusterId, appId, attributes, a
 
     setLoading(true);
     setIsSubmitting(true);
-
-    debugger;
     await api.createAppSession({ body: {
       cluster: clusterId,
       appId,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20192,7 +20192,3 @@ packages:
     name: tiny-inflate
     version: 1.0.3
     dev: false
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -659,6 +659,9 @@ importers:
       '@scow/protos':
         specifier: workspace:*
         version: link:../../libs/protos/scow
+      '@scow/rich-error-model':
+        specifier: workspace:*
+        version: link:../../libs/rich-error-model
       '@scow/utils':
         specifier: workspace:*
         version: link:../../libs/utils
@@ -20189,3 +20192,7 @@ packages:
     name: tiny-inflate
     version: 1.0.3
     dev: false
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false


### PR DESCRIPTION
**现状**
创建交互式应用失败时不能显示详细信息
![image](https://github.com/PKUHPC/SCOW/assets/43978285/44195ce7-a305-435e-9e54-f1b7be2f80f2)

**做了什么**
此PR使用`rich-error-model`重构了创建交互式应用时的错误信息处理
在创建交互式应用失败时创建`modal`提示错误详细信息

`slurm返回错误`👇
![image](https://github.com/PKUHPC/SCOW/assets/43978285/b7ec629b-1dba-42c7-9f82-42db4812d462)
`交互式应用配置找不到时返回错误`👇
![image](https://github.com/PKUHPC/SCOW/assets/43978285/ba62d886-b500-4943-b84a-61de6e6efe14)
`配置表单中选择项出问题时返回错误`👇
![image](https://github.com/PKUHPC/SCOW/assets/43978285/98b4a949-63f7-4719-9f67-59a3ce7caa9f)

