### PR TITLE
feat: 增加提交作业的命令框中的提示语句可配置

### DIFF
--- a/.changeset/spotty-gorillas-worry.md
+++ b/.changeset/spotty-gorillas-worry.md
@@ -1,0 +1,7 @@
+---
+"@scow/portal-web": patch
+"@scow/config": patch
+"@scow/docs": patch
+---
+
+增加提交作业的命令框中的提示语句可配置

--- a/apps/portal-server/config/portal.yaml
+++ b/apps/portal-server/config/portal.yaml
@@ -39,7 +39,7 @@ homeText:
     a.com: "a.com's SCOW"
 
 # 提交作业命令框中的提示语
-# submitPromptText: "#此处参数设置的优先级高于页面其它地方，两者冲突时以此处为准"
+# submitJobPromptText: "#此处参数设置的优先级高于页面其它地方，两者冲突时以此处为准"
 
 # 如果部署了管理系统，请设置管理系统部署的路径
 # misPath: /mis

--- a/apps/portal-server/config/portal.yaml
+++ b/apps/portal-server/config/portal.yaml
@@ -38,6 +38,9 @@ homeText:
   hostnameMap:
     a.com: "a.com's SCOW"
 
+# 提交作业命令框中的提示语
+# submitPromptText: "#此处参数设置的优先级高于页面其它地方，两者冲突时以此处为准"
+
 # 如果部署了管理系统，请设置管理系统部署的路径
 # misPath: /mis
 

--- a/apps/portal-web/config.js
+++ b/apps/portal-web/config.js
@@ -147,6 +147,8 @@ const buildRuntimeConfig = async (phase, basePath) => {
     HOME_TITLES: portalConfig.homeTitle.hostnameMap,
     SUBMIT_JOB_WORKING_DIR: portalConfig.submitJobDefaultPwd,
     SCOW_API_AUTH_TOKEN: commonConfig.scowApi?.auth?.token,
+    DEFAULT_SUBMIT_PROMPT_TEXT:portalConfig.submitPromptText.defaultText,
+    SUBMIT_PROMPT_TEXT:portalConfig.submitPromptText.hostnameMap,
   };
 
   // query auth capabilities to set optional auth features

--- a/apps/portal-web/config.js
+++ b/apps/portal-web/config.js
@@ -147,8 +147,7 @@ const buildRuntimeConfig = async (phase, basePath) => {
     HOME_TITLES: portalConfig.homeTitle.hostnameMap,
     SUBMIT_JOB_WORKING_DIR: portalConfig.submitJobDefaultPwd,
     SCOW_API_AUTH_TOKEN: commonConfig.scowApi?.auth?.token,
-    DEFAULT_SUBMIT_PROMPT_TEXT:portalConfig.submitPromptText.defaultText,
-    SUBMIT_PROMPT_TEXT:portalConfig.submitPromptText.hostnameMap,
+    SUBMIT_PROMPT_TEXT:portalConfig.submitPromptText,
   };
 
   // query auth capabilities to set optional auth features

--- a/apps/portal-web/config.js
+++ b/apps/portal-web/config.js
@@ -147,7 +147,7 @@ const buildRuntimeConfig = async (phase, basePath) => {
     HOME_TITLES: portalConfig.homeTitle.hostnameMap,
     SUBMIT_JOB_WORKING_DIR: portalConfig.submitJobDefaultPwd,
     SCOW_API_AUTH_TOKEN: commonConfig.scowApi?.auth?.token,
-    SUBMIT_PROMPT_TEXT:portalConfig.submitPromptText,
+    SUBMIT_JOB_PROMPT_TEXT:portalConfig.submitJobPromptText,
   };
 
   // query auth capabilities to set optional auth features

--- a/apps/portal-web/config/portal.yaml
+++ b/apps/portal-web/config/portal.yaml
@@ -39,7 +39,7 @@ homeText:
     a.com: "a.com's SCOW"
 
 # 提交作业命令框中的提示语
-# submitPromptText: "#此处参数设置的优先级高于页面其它地方，两者冲突时以此处为准"
+# submitJobPromptText: "#此处参数设置的优先级高于页面其它地方，两者冲突时以此处为准"
 
 # 如果部署了管理系统，请设置管理系统部署的路径
 # misPath: /mis

