### PR TITLE
fix: 门户和管理系统个人信息页面由水平布局改为垂直布局

### DIFF
--- a/.changeset/fair-dolphins-glow.md
+++ b/.changeset/fair-dolphins-glow.md
@@ -1,0 +1,6 @@
+---
+"@scow/portal-web": patch
+"@scow/mis-web": patch
+---
+
+个人信息页面由水平布局改为垂直布局

--- a/apps/mis-web/src/pages/profile/index.tsx
+++ b/apps/mis-web/src/pages/profile/index.tsx
@@ -24,6 +24,7 @@ import styled from "styled-components";
 const Container = styled.div`
   display: flex;
   flex-wrap: wrap;
+  flex-direction: column;
 `;
 
 const Part = styled(Section)`
@@ -72,13 +73,9 @@ export const ProfilePage: NextPage = requireAuth(() => true)(({ userStore: { use
             </Part>
           ) : undefined
         }
-      </Container>
-      <Container>
-        {
-          <Part title="修改邮箱">
-            <ChangeEmailForm />
-          </Part>
-        }
+        <Part title="修改邮箱">
+          <ChangeEmailForm />
+        </Part>
       </Container>
     </>
     

--- a/apps/portal-web/src/pages/profile/index.tsx
+++ b/apps/portal-web/src/pages/profile/index.tsx
@@ -22,6 +22,7 @@ import styled from "styled-components";
 const Container = styled.div`
   display: flex;
   flex-wrap: wrap;
+  flex-direction: column;
 `;
 
 const Part = styled(Section)`


### PR DESCRIPTION
## 之前：个人信息页面左右布局：
![image](https://github.com/PKUHPC/SCOW/assets/74037789/21fdc5b1-b17e-4bea-97d0-4059fbc0a4c0)
## 现在：两个页面中将修改密码和修改邮箱部分移至左侧，形成上下布局，避免整个页面显示杂乱；
![image](https://github.com/PKUHPC/SCOW/assets/74037789/6e6de845-9475-4992-81ce-145ba546808b)
