### PR TITLE
feat(mis): 租户管理下账户列表及白名单账户列表显示优化 

### DIFF
--- a/.changeset/afraid-tigers-count.md
+++ b/.changeset/afraid-tigers-count.md
@@ -1,0 +1,7 @@
+---
+"@scow/mis-server": patch
+"@scow/mis-web": patch
+"@scow/lib-web": patch
+---
+
+租户管理下账户列表，白名单账户显示优化；增加账户统计信息，用户数量显示等功能。

--- a/.changeset/itchy-emus-divide.md
+++ b/.changeset/itchy-emus-divide.md
@@ -1,0 +1,5 @@
+---
+"@scow/grpc-api": patch
+---
+
+在获取账户白名单 getWhitelistedAccounts 接口返回值中增加账户余额 balance

--- a/apps/mis-server/src/services/account.ts
+++ b/apps/mis-server/src/services/account.ts
@@ -227,6 +227,7 @@ export const accountServiceServer = plugin((server) => {
             addTime: x.time.toISOString(),
             ownerId: accountOwner.id + "",
             ownerName: accountOwner.name,
+            balance: decimalToMoney(x.account.$.balance),
           };
 
         }),

--- a/apps/mis-web/src/apis/api.mock.ts
+++ b/apps/mis-web/src/apis/api.mock.ts
@@ -383,6 +383,7 @@ export const mockApi: MockApi<typeof api> = {
     operatorId: "123",
     ownerId: "123",
     ownerName: "123",
+    balance: numberToMoney(10.5),
   }], totalCount: 1 }),
 
   changePassword: async () => null,

--- a/apps/mis-web/src/models/UserSchemaModel.ts
+++ b/apps/mis-web/src/models/UserSchemaModel.ts
@@ -121,6 +121,7 @@ export const WhitelistedAccount = Type.Object({
   addTime: Type.Optional(Type.String()),
   operatorId: Type.String(),
   comment: Type.String(),
+  balance: Type.Optional(Money),
 });
 export type WhitelistedAccount = Static<typeof WhitelistedAccount>;
 

--- a/apps/mis-web/src/pageComponents/tenant/AccountTable.tsx
+++ b/apps/mis-web/src/pageComponents/tenant/AccountTable.tsx
@@ -58,17 +58,15 @@ export const AccountTable: React.FC<Props> = ({
       && (rangeSearchStatus === "ALL" || (rangeSearchStatus === "BLOCKED" ? x.blocked : !x.balance.positive))
   )) : undefined, [data, query, rangeSearchStatus]);
 