--- a/apps/portal-web/config/portal.yaml
+++ b/apps/portal-web/config/portal.yaml
@@ -39,12 +39,7 @@ homeText:
     a.com: "a.com's SCOW"
 
 # 提交作业命令框中的提示语
-submitPromptText:
-  # 默认文本
-  defaultText: "#此处参数设置的优先级高于页面其它地方，两者冲突时以此处为准"
-  # 从不同域名访问，显示的不同的提示词
-  hostnameMap:
-    a.com: "a.com's 提交作业命令框中的提示语"
+# submitPromptText: "#此处参数设置的优先级高于页面其它地方，两者冲突时以此处为准"
 
 # 如果部署了管理系统，请设置管理系统部署的路径
 # misPath: /mis

--- a/apps/portal-web/config/portal.yaml
+++ b/apps/portal-web/config/portal.yaml
@@ -38,6 +38,14 @@ homeText:
   hostnameMap:
     a.com: "a.com's SCOW"
 
+# 提交作业命令框中的提示语
+submitPromptText:
+  # 默认文本
+  defaultText: "#此处参数设置的优先级高于页面其它地方，两者冲突时以此处为准"
+  # 从不同域名访问，显示的不同的提示词
+  hostnameMap:
+    a.com: "a.com's 提交作业命令框中的提示语"
+
 # 如果部署了管理系统，请设置管理系统部署的路径
 # misPath: /mis
 

