### PR TITLE
fix(mis-server): 修复调用适配器 getJobById 时，循环 jobIdList 获取 jobId 问题

### DIFF
--- a/.changeset/ten-islands-tickle.md
+++ b/.changeset/ten-islands-tickle.md
@@ -1,0 +1,5 @@
+---
+"@scow/mis-server": patch
+---
+
+修复调用适配器 getJobById 时，循环 jobIdList 获取 jobId 问题

--- a/apps/mis-server/src/services/job.ts
+++ b/apps/mis-server/src/services/job.ts
@@ -237,8 +237,12 @@ export const jobServiceServer = plugin((server) => {
           ];
           if (jobIdList.length > 0) {
             const jobInfoList: AdapterJobInfo[] = [];
-            for (const jobId in jobIdList) {
-              const jobInfo = await asyncClientCall(client.job, "getJobById", { fields, jobId: Number(jobId) });
+            for (const jobId of jobIdList) {
+              const jobInfo = await asyncClientCall(client.job, "getJobById", { fields, jobId: Number(jobId) })
+                .catch((e) => {
+                  logger.info("GetJobById with JobId: %s failed", jobId, e);
+                  return { job: undefined };
+                });
               if (jobInfo.job) jobInfoList.push(jobInfo.job);
             }
             return jobInfoList;


### PR DESCRIPTION
## 现状
修改作业时限时，如果用户不是平台管理员，会查询单个作业信息，此时由于mis-server对jobIdList的遍历存在问题，会导致获取不到job信息报错

## 改动
1. 将```for in``` 改为```for of``` 遍历jobIdList
2. 每次遍历时捕获错误，使得正确的job信息可以得到返回。