### PR TITLE
fix(web): 修复antd主题未能应用到整体页面

### DIFF
--- a/.changeset/mighty-spies-grab.md
+++ b/.changeset/mighty-spies-grab.md
@@ -1,0 +1,7 @@
+---
+"@scow/portal-web": patch
+"@scow/mis-web": patch
+"@scow/lib-web": patch
+---
+
+修复 antd 主题没有应用完全的问题

--- a/apps/mis-web/package.json
+++ b/apps/mis-web/package.json
@@ -36,7 +36,7 @@
     "@scow/lib-web": "workspace:*",
     "@scow/utils": "workspace:*",
     "@sinclair/typebox": "0.29.4",
-    "antd": "5.6.4",
+    "antd": "5.7.0",
     "dayjs": "1.11.9",
     "google-protobuf": "3.21.2",
     "less": "4.1.3",

--- a/apps/mis-web/src/layouts/AntdConfigProvider.tsx
+++ b/apps/mis-web/src/layouts/AntdConfigProvider.tsx
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2022 Peking University and Peking University Institute for Computing and Digital Economy
+ * SCOW is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *          http://license.coscl.org.cn/MulanPSL2
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PSL v2 for more details.
+ */
+
+import "dayjs/locale/zh-cn";
+
+import { AntdConfigProvider as LibAntdConfigProvider } from "@scow/lib-web/build/layouts/AntdConfigProvider";
+import { useDarkMode } from "@scow/lib-web/build/layouts/darkMode";
+import { App, ConfigProvider, theme } from "antd";
+import zhCNlocale from "antd/locale/zh_CN";
+import React from "react";
+import { ThemeProvider } from "styled-components";
+
+type Props = React.PropsWithChildren<{
+  color: string;
+}>;
+
+const StyledComponentsThemeProvider: React.FC<Props> = ({ children }) => {
+  const { token } = theme.useToken();
+
+  return (
+    <ThemeProvider theme={{ token }}>
+      {children}
+    </ThemeProvider>
+  );
+};
+
+// FIXME
+// The LibAntdConfigProvider only affects themes of the elements from @scow/lib-web package
+export const AntdConfigProvider: React.FC<Props> = ({ children, color }) => {
+
+  const { dark } = useDarkMode();
+
+  return (
+    <LibAntdConfigProvider color={color}>
+      <ConfigProvider
+        locale={zhCNlocale}
+        theme={{ token: { colorPrimary: color, colorInfo: color }, algorithm: dark ? theme.darkAlgorithm : undefined }}
+      >
+        <StyledComponentsThemeProvider color={color}>
+          <App>
+            {children}
+          </App>
+        </StyledComponentsThemeProvider>
+      </ConfigProvider>
+    </LibAntdConfigProvider>
+  );
+};

--- a/apps/mis-web/src/pages/_app.tsx
+++ b/apps/mis-web/src/pages/_app.tsx
@@ -14,7 +14,6 @@ import "nprogress/nprogress.css";
 import "antd/dist/reset.css";
 
 import { failEvent } from "@ddadaal/next-typed-api-routes-runtime/lib/client";
-import { AntdConfigProvider } from "@scow/lib-web/build/layouts/AntdConfigProvider";
 import { DarkModeCookie, DarkModeProvider, getDarkModeCookieValue } from "@scow/lib-web/build/layouts/darkMode";
 import { GlobalStyle } from "@scow/lib-web/build/layouts/globalStyle";
 import { getHostname } from "@scow/lib-web/build/utils/getHostname";
@@ -31,6 +30,7 @@ import { createStore, StoreProvider, useStore } from "simstate";
 import { api } from "src/apis";
 import { USE_MOCK } from "src/apis/useMock";
 import { getTokenFromCookie } from "src/auth/cookie";