-  const getUsersStatusCount = (status: FilteredStatus): number => {
-    switch (status) {
-    case "BLOCKED":
-      return data ? data.results.filter((user) => user.blocked).length : 0;
-    case "DEBT":
-      return data ? data.results.filter((user) => !user.balance.positive).length : 0;
-    case "ALL":
-    default:
-      return data ? data.results.length : 0;
-    }
-  };
+  const usersStatusCount = useMemo(() => {
+    if (!data || !data.results) return { BLOCKED : 0, DEBT : 0, ALL : 0 };
+    const counts = {
+      BLOCKED: data.results.filter((user) => user.blocked).length,
+      DEBT: data.results.filter((user) => !user.balance.positive).length,
+      ALL: data.results.length,
+    };
+    return counts;
+  }, [data]);
 
   const handleTableChange = (_, __, sortInfo) => {
     setCurrentSortInfo({ field: sortInfo.field, order: sortInfo.order });
@@ -103,7 +101,7 @@ export const AccountTable: React.FC<Props> = ({
         <Space style={{ marginBottom: "-16px" }}>
           <FilterFormTabs
             tabs={Object.keys(filteredStatuses).map((status) => ({
-              title: `${filteredStatuses[status]}(${getUsersStatusCount(status as FilteredStatus)})`,
+              title: `${filteredStatuses[status]}(${usersStatusCount[status as FilteredStatus]})`,
               key: status,
             }))}
             onChange={(value) => handleFilterStatusChange(value as FilteredStatus)}

--- a/apps/mis-web/src/pageComponents/tenant/AccountWhitelistTable.tsx
+++ b/apps/mis-web/src/pageComponents/tenant/AccountWhitelistTable.tsx
@@ -11,19 +11,27 @@
  */
 
 import { ExclamationCircleOutlined } from "@ant-design/icons";
+import { FilterFormContainer } from "@scow/lib-web/build/components/FilterFormContainer";
 import { formatDateTime } from "@scow/lib-web/build/utils/datetime";
 import { WhitelistedAccount } from "@scow/protos/build/server/account";
 import { Static } from "@sinclair/typebox";
-import { App, Divider, Space, Table } from "antd";
-import React from "react";
+import { App, Button, Divider, Form, Input, Space, Table } from "antd";
+import React, { useMemo, useState } from "react";
 import { api } from "src/apis";
+import { TableTitle } from "src/components/TableTitle";
+import { Money } from "src/models/UserSchemaModel";
 import type {
   GetWhitelistedAccountsSchema } from "src/pages/api/tenant/accountWhitelist/getWhitelistedAccounts";
+import { moneyToString } from "src/utils/money";
 
 interface Props {
   data: Static<typeof GetWhitelistedAccountsSchema["responses"]["200"]> | undefined;
   isLoading: boolean;
   reload: () => void;
+}
+
+interface FilterForm {
+  accountName: string | undefined;
 }
 
 export const AccountWhitelistTable: React.FC<Props> = ({
@@ -32,53 +40,121 @@ export const AccountWhitelistTable: React.FC<Props> = ({
 
   const { message, modal } = App.useApp();
 
+  const [form] = Form.useForm<FilterForm>();
+  const [query, setQuery] = useState<FilterForm>({
+    accountName: undefined,
+  });
+  const [currentPageNum, setCurrentPageNum] = useState<number>(1);
+
+  const filteredData = useMemo(() => data ? data.results.filter((x) => (
+    (!query.accountName || x.accountName.includes(query.accountName))
+  )) : undefined, [data, query]);
+
+  const getTotalDebtAmount =
+    (data: Static<typeof GetWhitelistedAccountsSchema["responses"]["200"]> | undefined): number => {
+      const sum = data?.results.filter((acct) => !acct.balance?.positive)
+        .reduce((acc, acct) => {
+          const debtAmount = acct.balance ? moneyToString(acct.balance) : "0.000";
+          return acc + parseFloat(debtAmount);
+        }, 0);
+      return sum ?? 0;
+    };
+
   return (
-    <Table
-      dataSource={data?.results}
-      loading={isLoading}
-      rowKey="accountName"
-      scroll={{ x: true }}
-      pagination={{ showSizeChanger: true }}
-    >
-      <Table.Column<WhitelistedAccount> dataIndex="accountName" title="账户名" />
-      <Table.Column<WhitelistedAccount>
-        dataIndex="ownerId"
-        title="拥有者"
-        render={(_, r) => `${r.ownerName} (id: ${r.ownerId})`}
-      />
-      <Table.Column
-        dataIndex="addTime"
-        title="加入时间"
-        render={(time: string) => formatDateTime(time) }
-      />
-      <Table.Column<WhitelistedAccount> dataIndex="comment" title="备注" />
-      <Table.Column<WhitelistedAccount> dataIndex="operatorId" title="操作人" />
-      <Table.Column<WhitelistedAccount>
-        title="操作"
-        render={(_, r) => (
-          <Space split={<Divider type="vertical" />}>
-            <a onClick={() => {
-              modal.confirm({
-                title: "确认将账户移除白名单？",
-                icon: <ExclamationCircleOutlined />,
-                content: `确认要将账户${r.accountName}从白名单移除？`,
-                onOk: async () => {
-                  await api.dewhitelistAccount({ query: {
-                    accountName: r.accountName,
-                  } })
-                    .then(() => {
-                      message.success("移出白名单成功！");
-                      reload();
-                    });
-                },
-              });
-            }}
-            >
-              从白名单中去除
-            </a>
-          </Space>
-        )}
-      />
-    </Table>
+    <div>
+      <FilterFormContainer>
+        <Form<FilterForm>
+          layout="inline"
+          form={form}
+          initialValues={query}
+          onFinish={async () => {
+            setQuery(await form.validateFields());
+            setCurrentPageNum(1);
+          }}
+        >
+          <Form.Item label="账户" name="accountName">
+            <Input />
+          </Form.Item>
+          <Form.Item>
+            <Button type="primary" htmlType="submit">搜索</Button>
+          </Form.Item>
+        </Form>
+      </FilterFormContainer>
+      <>
+        <TableTitle justify="flex-start">
+          {
+            data ? (
+              <div>
+                <span>
+                  白名单数量：<strong>{data.results.length ?? 0}</strong>
+                </span>
+                <>
+                  <Divider type="vertical" />
+                  <span>
+                    白名单欠费合计：<strong>{getTotalDebtAmount(data).toFixed(2)} 元</strong>
+                  </span>
+                </>
+              </div>
+            ) : undefined
+          }
+        </TableTitle>
+        <Table
+          dataSource={filteredData}
+          loading={isLoading}
+          rowKey="accountName"
+          scroll={{ x: true }}
+          pagination={{
+            showSizeChanger: true,
+            current: currentPageNum,
+            onChange: (page) => setCurrentPageNum(page),
+          }}
+        >
+          <Table.Column<WhitelistedAccount> dataIndex="accountName" title="账户名" />
+          <Table.Column<WhitelistedAccount>
+            dataIndex="ownerId"
+            title="拥有者"
+            render={(_, r) => `${r.ownerName} (id: ${r.ownerId})`}
+          />
+          <Table.Column<WhitelistedAccount>
+            dataIndex="balance"
+            title="余额"
+            render={(b: Money) => moneyToString(b) + " 元" }
+          />
+          <Table.Column
+            dataIndex="addTime"
+            title="加入时间"
+            render={(time: string) => formatDateTime(time) }
+          />
+          <Table.Column<WhitelistedAccount> dataIndex="comment" title="备注" />
+          <Table.Column<WhitelistedAccount> dataIndex="operatorId" title="操作人" />
+          <Table.Column<WhitelistedAccount>
+            title="操作"
+            render={(_, r) => (
+              <Space split={<Divider type="vertical" />}>
+                <a onClick={() => {
+                  modal.confirm({
+                    title: "确认将账户移除白名单？",
+                    icon: <ExclamationCircleOutlined />,
+                    content: `确认要将账户${r.accountName}从白名单移除？`,
+                    onOk: async () => {
+                      await api.dewhitelistAccount({ query: {
+                        accountName: r.accountName,
+                      } })
+                        .then(() => {
+                          message.success("移出白名单成功！");
+                          reload();
+                        });
+                    },
+                  });
+                }}
+                >
+                  从白名单中去除
+                </a>
+              </Space>
+            )}
+          />
+        </Table>
+      </>
+    </div>
   );
 };

--- a/libs/web/src/components/FilterFormContainer.tsx
+++ b/libs/web/src/components/FilterFormContainer.tsx
@@ -32,8 +32,8 @@ const TabFormContainer = styled.div`
 `;
 
 interface TabbedFilterFormProps {
-  button: JSX.Element;
-  tabs: { title: string; key?: string; node: JSX.Element; }[];
+  button?: JSX.Element;
+  tabs: { title: string; key?: string; node?: JSX.Element; }[];
   onChange?: (activeKey: string) => void;
 }
 

--- a/protos/server/account.proto
+++ b/protos/server/account.proto
@@ -53,6 +53,7 @@ message WhitelistedAccount {
   google.protobuf.Timestamp add_time = 4;
   string operator_id = 5;
   string comment = 6;
+  common.Money balance = 7;
 }
 
 message GetWhitelistedAccountsResponse {


### PR DESCRIPTION
### 实现了什么

**在租户管理的账户列表下做了以下修改**

1. 在右上角添加所有账户、欠费账户、封锁账户，括号内为数量，点击后显示相应的账户，点击后动作与用户列表优化相同
2. 去除原有搜索左边的筛选条件
3. 拥有者后增加用户数量显示列
4. 增加按余额和状态排序
![image](https://github.com/PKUHPC/SCOW/assets/43978285/3b78aee6-c7b3-44ca-b6bb-b1f83fcf3353)

**在租户管理的白名单账户列表下做了以下修改**

1. 增加按账户名搜索功能
2. 搜索栏下增加白名单数量和白名单欠费合计金额显示，金额显示为与其他页面统一产品需求调整为显示小数点后3位小数
3. 拥有者后增加账户余额显示列
4. 增加按账户名和余额排序
![image](https://github.com/PKUHPC/SCOW/assets/43978285/ca1d8a3f-5309-4d50-b762-d2a05557563d)

