### PR TITLE
fix(doc): 修正自定义 favicon 文档中的错误信息

### DIFF
--- a/.changeset/fair-masks-smile.md
+++ b/.changeset/fair-masks-smile.md
@@ -1,0 +1,5 @@
+---
+"@scow/docs": patch
+---
+
+修改自定义 favicon 文档中的错误信息

--- a/docs/docs/deploy/config/customization/webui.md
+++ b/docs/docs/deploy/config/customization/webui.md
@@ -9,7 +9,7 @@ title: 自定义前端项目主题
 
 ## 自定义favicon
 
-favicon文件应取名为`favicon.ico`，放到`config/icon`下。
+favicon文件应取名为`favicon.ico`，放到`config/icons`下。
 
 系统支持根据不同的来访域名显示不同的LOGO。将需要在某个域名下显示的LOGO文件放到`config/logo/{域名}`下即可。`config/logo`下的文件为对所有其他域名的LOGO图片。
 


### PR DESCRIPTION
文档有疏漏，路径少了一个s，代码中写的路径是icons，用户根据原文档无法修改icon，本PR修正此问题。

定义文件路径的代码 apps/mis-web/src/pages/api/icon.ts ：
```ts
import { DEFAULT_CONFIG_BASE_PATH } from "@scow/config/build/constants";
import { serveIcon } from "@scow/lib-web/build/routes/icon/icon";
import { NextApiRequest, NextApiResponse } from "next";

const BUILTIN_DEFAULT_DIR = "assets/icons";

export default (req: NextApiRequest, res: NextApiResponse) =>
  serveIcon(req, res, BUILTIN_DEFAULT_DIR, DEFAULT_CONFIG_BASE_PATH);

```