### PR TITLE
ci: 去除push镜像到北大镜像库

### DIFF
--- a/.github/workflows/test-build-publish.yaml
+++ b/.github/workflows/test-build-publish.yaml
@@ -14,8 +14,6 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 env:
   GITHUB_CR: ghcr.io
-  PKU_CR: mirrors.eecser.com
-  PKU_PROJECT_NAME: pkuhpc-icode
   # ALIYUN_CR: registry.cn-hangzhou.aliyuncs.com
   # ALIYUN_PROJECT_NAME: scow
 
@@ -161,20 +159,12 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Log in to the PKU registry
-        uses: docker/login-action@a9794064588be971151ec5e7144cb535bcb56e36
-        with:
-          registry: ${{ env.PKU_CR }}
-          username: ${{ secrets.PKUREGISTRY_USERNAME }}
-          password: ${{ secrets.PKUREGISTRY_PASSWORD }}
-
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
         with:
           images: |
             ${{ env.GITHUB_CR }}/${{ github.repository }}/${{ matrix.name }}
-            ${{ env.PKU_CR }}/${{ env.PKU_PROJECT_NAME }}/${{ matrix.name }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v4
@@ -187,6 +177,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           # only build arm64 in master commits
           platforms: linux/amd64${{ github.ref_type == 'tag' && ',linux/arm64' || '' }}
+
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
回滚#708。由于github actions访问北大镜像库速度较慢，故此PR使CI时不push镜像到北大镜像库中。北大镜像库
中通过webhook和镜像的方式从ghcr中同步镜像。
