### PR TITLE
ci: 从CI中去除安装buf步骤

### DIFF
--- a/.github/workflows/test-build-publish.yaml
+++ b/.github/workflows/test-build-publish.yaml
@@ -41,11 +41,6 @@ jobs:
           node-version: 18.x
           cache: pnpm
 
-      - uses: bufbuild/buf-setup-action@v1
-        with:
-          version: "1.11.0"
-          github_token: ${{ github.token }}
-
       - name: Install dependencies
         run: pnpm i --frozen-lockfile
 


### PR DESCRIPTION
Buf CLI目前从npm中获取，CI中不再需要单独安装buf。