### PR TITLE
fix(dev): 修复ssh-server容器构建

### DIFF
--- a/dev/ssh-server/Dockerfile
+++ b/dev/ssh-server/Dockerfile
@@ -12,7 +12,7 @@ FROM alpine:3.18
 
 ENV TZ Asia/Shanghai
 
-RUN apk add --no-cache openssh=9.3_p1-r3 sudo
+RUN apk add --no-cache openssh sudo
 
 RUN echo 'root:root' | chpasswd
 


### PR DESCRIPTION
测试开发环境的ssh-server的镜像使用alpine:3.18作为base path并指定了openssh版本，但是指定的版本在alpine:3.18的repo不存在了。这个PR使得这个镜像不指定具体的openssh版本。