### PR TITLE
fix(mis-web): 修复unsetInitAdmin和setAsInitAdmin文件名错误

### DIFF
--- a/.changeset/plenty-pianos-play.md
+++ b/.changeset/plenty-pianos-play.md
@@ -1,0 +1,5 @@
+---
+"@scow/mis-web": patch
+---
+
+修复 setAsInitAdmin.ts 和 unsetInitAdmin.ts 文件命名错误

--- a/apps/mis-web/src/apis/api.ts
+++ b/apps/mis-web/src/apis/api.ts
@@ -46,8 +46,8 @@ import type { CompleteInitSchema } from "src/pages/api/init/completeInit";
 import type { CreateInitAdminSchema } from "src/pages/api/init/createInitAdmin";
 import type { InitGetAccountsSchema } from "src/pages/api/init/getAccounts";
 import type { InitGetUsersSchema } from "src/pages/api/init/getUsers";
-import type { UnsetInitAdminSchema } from "src/pages/api/init/setAsInitAdmin";
-import type { SetAsInitAdminSchema } from "src/pages/api/init/setAsInitAdmin copy";
+import type { SetAsInitAdminSchema } from "src/pages/api/init/setAsInitAdmin";
+import type { UnsetInitAdminSchema } from "src/pages/api/init/unsetInitAdmin";
 import type { UserExistsSchema } from "src/pages/api/init/userExists";
 import type { AddBillingItemSchema } from "src/pages/api/job/addBillingItem";
 import type { ChangeJobTimeLimitSchema } from "src/pages/api/job/changeJobTimeLimit";
@@ -60,7 +60,7 @@ import type { QueryJobTimeLimitSchema } from "src/pages/api/job/queryJobTimeLimi
 import type { GetRunningJobsSchema } from "src/pages/api/job/runningJobs";
 import type { ChangeEmailSchema } from "src/pages/api/profile/changeEmail";
 import type { ChangePasswordSchema } from "src/pages/api/profile/changePassword";
-import checkPassword, { CheckPasswordSchema } from "src/pages/api/profile/checkPassword";
+import { CheckPasswordSchema } from "src/pages/api/profile/checkPassword";
 import type { DewhitelistAccountSchema } from "src/pages/api/tenant/accountWhitelist/dewhitelistAccount";
 import type { GetWhitelistedAccountsSchema } from "src/pages/api/tenant/accountWhitelist/getWhitelistedAccounts";
 import type { WhitelistAccountSchema } from "src/pages/api/tenant/accountWhitelist/whitelistAccount";
@@ -116,8 +116,8 @@ export const api = {
   createInitAdmin: apiClient.fromTypeboxRoute<typeof CreateInitAdminSchema>("POST", "/api/init/createInitAdmin"),
   initGetAccounts: apiClient.fromTypeboxRoute<typeof InitGetAccountsSchema>("GET", "/api/init/getAccounts"),
   initGetUsers: apiClient.fromTypeboxRoute<typeof InitGetUsersSchema>("GET", "/api/init/getUsers"),
-  setAsInitAdmin: apiClient.fromTypeboxRoute<typeof SetAsInitAdminSchema>("PATCH", "/api/init/setAsInitAdmin copy"),
-  unsetInitAdmin: apiClient.fromTypeboxRoute<typeof UnsetInitAdminSchema>("DELETE", "/api/init/setAsInitAdmin"),
+  setAsInitAdmin: apiClient.fromTypeboxRoute<typeof SetAsInitAdminSchema>("PATCH", "/api/init/setAsInitAdmin"),
+  unsetInitAdmin: apiClient.fromTypeboxRoute<typeof UnsetInitAdminSchema>("DELETE", "/api/init/unsetInitAdmin"),
   userExists: apiClient.fromTypeboxRoute<typeof UserExistsSchema>("POST", "/api/init/userExists"),
   addBillingItem: apiClient.fromTypeboxRoute<typeof AddBillingItemSchema>("POST", "/api/job/addBillingItem"),
   changeJobTimeLimit: apiClient.fromTypeboxRoute<typeof ChangeJobTimeLimitSchema>("PATCH", "/api/job/changeJobTimeLimit"),

--- a/apps/mis-web/src/pages/api/init/setAsInitAdmin.ts
+++ b/apps/mis-web/src/pages/api/init/setAsInitAdmin.ts
@@ -17,10 +17,10 @@ import { Type } from "@sinclair/typebox";
 import { getClient } from "src/utils/client";
 import { queryIfInitialized } from "src/utils/init";
 
-export const UnsetInitAdminSchema = typeboxRouteSchema({
-  method: "DELETE",
+export const SetAsInitAdminSchema = typeboxRouteSchema({
+  method: "PATCH",
 
-  query: Type.Object({
+  body: Type.Object({
     userId: Type.String(),
   }),
 
@@ -32,16 +32,16 @@ export const UnsetInitAdminSchema = typeboxRouteSchema({
   },
 });
 
-export default typeboxRoute(UnsetInitAdminSchema, async (req) => {
+export default typeboxRoute(SetAsInitAdminSchema, async (req) => {
   const result = await queryIfInitialized();
 
   if (result) { return { 409: { code: "ALREADY_INITIALIZED" as const } }; }
 
-  const { userId } = req.query;
+  const { userId } = req.body;
 
   const client = getClient(InitServiceClient);
 
-  await asyncClientCall(client, "unsetInitAdmin", {
+  await asyncClientCall(client, "setAsInitAdmin", {
     userId,
   });
 

--- a/apps/mis-web/src/pages/api/init/unsetInitAdmin.ts
+++ b/apps/mis-web/src/pages/api/init/unsetInitAdmin.ts
@@ -17,10 +17,10 @@ import { Type } from "@sinclair/typebox";
 import { getClient } from "src/utils/client";
 import { queryIfInitialized } from "src/utils/init";
 
-export const SetAsInitAdminSchema = typeboxRouteSchema({
-  method: "PATCH",
+export const UnsetInitAdminSchema = typeboxRouteSchema({
+  method: "DELETE",
 
-  body: Type.Object({
+  query: Type.Object({
     userId: Type.String(),
   }),
 
@@ -32,16 +32,16 @@ export const SetAsInitAdminSchema = typeboxRouteSchema({
   },
 });
 
-export default typeboxRoute(SetAsInitAdminSchema, async (req) => {
+export default typeboxRoute(UnsetInitAdminSchema, async (req) => {
   const result = await queryIfInitialized();
 
   if (result) { return { 409: { code: "ALREADY_INITIALIZED" as const } }; }
 
-  const { userId } = req.body;
+  const { userId } = req.query;
 
   const client = getClient(InitServiceClient);
 
-  await asyncClientCall(client, "setAsInitAdmin", {
+  await asyncClientCall(client, "unsetInitAdmin", {
     userId,
   });
 


### PR DESCRIPTION
## 现状

文件命名错误:
setAsInitAdmin copy.ts 和 setAsInitAdmin.ts(应为unsetInitAdmin)

## 改动

![image](https://github.com/PKUHPC/SCOW/assets/130351655/11894df6-1866-4db0-a44e-3f6ba2127b53)
