### PR TITLE
fix(mis-web): 修复 Schema 中使用 Type.Union([Type.String(), Type.Undefined()])错误，改为 Type.Optional(Type.String())

### DIFF
--- a/.changeset/thin-peaches-fly.md
+++ b/.changeset/thin-peaches-fly.md
@@ -1,0 +1,5 @@
+---
+"@scow/mis-web": patch
+---
+
+修复 Schema 中使用 Type.Union([Type.String(), Type.Undefined()])错误，改为 Type.Optional(Type.String())

--- a/apps/mis-web/src/pages/api/profile/changePassword.ts
+++ b/apps/mis-web/src/pages/api/profile/changePassword.ts
@@ -31,7 +31,7 @@ export const ChangePasswordSchema = typeboxRouteSchema({
 
     400: Type.Object({
       code: Type.Literal("PASSWORD_NOT_VALID"),
-      message: Type.Union([Type.String(), Type.Undefined()]),
+      message: Type.Optional(Type.String()),
     }),
 
     /** 用户未找到 */

--- a/apps/mis-web/src/pages/api/tenant/create.ts
+++ b/apps/mis-web/src/pages/api/tenant/create.ts
@@ -43,7 +43,7 @@ export const CreateTenantSchema = typeboxRouteSchema({
         Type.Literal("PASSWORD_NOT_VALID"),
         Type.Literal("USERID_NOT_VALID"),
       ]),
-      message: Type.Union([Type.String(), Type.Undefined()]),
+      message: Type.Optional(Type.String()),
     }),
 
     /** 租户已经存在 */

--- a/apps/mis-web/src/pages/api/users/create.ts
+++ b/apps/mis-web/src/pages/api/users/create.ts
@@ -49,7 +49,7 @@ export const CreateUserSchema = typeboxRouteSchema({
         Type.Literal("PASSWORD_NOT_VALID"),
         Type.Literal("USERID_NOT_VALID"),
       ]),
-      message: Type.Union([Type.String(), Type.Undefined()]),
+      message: Type.Optional(Type.String()),
     }),
 
     /** 用户已经存在 */


### PR DESCRIPTION
## 问题

![image](https://github.com/PKUHPC/SCOW/assets/130351655/c2570d8b-0bda-4f3b-8c21-f5beeb4ce31e)

![image](https://github.com/PKUHPC/SCOW/assets/130351655/25297cd6-7c22-4691-b41a-2eba6ab42992)


## 改动
mis-web处的创建用户，修改密码以及创建租户处的schema
```typescript
Type.Union([Type.String(), Type.Undefined()])
```
修改为
```typescript
Type.Optional(Type.String())
```