--- a/apps/portal-web/src/pageComponents/job/SubmitJobForm.tsx
+++ b/apps/portal-web/src/pageComponents/job/SubmitJobForm.tsx
@@ -69,9 +69,10 @@ const initialValues = {
 
 interface Props {
   initial?: typeof initialValues;
+  submitPromptText: string;
 }
 
-export const SubmitJobForm: React.FC<Props> = ({ initial = initialValues }) => {
+export const SubmitJobForm: React.FC<Props> = ({ initial = initialValues, submitPromptText }) => {
   const { message, modal } = App.useApp();
 
   const [form] = Form.useForm<JobForm>();
@@ -221,7 +222,7 @@ export const SubmitJobForm: React.FC<Props> = ({ initial = initialValues }) => {
       >
         <CodeEditor
           height="50vh"
-          placeholder="#此处参数设置的优先级高于页面其它地方，两者冲突时以此处为准"
+          placeholder={submitPromptText}
         />
       </Form.Item>
       <Row gutter={4}>

--- a/apps/portal-web/src/pageComponents/job/SubmitJobForm.tsx
+++ b/apps/portal-web/src/pageComponents/job/SubmitJobForm.tsx
@@ -69,10 +69,10 @@ const initialValues = {
 
 interface Props {
   initial?: typeof initialValues;
-  submitPromptText: string;
+  submitJobPromptText: string;
 }
 
-export const SubmitJobForm: React.FC<Props> = ({ initial = initialValues, submitPromptText }) => {
+export const SubmitJobForm: React.FC<Props> = ({ initial = initialValues, submitJobPromptText }) => {
   const { message, modal } = App.useApp();
 
   const [form] = Form.useForm<JobForm>();
@@ -222,7 +222,7 @@ export const SubmitJobForm: React.FC<Props> = ({ initial = initialValues, submit
       >
         <CodeEditor
           height="50vh"
-          placeholder={submitPromptText}
+          placeholder={submitJobPromptText}
         />
       </Form.Item>
       <Row gutter={4}>

--- a/apps/portal-web/src/pages/jobs/submit.tsx
+++ b/apps/portal-web/src/pages/jobs/submit.tsx
@@ -10,7 +10,6 @@
  * See the Mulan PSL v2 for more details.
  */
 
-import { getHostname } from "@scow/lib-web/build/utils/getHostname";
 import { queryToString, useQuerystring } from "@scow/lib-web/build/utils/querystring";
 import { Spin } from "antd";
 import { GetServerSideProps, NextPage } from "next";
@@ -81,12 +80,9 @@ export const SubmitJobPage: NextPage<Props> = requireAuth(() => true)(
 
   });
 
-export const getServerSideProps: GetServerSideProps<Props> = async ({ req }) => {
+export const getServerSideProps: GetServerSideProps = async () => {
 
-  const hostname = getHostname(req);
-
-  const submitPromptText = (hostname && runtimeConfig.SUBMIT_PROMPT_TEXT[hostname]) ?? 
-  runtimeConfig.DEFAULT_SUBMIT_PROMPT_TEXT;
+  const submitPromptText = runtimeConfig.SUBMIT_PROMPT_TEXT;
 
   return {
     props: {

--- a/apps/portal-web/src/pages/jobs/submit.tsx
+++ b/apps/portal-web/src/pages/jobs/submit.tsx
@@ -23,7 +23,7 @@ import { publicConfig, runtimeConfig } from "src/utils/config";
 import { Head } from "src/utils/head";
 
 interface Props {
-  submitPromptText: string;
+  submitJobPromptText: string;
 }
 
 export const SubmitJobPage: NextPage<Props> = requireAuth(() => true)(
@@ -72,7 +72,7 @@ export const SubmitJobPage: NextPage<Props> = requireAuth(() => true)(
           isLoading ? (
             <Spin tip="正在加载作业模板" />
           ) : (
-            <SubmitJobForm initial={data} submitPromptText={props.submitPromptText} />
+            <SubmitJobForm initial={data} submitJobPromptText={props.submitJobPromptText} />
           )
         }
       </div>
@@ -82,11 +82,11 @@ export const SubmitJobPage: NextPage<Props> = requireAuth(() => true)(
 
 export const getServerSideProps: GetServerSideProps = async () => {
 
-  const submitPromptText = runtimeConfig.SUBMIT_PROMPT_TEXT;
+  const submitJobPromptText = runtimeConfig.SUBMIT_JOB_PROMPT_TEXT;
 
   return {
     props: {
-      submitPromptText,
+      submitJobPromptText,
     },
   };
 };

--- a/apps/portal-web/src/pages/jobs/submit.tsx
+++ b/apps/portal-web/src/pages/jobs/submit.tsx
@@ -10,20 +10,25 @@
  * See the Mulan PSL v2 for more details.
  */
 
+import { getHostname } from "@scow/lib-web/build/utils/getHostname";
 import { queryToString, useQuerystring } from "@scow/lib-web/build/utils/querystring";
 import { Spin } from "antd";
-import { NextPage } from "next";
+import { GetServerSideProps, NextPage } from "next";
 import { useCallback } from "react";
 import { useAsync } from "react-async";
 import { api } from "src/apis";
 import { requireAuth } from "src/auth/requireAuth";
 import { PageTitle } from "src/components/PageTitle";
 import { SubmitJobForm } from "src/pageComponents/job/SubmitJobForm";
-import { publicConfig } from "src/utils/config";
+import { publicConfig, runtimeConfig } from "src/utils/config";
 import { Head } from "src/utils/head";
 
-export const SubmitJobPage: NextPage = requireAuth(() => true)(
-  () => {
+interface Props {
+  submitPromptText: string;
+}
+
+export const SubmitJobPage: NextPage<Props> = requireAuth(() => true)(
+  (props: Props) => {
 
     const query = useQuerystring();
 
@@ -68,12 +73,26 @@ export const SubmitJobPage: NextPage = requireAuth(() => true)(
           isLoading ? (
             <Spin tip="正在加载作业模板" />
           ) : (
-            <SubmitJobForm initial={data} />
+            <SubmitJobForm initial={data} submitPromptText={props.submitPromptText} />
           )
         }
       </div>
     );
 
   });
+
+export const getServerSideProps: GetServerSideProps<Props> = async ({ req }) => {
+
+  const hostname = getHostname(req);
+
+  const submitPromptText = (hostname && runtimeConfig.SUBMIT_PROMPT_TEXT[hostname]) ?? 
+  runtimeConfig.DEFAULT_SUBMIT_PROMPT_TEXT;
+
+  return {
+    props: {
+      submitPromptText,
+    },
+  };
+};
 
 export default SubmitJobPage;

--- a/apps/portal-web/src/utils/config.ts
+++ b/apps/portal-web/src/utils/config.ts
@@ -41,6 +41,9 @@ export interface ServerRuntimeConfig {
   DEFAULT_HOME_TITLE: string;
   HOME_TITLES: {[hostname: string]: string };
 
+  DEFAULT_SUBMIT_PROMPT_TEXT: string;
+  SUBMIT_PROMPT_TEXT: {[hostname: string]: string };
+
   SUBMIT_JOB_WORKING_DIR: string;
 
   SCOW_API_AUTH_TOKEN?: string;

--- a/apps/portal-web/src/utils/config.ts
+++ b/apps/portal-web/src/utils/config.ts
@@ -41,8 +41,7 @@ export interface ServerRuntimeConfig {
   DEFAULT_HOME_TITLE: string;
   HOME_TITLES: {[hostname: string]: string };
 
-  DEFAULT_SUBMIT_PROMPT_TEXT: string;
-  SUBMIT_PROMPT_TEXT: {[hostname: string]: string };
+  SUBMIT_PROMPT_TEXT?: string;
 
   SUBMIT_JOB_WORKING_DIR: string;
 

--- a/apps/portal-web/src/utils/config.ts
+++ b/apps/portal-web/src/utils/config.ts
@@ -41,7 +41,7 @@ export interface ServerRuntimeConfig {
   DEFAULT_HOME_TITLE: string;
   HOME_TITLES: {[hostname: string]: string };
 
-  SUBMIT_PROMPT_TEXT?: string;
+  SUBMIT_JOB_PROMPT_TEXT?: string;
 
   SUBMIT_JOB_WORKING_DIR: string;
 

--- a/dev/vagrant/config/portal.yaml
+++ b/dev/vagrant/config/portal.yaml
@@ -40,7 +40,7 @@ homeText:
   #   a.com: "a.com's SCOW"
 
 # 提交作业命令框中的提示语
-# submitPromptText: "#此处参数设置的优先级高于页面其它地方，两者冲突时以此处为准"
+# submitJobPromptText: "#此处参数设置的优先级高于页面其它地方，两者冲突时以此处为准"
 
 # 是否启用终端功能
 shell: true

--- a/dev/vagrant/config/portal.yaml
+++ b/dev/vagrant/config/portal.yaml
@@ -44,8 +44,8 @@ submitPromptText:
   # 默认文本
   defaultText: "#此处参数设置的优先级高于页面其它地方，两者冲突时以此处为准"
   # 从不同域名访问，显示的不同的提示词
-   hostnameMap:
-     a.com: "a.com's 提交作业命令框中的提示语"
+  hostnameMap:
+    a.com: "a.com's 提交作业命令框中的提示语"
 
 # 是否启用终端功能
 shell: true

--- a/dev/vagrant/config/portal.yaml
+++ b/dev/vagrant/config/portal.yaml
@@ -39,6 +39,14 @@ homeText:
   # hostnameMap:
   #   a.com: "a.com's SCOW"
 
+# 提交作业命令框中的提示语
+submitPromptText:
+  # 默认文本
+  defaultText: "#此处参数设置的优先级高于页面其它地方，两者冲突时以此处为准"
+  # 从不同域名访问，显示的不同的提示词
+   hostnameMap:
+     a.com: "a.com's 提交作业命令框中的提示语"
+
 # 是否启用终端功能
 shell: true
 

--- a/dev/vagrant/config/portal.yaml
+++ b/dev/vagrant/config/portal.yaml
@@ -40,12 +40,7 @@ homeText:
   #   a.com: "a.com's SCOW"
 
 # 提交作业命令框中的提示语
-submitPromptText:
-  # 默认文本
-  defaultText: "#此处参数设置的优先级高于页面其它地方，两者冲突时以此处为准"
-  # 从不同域名访问，显示的不同的提示词
-  hostnameMap:
-    a.com: "a.com's 提交作业命令框中的提示语"
+# submitPromptText: "#此处参数设置的优先级高于页面其它地方，两者冲突时以此处为准"
 
 # 是否启用终端功能
 shell: true

--- a/docs/docs/deploy/config/portal/intro.md
+++ b/docs/docs/deploy/config/portal/intro.md
@@ -70,13 +70,8 @@ homeText:
   hostnameMap: 
     a.com: "a.com's SCOW"
 
-# 提交作业命令框中的提示语
-submitPromptText:
-  # 默认文本
-  defaultText: "#此处参数设置的优先级高于页面其它地方，两者冲突时以此处为准"
-  # 从不同域名访问，显示的不同的提示词
-   hostnameMap:
-     a.com: "a.com's 提交作业命令框中的提示语"
+# 提交作业命令框中的提示语，可选配置
+submitPromptText: "#此处参数设置的优先级高于页面其它地方，两者冲突时以此处为准"
 
 # 是否启用终端功能
 shell: true

--- a/docs/docs/deploy/config/portal/intro.md
+++ b/docs/docs/deploy/config/portal/intro.md
@@ -70,6 +70,14 @@ homeText:
   hostnameMap: 
     a.com: "a.com's SCOW"
 
+# 提交作业命令框中的提示语
+submitPromptText:
+  # 默认文本
+  defaultText: "#此处参数设置的优先级高于页面其它地方，两者冲突时以此处为准"
+  # 从不同域名访问，显示的不同的提示词
+   hostnameMap:
+     a.com: "a.com's 提交作业命令框中的提示语"
+
 # 是否启用终端功能
 shell: true
 

--- a/docs/docs/deploy/config/portal/intro.md
+++ b/docs/docs/deploy/config/portal/intro.md
@@ -71,7 +71,7 @@ homeText:
     a.com: "a.com's SCOW"
 
 # 提交作业命令框中的提示语，可选配置
-submitPromptText: "#此处参数设置的优先级高于页面其它地方，两者冲突时以此处为准"
+submitJobPromptText: "#此处参数设置的优先级高于页面其它地方，两者冲突时以此处为准"
 
 # 是否启用终端功能
 shell: true

--- a/libs/config/src/portal.ts
+++ b/libs/config/src/portal.ts
@@ -44,13 +44,8 @@ export const PortalConfigSchema = Type.Object({
     ),
   }),
 
-  submitPromptText: Type.Object({
-    defaultText: Type.String({ description: "提交作业命令框中的提示语", default: "#此处参数设置的优先级高于页面其它地方，两者冲突时以此处为准" }),
-    hostnameMap: Type.Record(
-      Type.String(), Type.String(),
-      { description: "根据域名(hostname，不包括port)不同，显示的不同的提示词", default: {} },
-    ),
-  }),
+  submitPromptText: 
+  Type.Optional(Type.String({ description: "提交作业命令框中的提示语", default: "#此处参数设置的优先级高于页面其它地方，两者冲突时以此处为准" })),
 
   misUrl: Type.Optional(Type.String({ description: "管理系统的部署URL或者路径" })),
 

--- a/libs/config/src/portal.ts
+++ b/libs/config/src/portal.ts
@@ -44,7 +44,7 @@ export const PortalConfigSchema = Type.Object({
     ),
   }),
 
-  submitPromptText: 
+  submitJobPromptText: 
   Type.Optional(Type.String({ description: "提交作业命令框中的提示语", default: "#此处参数设置的优先级高于页面其它地方，两者冲突时以此处为准" })),
 
   misUrl: Type.Optional(Type.String({ description: "管理系统的部署URL或者路径" })),

--- a/libs/config/src/portal.ts
+++ b/libs/config/src/portal.ts
@@ -44,6 +44,14 @@ export const PortalConfigSchema = Type.Object({
     ),
   }),
 
+  submitPromptText: Type.Object({
+    defaultText: Type.String({ description: "提交作业命令框中的提示语", default: "#此处参数设置的优先级高于页面其它地方，两者冲突时以此处为准" }),
+    hostnameMap: Type.Record(
+      Type.String(), Type.String(),
+      { description: "根据域名(hostname，不包括port)不同，显示的不同的提示词", default: {} },
+    ),
+  }),
+
   misUrl: Type.Optional(Type.String({ description: "管理系统的部署URL或者路径" })),
 
   shell: Type.Boolean({ description: "是否启用终端功能", default: true }),


### PR DESCRIPTION
![image](https://github.com/PKUHPC/SCOW/assets/74037789/2b7c435d-6867-4046-a3d4-f49290a06c08)
### 之前是提交作业的命令框中的的提示语句是固定的，现在改成可配置的，用户在portal.yaml文件中配置
```shell 
# 提交作业命令框中的提示语
submitPromptText:
  # 默认文本
  defaultText: "#此处参数设置的优先级高于页面其它地方，两者冲突时以此处为准"
  # 从不同域名访问，显示的不同的提示词
   hostnameMap:
     a.com: "a.com's 提交作业命令框中的提示语"
```
