### PR TITLE
feat(mis-server): 调整导入作业流程

### DIFF
--- a/.changeset/forty-books-tease.md
+++ b/.changeset/forty-books-tease.md
@@ -1,0 +1,5 @@
+---
+"@scow/mis-server": patch
+---
+
+调整导入作业流程

--- a/apps/mis-server/src/tasks/fetch.ts
+++ b/apps/mis-server/src/tasks/fetch.ts
@@ -81,7 +81,8 @@ export async function fetchJobs(
   const persistJobAndCharge = async (jobs: ({ cluster: string } & ClusterJobInfo)[]) => {
     const result = await em.transactional(async (em) => {
       // Calculate prices for new info and persist
-      const pricedJobs = [] as JobInfo[];
+      let pricedJob: JobInfo;
+      let count = 0;
       for (const job of jobs) {
         const tenant = accountTenantMap.get(job.account);
 
@@ -104,39 +105,36 @@ export async function fetchJobs(
             tenant,
           }) : emptyJobPriceInfo();
 
-          const pricedJob = new JobInfo(job, tenant, price);
+          pricedJob = new JobInfo(job, tenant, price);
 
           em.persist(pricedJob);
-          await em.flush();
 
-          pricedJobs.push(pricedJob);
+          // Determine whether the job can be inserted into the database. If not, skip the job
+          await em.flush();
         } catch (error) {
           logger.warn("invalid job. cluster: %s, jobId: %s, error: %s", job.cluster, job.jobId, error);
+          continue;
         }
-      }
 
-      // add job charge for user account
-      for (const x of pricedJobs) {
-
-        // add job charge for the user
+        // add job charge for user account
         const ua = await em.findOne(UserAccount, {
-          account: { accountName: x.account },
-          user: { userId: x.user },
+          account: { accountName: pricedJob.account },
+          user: { userId: pricedJob.user },
         }, {
           populate: ["user", "account", "account.tenant"],
         });
 
         if (!ua) {
-          logger.warn({ biJobIndex: x.biJobIndex },
-            "User %s in account %s is not found. Don't charge the job.", x.user, x.account);
+          logger.warn({ biJobIndex: pricedJob.biJobIndex },
+            "User %s in account %s is not found. Don't charge the job.", pricedJob.user, pricedJob.account);
         }
 
-        const comment = parsePlaceholder(misConfig.jobChargeComment, x);
+        const comment = parsePlaceholder(misConfig.jobChargeComment, pricedJob);
 
         if (ua) {
           // charge account
           await charge({
-            amount: x.accountPrice,
+            amount: pricedJob.accountPrice,
             type: misConfig.jobChargeType,
             comment,
             target: ua.account.$,
@@ -144,18 +142,18 @@ export async function fetchJobs(
 
           // charge tenant
           await charge({
-            amount: x.tenantPrice,
+            amount: pricedJob.tenantPrice,
             type: misConfig.jobChargeType,
             comment,
             target: ua.account.$.tenant.getEntity(),
           }, em, logger, clusterPlugin);
 
-          await addJobCharge(ua, x.accountPrice, clusterPlugin, logger);
+          await addJobCharge(ua, pricedJob.accountPrice, clusterPlugin, logger);
         }
+
+        count++;
       }
-
-      return pricedJobs.length;
-
+      return count;
     });
 
     em.clear();


### PR DESCRIPTION
当前版本中, 当导入一批作业时, 会先逐个计算每条作业的价格, 并尝试将作业写入数据库, 收集所有可导入数据库的已计费作业. 再统一进行扣费操作.

现在将流程改为: 对于一条作业, 先计费, 再导入作业, 再扣费; 完整进行上述流程后再继续导入下一条作业