### PR TITLE
fix(web): 退出登录或登陆过期时跳转页面修改

### DIFF
--- a/.changeset/ninety-planets-pretend.md
+++ b/.changeset/ninety-planets-pretend.md
@@ -1,0 +1,6 @@
+---
+"@scow/portal-web": patch
+"@scow/mis-web": patch
+---
+
+之前：退出登录或登陆过期时跳转到需要登录页面，现在：直接跳转到登录页面

--- a/apps/mis-web/src/auth/requireAuth.tsx
+++ b/apps/mis-web/src/auth/requireAuth.tsx
@@ -13,7 +13,7 @@
 import React from "react";
 import { useStore } from "simstate";
 import { ForbiddenPage } from "src/components/errorPages/ForbiddenPage";
-import { NotAuthorizedPage } from "src/components/errorPages/NotAuthorizedPage";
+import { Redirect } from "src/components/Redirect";
 import type { UserInfo } from "src/models/User";
 import { User, UserStore } from "src/stores/UserStore";
 
@@ -35,7 +35,7 @@ export const requireAuth = (
     const userStore = useStore(UserStore);
 
     if (!userStore.user) {
-      return <NotAuthorizedPage />;
+      return <Redirect url="/api/auth" />;
     }
 
     if (!check(userStore.user)) {

--- a/apps/mis-web/src/pages/accounts/[accountName]/info.tsx
+++ b/apps/mis-web/src/pages/accounts/[accountName]/info.tsx
@@ -15,10 +15,13 @@ import { queryToString } from "@scow/lib-web/build/utils/querystring";
 import { Descriptions, Tag } from "antd";
 import { GetServerSideProps, NextPage } from "next";
 import { USE_MOCK } from "src/apis/useMock";
+import { requireAuth } from "src/auth/requireAuth";
 import { ssrAuthenticate, SSRProps } from "src/auth/server";
 import { UnifiedErrorPage } from "src/components/errorPages/UnifiedErrorPage";
 import { PageTitle } from "src/components/PageTitle";
 import { UserRole } from "src/models/User";
+import {
+  checkQueryAccountNameIsAdmin } from "src/pageComponents/accounts/checkQueryAccountNameIsAdmin";
 import { getAccounts } from "src/pages/api/tenant/getAccounts";
 import { Head } from "src/utils/head";
 
@@ -30,7 +33,10 @@ type Props = SSRProps<{
   blocked: boolean;
 }, 404>
 
-export const AccountInfoPage: NextPage<Props> = (props) => {
+export const AccountInfoPage: NextPage<Props> = requireAuth(
+  (u) => u.accountAffiliations.length > 0,
+  checkQueryAccountNameIsAdmin,
+)((props: Props) => {
 
   if ("error" in props) {
     return <UnifiedErrorPage code={props.error} />;
@@ -59,7 +65,8 @@ export const AccountInfoPage: NextPage<Props> = (props) => {
       </Descriptions>
     </div>
   );
-};
+});
+
 
 export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
 

--- a/apps/mis-web/src/pages/admin/info.tsx
+++ b/apps/mis-web/src/pages/admin/info.tsx
@@ -16,6 +16,7 @@ import { AdminServiceClient } from "@scow/protos/build/server/admin";
 import { Descriptions, Tag } from "antd";
 import { GetServerSideProps, NextPage } from "next";
 import { USE_MOCK } from "src/apis/useMock";
+import { requireAuth } from "src/auth/requireAuth";
 import { ssrAuthenticate, SSRProps } from "src/auth/server";
 import { UnifiedErrorPage } from "src/components/errorPages/UnifiedErrorPage";
 import { PageTitle } from "src/components/PageTitle";
@@ -27,7 +28,9 @@ type Info = GetAdminInfoResponse
 
 type Props = SSRProps<Info, 500>
 
-export const PlatformInfoPage: NextPage<Props> = (props) => {
+export const PlatformInfoPage: NextPage<Props> = 
+requireAuth((u) => u.platformRoles.includes(PlatformRole.PLATFORM_ADMIN))
+((props: Props) => {
 
   if ("error" in props) {
     return <UnifiedErrorPage code={props.error} />;
@@ -71,7 +74,7 @@ export const PlatformInfoPage: NextPage<Props> = (props) => {
       </Descriptions>
     </div>
   );
-};
+});
 
 export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
   const auth = ssrAuthenticate(

--- a/apps/mis-web/src/pages/tenant/info.tsx
+++ b/apps/mis-web/src/pages/tenant/info.tsx
@@ -18,6 +18,7 @@ import { TenantServiceClient } from "@scow/protos/build/server/tenant";
 import { Descriptions, Tag } from "antd";
 import { GetServerSideProps, NextPage } from "next";
 import { USE_MOCK } from "src/apis/useMock";
+import { requireAuth } from "src/auth/requireAuth";
 import { ssrAuthenticate, SSRProps } from "src/auth/server";
 import { UnifiedErrorPage } from "src/components/errorPages/UnifiedErrorPage";
 import { PageTitle } from "src/components/PageTitle";
@@ -31,7 +32,8 @@ type Info = GetTenantInfoResponse & { tenantName: string };
 
 type Props = SSRProps<Info, 404>
 
-export const TenantInfoPage: NextPage<Props> = (props) => {
+export const TenantInfoPage: NextPage<Props> = requireAuth((u) => u.tenantRoles.includes(TenantRole.TENANT_ADMIN))
+((props: Props) => {
 
   if ("error" in props) {
     return <UnifiedErrorPage code={props.error} />;
@@ -78,7 +80,7 @@ export const TenantInfoPage: NextPage<Props> = (props) => {
       </Descriptions>
     </div>
   );
-};
+});
 
 export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
 

--- a/apps/portal-web/src/auth/requireAuth.tsx
+++ b/apps/portal-web/src/auth/requireAuth.tsx
@@ -13,9 +13,9 @@
 import React from "react";
 import { useStore } from "simstate";
 import { ForbiddenPage } from "src/components/errorPages/ForbiddenPage";
-import { NotAuthorizedPage } from "src/components/errorPages/NotAuthorizedPage";
+import { Redirect } from "src/components/Redirect";
 import type { UserInfo } from "src/models/User";
-import { User, UserStore } from "src/stores/UserStore";
+import { User, UserStore } from "src/stores/UserStore"; ;
 
 type UserStoreType = ReturnType<typeof UserStore>;
 
@@ -35,7 +35,7 @@ export const requireAuth = (
     const userStore = useStore(UserStore);
 
     if (!userStore.user) {
-      return <NotAuthorizedPage />;
+      return <Redirect url="/api/auth" />;
     }
 
     if (!check(userStore.user)) {

--- a/apps/portal-web/src/pages/desktop/index.tsx
+++ b/apps/portal-web/src/pages/desktop/index.tsx
@@ -11,17 +11,18 @@
  */
 
 import { GetServerSideProps, NextPage } from "next";
+import { requireAuth } from "src/auth/requireAuth";
 import { NotFoundPage } from "src/components/errorPages/NotFoundPage";
 import { PageTitle } from "src/components/PageTitle";
 import { DesktopTable } from "src/pageComponents/desktop/DesktopTable";
 import { Cluster, getLoginDesktopEnabled, publicConfig, runtimeConfig } from "src/utils/config";
 import { Head } from "src/utils/head";
-
 type Props = {
   loginDesktopEnabledClusters: Cluster[];
 };
 
-export const DesktopIndexPage: NextPage<Props> = (props: Props) => {
+export const DesktopIndexPage: NextPage<Props> = requireAuth(() => true)
+((props: Props) => {
 
   if (!publicConfig.ENABLE_LOGIN_DESKTOP) {
     return <NotFoundPage />;
@@ -34,7 +35,7 @@ export const DesktopIndexPage: NextPage<Props> = (props: Props) => {
       <DesktopTable loginDesktopEnabledClusters={props.loginDesktopEnabledClusters} />
     </div>
   );
-};
+});
 
 
 export const getServerSideProps: GetServerSideProps<Props> = async () => {


### PR DESCRIPTION
## 1. 之前：用户退出登录或者登录过期时，跳转“需要登陆”页面
![image](https://github.com/PKUHPC/SCOW/assets/74037789/ae97568c-84a9-4731-a386-a3cdd36fddef)
## 现在直接跳转登陆页面：
![image](https://github.com/PKUHPC/SCOW/assets/74037789/13cd9e18-7f15-4282-89f4-3b7c088e083b)
## 2.之前：管理系统中，当处于账户信息、租户信息或者平台信息页面以及门户的桌面页面退出登录时，仍然停留在原页面
![image](https://github.com/PKUHPC/SCOW/assets/74037789/3403df79-1d9b-40b5-8fe8-0fa1ea195a7f)
## 现在直接跳转登陆页面