### PR TITLE
fix(web): 修改icon和logo访问时错误参数下scow返回的报错信息

### DIFF
--- a/.changeset/quick-llamas-cross.md
+++ b/.changeset/quick-llamas-cross.md
@@ -1,0 +1,5 @@
+---
+"@scow/lib-web": patch
+---
+
+修改 favicon 和 logo 访问时错误参属下返回的报错信息为固定文字“Invalid request Value”

--- a/libs/web/src/routes/icon/utils.ts
+++ b/libs/web/src/routes/icon/utils.ts
@@ -24,7 +24,7 @@ export function validatePayload <TSchema extends ZodRawShape>(
 
   const parsed = schema.safeParse(payload);
   if (!parsed.success) {
-    res.status(400).send(parsed.error.message);
+    res.status(400).send("Invalid requeset value");
     return undefined;
   }
   return parsed.data;


### PR DESCRIPTION
**问题**
系统中icon和logo访问时，由于使用了
```
const parsed = schema.safeParse(payload);
  if (!parsed.success) {
    res.status(400).send("Invalid requeset value");
    return undefined;
  }
```
会在验证查询参数不成功时向页面返回错误信息的详细信息，会被很多漏洞扫描工具认为是高危漏洞

这个PR将验证查询参数不成功时向页面返回的信息修改为固定字符串`Invalid request value`来解决这个问题