### PR TITLE
fix(portal-web): 修复 localStorage 设置了默认集群但默认集群在 scow 上不存在导致网站无法加载的问题

### DIFF
--- a/.changeset/tiny-chicken-cheat.md
+++ b/.changeset/tiny-chicken-cheat.md
@@ -1,0 +1,5 @@
+---
+"@scow/portal-web": patch
+---
+
+修复 storage 设置了默认集群但默认集群在 scow 上不存在导致网站无法加载的问题

--- a/apps/portal-web/src/stores/DefaultClusterStore.ts
+++ b/apps/portal-web/src/stores/DefaultClusterStore.ts
@@ -23,7 +23,8 @@ export function DefaultClusterStore() {
     publicConfig.CLUSTERS[0].id,
   );
 
-  const defaultCluster = publicConfig.CLUSTERS.find((cluster) => cluster.id === clusterId) || {} as Cluster;
+  const defaultCluster = publicConfig.CLUSTERS.find((cluster) => cluster.id === clusterId)
+    || publicConfig.CLUSTERS[0] as Cluster;
 
   const setDefaultCluster = (cluster: Cluster) => {
     setClusterId(cluster.id);


### PR DESCRIPTION
问题复现：先通过操作作业或者交互式应用，scow将在浏览器中存储默认集群的id，修改集群配置文件名字，重启服务后，发现重新登录scow会无法正确渲染，需清除浏览器缓存后才能渲染。系统取集群的id通过join拼接路径，join的Path不能为空。
解决：给默认集群加一个默认值，设为第一个集群