### PR TITLE
fix(mis-server): 调整callonall的返回类型

### DIFF
--- a/apps/mis-server/src/bl/PriceMap.ts
+++ b/apps/mis-server/src/bl/PriceMap.ts
@@ -92,9 +92,7 @@ export async function createPriceMap(
     async (client) => await asyncClientCall(client.config, "getClusterConfig", {}),
   );
   reply.forEach((x) => {
-    if (x.success) {
-      partitionsForClusters[x.cluster] = x.result.partitions;
-    }
+    partitionsForClusters[x.cluster] = x.result.partitions;
   });
 
   return {


### PR DESCRIPTION
当前, callonall的返回类型为`({cluster: string; success: boolean; result: T} |  {cluster: string; success: boolean; error: any}) []`, 然而实际上在返回前会判断是否存在错误, 如果有success为false的情况, 则直接抛出错误, 因此callonall如果正常返回, 则success不可能为false

这个pr调整了callonall的返回类型, 只返回`{cluster: string, result: T}[]`类型