+import { AntdConfigProvider } from "src/layouts/AntdConfigProvider";
 import { BaseLayout } from "src/layouts/BaseLayout";
 import { FloatButtons } from "src/layouts/FloatButtons";
 import { DefaultClusterStore } from "src/stores/DefaultClusterStore";

--- a/apps/portal-web/package.json
+++ b/apps/portal-web/package.json
@@ -47,7 +47,7 @@
     "@ant-design/cssinjs": "1.11.2",
     "@uiw/codemirror-theme-github": "4.21.7",
     "@uiw/react-codemirror": "4.21.7",
-    "antd": "5.6.4",
+    "antd": "5.7.0",
     "busboy": "1.6.0",
     "dayjs": "1.11.9",
     "google-protobuf": "3.21.2",

--- a/apps/portal-web/src/layouts/AntdConfigProvider.tsx
+++ b/apps/portal-web/src/layouts/AntdConfigProvider.tsx
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2022 Peking University and Peking University Institute for Computing and Digital Economy
+ * SCOW is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *          http://license.coscl.org.cn/MulanPSL2
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PSL v2 for more details.
+ */
+
+import "dayjs/locale/zh-cn";
+
+import { AntdConfigProvider as LibAntdConfigProvider } from "@scow/lib-web/build/layouts/AntdConfigProvider";
+import { useDarkMode } from "@scow/lib-web/build/layouts/darkMode";
+import { App, ConfigProvider, theme } from "antd";
+import zhCNlocale from "antd/locale/zh_CN";
+import React from "react";
+import { ThemeProvider } from "styled-components";
+
+type Props = React.PropsWithChildren<{
+  color: string;
+}>;
+
+const StyledComponentsThemeProvider: React.FC<Props> = ({ children }) => {
+  const { token } = theme.useToken();
+
+  return (
+    <ThemeProvider theme={{ token }}>
+      {children}
+    </ThemeProvider>
+  );
+};
+
+export const AntdConfigProvider: React.FC<Props> = ({ children, color }) => {
+
+  const { dark } = useDarkMode();
+
+  return (
+    <LibAntdConfigProvider color={color}>
+      <ConfigProvider
+        locale={zhCNlocale}
+        theme={{ token: { colorPrimary: color, colorInfo: color }, algorithm: dark ? theme.darkAlgorithm : undefined }}
+      >
+        <StyledComponentsThemeProvider color={color}>
+          <App>
+            {children}
+          </App>
+        </StyledComponentsThemeProvider>
+      </ConfigProvider>
+    </LibAntdConfigProvider>
+  );
+};

--- a/apps/portal-web/src/pages/_app.tsx
+++ b/apps/portal-web/src/pages/_app.tsx
@@ -14,7 +14,6 @@ import "nprogress/nprogress.css";
 import "antd/dist/reset.css";
 
 import { failEvent } from "@ddadaal/next-typed-api-routes-runtime/lib/client";
-import { AntdConfigProvider } from "@scow/lib-web/build/layouts/AntdConfigProvider";
 import { DarkModeCookie, DarkModeProvider, getDarkModeCookieValue } from "@scow/lib-web/build/layouts/darkMode";
 import { GlobalStyle } from "@scow/lib-web/build/layouts/globalStyle";
 import { getHostname } from "@scow/lib-web/build/utils/getHostname";
@@ -31,6 +30,7 @@ import { createStore, StoreProvider, useStore } from "simstate";
 import { api } from "src/apis";
 import { USE_MOCK } from "src/apis/useMock";
 import { getTokenFromCookie } from "src/auth/cookie";
+import { AntdConfigProvider } from "src/layouts/AntdConfigProvider";
 import { BaseLayout } from "src/layouts/BaseLayout";
 import { FloatButtons } from "src/layouts/FloatButtons";
 import { DefaultClusterStore } from "src/stores/DefaultClusterStore";

--- a/libs/web/package.json
+++ b/libs/web/package.json
@@ -21,14 +21,18 @@
     "nookies": "2.5.2"
   },
   "peerDependencies": {
-    "antd": "5.6.4",
+    "antd": "5.7.0",
     "next": "13.4.10",
     "styled-components": "6.0.4",
     "@ant-design/icons": "5.1.4",
-    "dayjs": "1.11.9"
+    "dayjs": "1.11.9",
+    "react": ">=18.2.0",
+    "react-dom": ">=18.2.0",
+    "react-is": "18.2.0",
+    "nookies": "2.5.2"
   },
   "devDependencies": {
-    "antd": "5.6.4",
+    "antd": "5.7.0",
     "next": "13.4.10",
     "styled-components": "6.0.4",
     "@grpc/grpc-js": "1.8.18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -424,8 +424,8 @@ importers:
         specifier: 0.29.4
         version: 0.29.4
       antd:
-        specifier: 5.6.4
-        version: 5.6.4(react-dom@18.2.0)(react@18.2.0)
+        specifier: 5.7.0
+        version: 5.7.0(react-dom@18.2.0)(react@18.2.0)
       dayjs:
         specifier: 1.11.9
         version: 1.11.9
@@ -675,8 +675,8 @@ importers:
         specifier: 4.21.7
         version: 4.21.7(@babel/runtime@7.22.6)(@codemirror/autocomplete@6.6.0)(@codemirror/language@6.8.0)(@codemirror/lint@6.0.0)(@codemirror/search@6.2.3)(@codemirror/state@6.2.0)(@codemirror/theme-one-dark@6.1.0)(@codemirror/view@6.14.1)(codemirror@6.0.1)(react-dom@18.2.0)(react@18.2.0)
       antd:
-        specifier: 5.6.4
-        version: 5.6.4(react-dom@18.2.0)(react@18.2.0)
+        specifier: 5.7.0
+        version: 5.7.0(react-dom@18.2.0)(react@18.2.0)
       busboy:
         specifier: 1.6.0
         version: 1.6.0
@@ -1116,8 +1116,8 @@ importers:
         specifier: 5.1.26
         version: 5.1.26
       antd:
-        specifier: 5.6.4
-        version: 5.6.4(react-dom@18.2.0)(react@18.2.0)
+        specifier: 5.7.0
+        version: 5.7.0(react-dom@18.2.0)(react@18.2.0)
       dayjs:
         specifier: 1.11.9
         version: 1.11.9
@@ -6706,8 +6706,8 @@ packages:
   /@protobufjs/utf8@1.1.0:
     resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
 
-  /@rc-component/color-picker@1.2.0(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-IitJ6RWGHs7btI1AqzGPrehr5bueWLGDUyMKwDwvFunfSDo/o8g/95kUG55vC5EYLM0ZJ3SDfw45OrW5KAx3oA==}
+  /@rc-component/color-picker@1.4.1(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-vh5EWqnsayZa/JwUznqDaPJz39jznx/YDbyBuVJntv735tKXKwEUZZb2jYEldOg+NKWZwtALjGMrNeGBmqFoEw==}
     peerDependencies:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
@@ -8141,8 +8141,8 @@ packages:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
     engines: {node: '>=12'}
 
-  /antd@5.6.4(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-ttAN5vk6yUybDCe5WFloEb49dyLwyec+FJlvopfZFSkScHX2OBbfpPlCQ50Bpp2u5P/eqN6EQUM4PsE4MPslAA==}
+  /antd@5.7.0(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-jUu6wfoN633rKsTSJcfVtXYTMdVu885LoYm2A52Vur8gnYfP3GzekCuGpTXZKGZRwGLNs3D2HbpaHciusF+2Gg==}
     peerDependencies:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
@@ -8153,7 +8153,7 @@ packages:
       '@ant-design/react-slick': 1.0.0(react@18.2.0)
       '@babel/runtime': 7.22.6
       '@ctrl/tinycolor': 3.6.0
-      '@rc-component/color-picker': 1.2.0(react-dom@18.2.0)(react@18.2.0)
+      '@rc-component/color-picker': 1.4.1(react-dom@18.2.0)(react@18.2.0)
       '@rc-component/mutate-observer': 1.0.0(react-dom@18.2.0)(react@18.2.0)
       '@rc-component/tour': 1.8.0(react-dom@18.2.0)(react@18.2.0)
       '@rc-component/trigger': 1.13.6(react-dom@18.2.0)(react@18.2.0)
@@ -8168,15 +8168,15 @@ packages:
       rc-drawer: 6.2.0(react-dom@18.2.0)(react@18.2.0)
       rc-dropdown: 4.1.0(react-dom@18.2.0)(react@18.2.0)
       rc-field-form: 1.34.2(react-dom@18.2.0)(react@18.2.0)
-      rc-image: 5.17.1(react-dom@18.2.0)(react@18.2.0)
-      rc-input: 1.0.4(react-dom@18.2.0)(react@18.2.0)
-      rc-input-number: 7.4.2(react-dom@18.2.0)(react@18.2.0)
-      rc-mentions: 2.3.0(react-dom@18.2.0)(react@18.2.0)
-      rc-menu: 9.9.2(react-dom@18.2.0)(react@18.2.0)
+      rc-image: 7.0.0(react-dom@18.2.0)(react@18.2.0)
+      rc-input: 1.1.0(react-dom@18.2.0)(react@18.2.0)
+      rc-input-number: 8.0.1(react-dom@18.2.0)(react@18.2.0)
+      rc-mentions: 2.5.0(react-dom@18.2.0)(react@18.2.0)
+      rc-menu: 9.10.0(react-dom@18.2.0)(react@18.2.0)
       rc-motion: 2.7.3(react-dom@18.2.0)(react@18.2.0)
       rc-notification: 5.0.4(react-dom@18.2.0)(react@18.2.0)
       rc-pagination: 3.5.0(react-dom@18.2.0)(react@18.2.0)
-      rc-picker: 3.8.2(dayjs@1.11.9)(react-dom@18.2.0)(react@18.2.0)
+      rc-picker: 3.10.0(dayjs@1.11.9)(react-dom@18.2.0)(react@18.2.0)
       rc-progress: 3.4.1(react-dom@18.2.0)(react@18.2.0)
       rc-rate: 2.12.0(react-dom@18.2.0)(react@18.2.0)
       rc-resize-observer: 1.3.1(react-dom@18.2.0)(react@18.2.0)
@@ -8186,8 +8186,8 @@ packages:
       rc-steps: 6.0.0(react-dom@18.2.0)(react@18.2.0)
       rc-switch: 4.1.0(react-dom@18.2.0)(react@18.2.0)
       rc-table: 7.32.1(react-dom@18.2.0)(react@18.2.0)
-      rc-tabs: 12.7.1(react-dom@18.2.0)(react@18.2.0)
-      rc-textarea: 1.2.3(react-dom@18.2.0)(react@18.2.0)
+      rc-tabs: 12.9.0(react-dom@18.2.0)(react@18.2.0)
+      rc-textarea: 1.3.2(react-dom@18.2.0)(react@18.2.0)
       rc-tooltip: 6.0.1(react-dom@18.2.0)(react@18.2.0)
       rc-tree: 5.7.6(react-dom@18.2.0)(react@18.2.0)
       rc-tree-select: 5.9.0(react-dom@18.2.0)(react@18.2.0)
@@ -16418,8 +16418,8 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
-  /rc-image@5.17.1(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-oR4eviLyQxd/5A7pn843w2/Z1wuBA27L2lS4agq0sjl2z97ssNIVEzRzgwgB0ZxVZG/qSu9Glit2Zgzb/n+blQ==}
+  /rc-image@7.0.0(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-pOr/LYthg5a+R2LDlFPv8u2ndX4aJQNghWCiWxflmLglC3p0uts/NIWLAituQOKvV1wO1aFI1CZtLMT7jrU3vA==}
     peerDependencies:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
@@ -16433,8 +16433,8 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
-  /rc-input-number@7.4.2(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-yGturTw7WGP+M1GbJ+UTAO7L4buxeW6oilhL9Sq3DezsRS8/9qec4UiXUbeoiX9bzvRXH11JvgskBtxSp4YSNg==}
+  /rc-input-number@8.0.1(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-b5LIQ9hmqPI/5NwoRQsQXftrrmuXxcaO9pftFnq4AkjPVtfCG+sqcGEIBmXC/YkS4p6R6dwqclpQLFJyMYx7DA==}
     peerDependencies:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
@@ -16442,12 +16442,13 @@ packages:
       '@babel/runtime': 7.22.6
       '@rc-component/mini-decimal': 1.0.1
       classnames: 2.3.2
+      rc-input: 1.1.0(react-dom@18.2.0)(react@18.2.0)
       rc-util: 5.34.1(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
-  /rc-input@1.0.4(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-clY4oneVHRtKHYf/HCxT/MO+4BGzCIywSNLosXWOm7fcQAS0jQW7n0an8Raa8JMB8kpxc8m28p7SNwFZmlMj6g==}
+  /rc-input@1.1.0(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-izuNXPABQPh4KD7ANFcTrIGp9EZU0FkjTw6AvwCQ/rGPrdDsUTHLsp/Wju/kzGMLJFJWKNF3smbmXRNO23DtXA==}
     peerDependencies:
       react: '>=16.0.0'
       react-dom: '>=16.0.0'
@@ -16458,8 +16459,8 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
-  /rc-mentions@2.3.0(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-gNpsSKsBHSXvyAA1ZowVTqXSWUIw7+OI9wmjL87KcYURvtm9nDo8R0KtOc2f1PT7q9McUpFzhm6AvQdIly0aRA==}
+  /rc-mentions@2.5.0(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-rERXsbUTNVrb5T/iDC0ki/SRGWJnOVraDy6O25Us3FSpuUZ3uq2TPZB4fRk0Hss5kyiEPzz2sprhkI4b+F4jUw==}
     peerDependencies:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
@@ -16467,15 +16468,15 @@ packages:
       '@babel/runtime': 7.22.6
       '@rc-component/trigger': 1.13.6(react-dom@18.2.0)(react@18.2.0)
       classnames: 2.3.2
-      rc-input: 1.0.4(react-dom@18.2.0)(react@18.2.0)
-      rc-menu: 9.9.2(react-dom@18.2.0)(react@18.2.0)
-      rc-textarea: 1.2.3(react-dom@18.2.0)(react@18.2.0)
+      rc-input: 1.1.0(react-dom@18.2.0)(react@18.2.0)
+      rc-menu: 9.10.0(react-dom@18.2.0)(react@18.2.0)
+      rc-textarea: 1.3.2(react-dom@18.2.0)(react@18.2.0)
       rc-util: 5.34.1(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
-  /rc-menu@9.9.2(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-kVJwaQn5VUu6DIddxd/jz3QupTPg0tNYq+mpFP8wYsRF5JgzPA9fPVw+CfwlTPwA1w7gzEY42S8pj6M3uev5CQ==}
+  /rc-menu@9.10.0(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-g27kpXaAoJh/fkPZF65/d4V+w4DhDeqomBdPcGnkFAcJnEM4o21TnVccrBUoDedLKzC7wJRw1Q7VTqEsfEufmw==}
     peerDependencies:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
@@ -16540,8 +16541,8 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
-  /rc-picker@3.8.2(dayjs@1.11.9)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-q6jnMwBoOi6tFA4xohrKIhzq80Fc3dH0Kiw5VRx6Tf1db7y27PBFCLwu6f66niXidZKD8F4R0M9VIui/jkL4cg==}
+  /rc-picker@3.10.0(dayjs@1.11.9)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-Euki50qtEct6ByOeYlnA4TLs/LcXz7BAYS4cmCTKJ3dWg2sNTVtredLdbS9aJ/9fhMacxGAYAlcQJpQx+av43A==}
     engines: {node: '>=8.x'}
     peerDependencies:
       date-fns: '>= 2.x'
@@ -16689,8 +16690,8 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
-  /rc-tabs@12.7.1(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-NrltXEYIyiDP5JFu85NQwc9eR+7e50r/6MNXYDyG1EMIFNc7BgDppzdpnD3nW4NHYWw5wLIThCURGib48OCTBg==}
+  /rc-tabs@12.9.0(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-2HnVowgMVrq0DfQtyu4mCd9E6pXlWNdM6VaDvOOHMsLYqPmpY+7zBqUC6YrrQ9xYXHciTS0e7TtjOHIvpVCHLQ==}
     engines: {node: '>=8.x'}
     peerDependencies:
       react: '>=16.9.0'
@@ -16699,22 +16700,22 @@ packages:
       '@babel/runtime': 7.22.6
       classnames: 2.3.2
       rc-dropdown: 4.1.0(react-dom@18.2.0)(react@18.2.0)
-      rc-menu: 9.9.2(react-dom@18.2.0)(react@18.2.0)
+      rc-menu: 9.10.0(react-dom@18.2.0)(react@18.2.0)
       rc-motion: 2.7.3(react-dom@18.2.0)(react@18.2.0)
       rc-resize-observer: 1.3.1(react-dom@18.2.0)(react@18.2.0)
       rc-util: 5.34.1(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
-  /rc-textarea@1.2.3(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-YvN8IskIVBRRzcS4deT0VAMim31+T3IoVX4yoCJ+b/iVCvw7yf0usR7x8OaHiUOUoURKcn/3lfGjmtzplcy99g==}
+  /rc-textarea@1.3.2(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-6+lq161wBLEr3ZM9IGxIWmuc7odKVobjtwQeEGHi1jiqqL9bFEipFedi4kA5RuVUgyVklDqYkK0MHdhtBb46yg==}
     peerDependencies:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
     dependencies:
       '@babel/runtime': 7.22.6
       classnames: 2.3.2
-      rc-input: 1.0.4(react-dom@18.2.0)(react@18.2.0)
+      rc-input: 1.1.0(react-dom@18.2.0)(react@18.2.0)
       rc-resize-observer: 1.3.1(react-dom@18.2.0)(react@18.2.0)
       rc-util: 5.34.1(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0


### PR DESCRIPTION
按现在的前端的架构，页面主要由实现在libs/web下的总体布局以及实现在portal-web或者mis-web里的业务组件组成。portal-web和mis-web将会从libs/web导入UI组件并渲染在页面上。特别的，portal-web和mis-web将会在libs/web下导入一个AntdConfigProvider组件，这个组件引入了`antd`的ConfigProvider，用于配置UI的主题。

在上一次依赖项升级后，libs/web中的AntdConfigProvider组件配置的主题不会影响portal-web和mis-web中的UI。

![img_v2_49fda615-76cc-4e74-92a5-f80507ba5d6g](https://github.com/PKUHPC/SCOW/assets/8363856/479f5981-9a7b-4b40-a3a5-020ab45a892e)

此问题具体原因不明，但有可能是因为pnpm的依赖解析算法导致导入了多个antd或者react实例。已确认并非libs/web项目的peerDependencies导致的。本PR同时修改了libs/web项目的peerDependencies，在其中加入了react, react-dom等其他依赖项，但并未解决此问题。

此PR提出了临时的解决方案，即在portal-web和mis-web中复制粘贴一份AntdConfigProvider组件。这个组件直接从antd导入`ConfigProvider`来配置portal-web和mis-web中的UI的主题，并同时使用了libs/web中的`AntdConfigProvider`以配置libs/web下的UI。
