### PR TITLE
feat(mis): 修改作业时限优化，将增加减少时限改为直接设置作业时限，并且检查是否大于作业的运行时间

### DIFF
--- a/.changeset/pretty-dancers-hunt.md
+++ b/.changeset/pretty-dancers-hunt.md
@@ -1,0 +1,8 @@
+---
+"@scow/mis-server": patch
+"@scow/portal-web": patch
+"@scow/mis-web": patch
+"@scow/lib-web": patch
+---
+
+修改作业时限优化，将增加减少时限改为直接设置作业时限，并且检查是否大于作业的运行时间

--- a/.changeset/rich-hotels-boil.md
+++ b/.changeset/rich-hotels-boil.md
@@ -1,0 +1,5 @@
+---
+"@scow/grpc-api": minor
+---
+
+ChangeJobTimeLimitRequest 的传参由传差值 delta 改为传作业时限 limit

--- a/apps/mis-server/src/services/job.ts
+++ b/apps/mis-server/src/services/job.ts
@@ -260,13 +260,13 @@ export const jobServiceServer = plugin((server) => {
     },
 
     changeJobTimeLimit: async ({ request, logger }) => {
-      const { cluster, delta, jobId } = request;
+      const { cluster, limit, jobId } = request;
 
       await server.ext.clusters.callOnOne(
         cluster,
         logger,
         async (client) => await asyncClientCall(client.job, "changeJobTimeLimit", {
-          jobId: Number(jobId), deltaMinutes: delta,
+          jobId: Number(jobId), deltaMinutes: limit,
         }),
       );
 

--- a/apps/mis-server/src/services/job.ts
+++ b/apps/mis-server/src/services/job.ts
@@ -265,9 +265,12 @@ export const jobServiceServer = plugin((server) => {
       await server.ext.clusters.callOnOne(
         cluster,
         logger,
-        async (client) => await asyncClientCall(client.job, "changeJobTimeLimit", {
-          jobId: Number(jobId), deltaMinutes: limit,
-        }),
+        async (client) => {
+          const { timeLimitMinutes } = await asyncClientCall(client.job, "queryJobTimeLimit", { jobId: Number(jobId) });
+          await asyncClientCall(client.job, "changeJobTimeLimit", {
+            jobId: Number(jobId), deltaMinutes: limit - timeLimitMinutes,
+          });
+        },
       );
 
       return [{}];

--- a/apps/mis-server/src/services/job.ts
+++ b/apps/mis-server/src/services/job.ts
@@ -260,7 +260,7 @@ export const jobServiceServer = plugin((server) => {
     },
 
     changeJobTimeLimit: async ({ request, logger }) => {
-      const { cluster, limit, jobId } = request;
+      const { cluster, limitMinutes, jobId } = request;
 
       await server.ext.clusters.callOnOne(
         cluster,
@@ -268,7 +268,7 @@ export const jobServiceServer = plugin((server) => {
         async (client) => {
           const { timeLimitMinutes } = await asyncClientCall(client.job, "queryJobTimeLimit", { jobId: Number(jobId) });
           await asyncClientCall(client.job, "changeJobTimeLimit", {
-            jobId: Number(jobId), deltaMinutes: limit - timeLimitMinutes,
+            jobId: Number(jobId), deltaMinutes: limitMinutes - timeLimitMinutes,
           });
         },
       );

--- a/apps/mis-web/src/pageComponents/job/ChangeJobTimeLimitModal.tsx
+++ b/apps/mis-web/src/pageComponents/job/ChangeJobTimeLimitModal.tsx
@@ -26,7 +26,7 @@ interface Props {
 }
 
 interface FormProps {
-  limit: number;
+  limitMinutes: number;
 }
 
 interface CompletionStatus {
@@ -67,13 +67,13 @@ export const ChangeJobTimeLimitModal: React.FC<Props> = ({ open, onClose, data, 
       confirmLoading={loading}
       destroyOnClose
       onOk={async () => {
-        const { limit } = await form.validateFields();
+        const { limitMinutes } = await form.validateFields();
         setLoading(true);
 
         completionStatus.current = { total: data.length, success: 0, failed: []};
 
         await Promise.all(data.map(async (r) => {
-          await api.changeJobTimeLimit({ body: { cluster: r.cluster.id, limit, jobId: r.jobId } })
+          await api.changeJobTimeLimit({ body: { cluster: r.cluster.id, limitMinutes, jobId: r.jobId } })
             .httpError(400, (e) => {
               if (e.code === "TIME_LIME_NOT_VALID") {
                 message.error(e.message);
@@ -106,7 +106,7 @@ export const ChangeJobTimeLimitModal: React.FC<Props> = ({ open, onClose, data, 
 
       }}
     >
-      <Form form={form} initialValues={{ limit: 1 }}>
+      <Form form={form} initialValues={{ limitMinutes: 1 }}>
         {
           Array.from(dataGroupedByCluster.entries()).map(([cluster, data]) => (
             <>
@@ -121,7 +121,7 @@ export const ChangeJobTimeLimitModal: React.FC<Props> = ({ open, onClose, data, 
           ))
         }
         <Form.Item<FormProps> label="设置作业时限" rules={[{ required: true }]}>
-          <Form.Item name="limit" noStyle>
+          <Form.Item name="limitMinutes" noStyle>
             <InputNumber min={1} step={1} addonAfter={"分钟"} />
           </Form.Item>
         </Form.Item>

--- a/apps/mis-web/src/pageComponents/job/ChangeJobTimeLimitModal.tsx
+++ b/apps/mis-web/src/pageComponents/job/ChangeJobTimeLimitModal.tsx
@@ -74,6 +74,12 @@ export const ChangeJobTimeLimitModal: React.FC<Props> = ({ open, onClose, data, 
 
         await Promise.all(data.map(async (r) => {
           await api.changeJobTimeLimit({ body: { cluster: r.cluster.id, limit, jobId: r.jobId } })
+            .httpError(400, (e) => {
+              if (e.code === "TIME_LIME_NOT_VALID") {
+                message.error(e.message);
+              };
+              throw e;
+            })
             .then(() => {
               if (completionStatus.current) {
                 completionStatus.current.success++;

--- a/apps/mis-web/src/pages/api/job/changeJobTimeLimit.ts
+++ b/apps/mis-web/src/pages/api/job/changeJobTimeLimit.ts
@@ -38,7 +38,7 @@ export const ChangeJobTimeLimitSchema = typeboxRouteSchema({
      * 新的作业运行时限
      * @type integer
      */
-    limit: Type.Integer(),
+    limitMinutes: Type.Integer(),
   }),
 
   responses: {
@@ -61,13 +61,13 @@ export default typeboxRoute(ChangeJobTimeLimitSchema,
     const info = await auth(req, res);
     if (!info) { return; }
 
-    const { cluster, limit, jobId } = req.body;
+    const { cluster, limitMinutes, jobId } = req.body;
 
     const client = getClient(JobServiceClient);
 
     // check if the user can change the job time limit
 
-    const jobAccessible = await checkJobAccessible(jobId, cluster, info, limit);
+    const jobAccessible = await checkJobAccessible(jobId, cluster, info, limitMinutes);
 
     if (jobAccessible === "NotAllowed") {
       return { 403: null };
@@ -84,7 +84,7 @@ export default typeboxRoute(ChangeJobTimeLimitSchema,
 
     return await asyncClientCall(client, "changeJobTimeLimit", {
       cluster,
-      limit,
+      limitMinutes,
       jobId,
     })
       .then(() => ({ 204: null }))

--- a/apps/mis-web/src/pages/api/job/changeJobTimeLimit.ts
+++ b/apps/mis-web/src/pages/api/job/changeJobTimeLimit.ts
@@ -48,7 +48,9 @@ export const ChangeJobTimeLimitSchema = typeboxRouteSchema({
     /** 作业未找到 */
     404: Type.Null(),
     /** 用户设置的时限错误 */
-    400: Type.Object({ code: Type.Literal("TIME_LIME_NOT_VALID") }),
+    400: Type.Object({ code: Type.Literal("TIME_LIME_NOT_VALID"),
+      message: Type.String(),
+    }),
   },
 });
 
@@ -75,11 +77,11 @@ export default typeboxRoute(ChangeJobTimeLimitSchema,
       return {
         400: {
           code: "TIME_LIME_NOT_VALID" as const,
-          message: "time limit should be longer than job's running time.",
+          message: "设置作业时限需要大于该作业的运行时长",
         },
       };
     }
-    
+
     return await asyncClientCall(client, "changeJobTimeLimit", {
       cluster,
       limit,

--- a/apps/mis-web/src/pages/api/job/changeJobTimeLimit.ts
+++ b/apps/mis-web/src/pages/api/job/changeJobTimeLimit.ts
@@ -77,7 +77,7 @@ export default typeboxRoute(ChangeJobTimeLimitSchema,
       return {
         400: {
           code: "TIME_LIME_NOT_VALID" as const,
-          message: "设置作业时限需要大于该作业的运行时长",
+          message: "设置作业时限需要大于该作业的运行时长。",
         },
       };
     }

--- a/apps/mis-web/src/server/jobAccessible.ts
+++ b/apps/mis-web/src/server/jobAccessible.ts
@@ -37,7 +37,7 @@ export async function checkJobAccessible(
 
   const job = reply.jobs[0];
 
-  // 如果设置的作业时限比该作业运行时间小， 则改作业不可以修改作业时限
+  // 如果设置的作业时限比该作业运行时间小， 则该作业不可以修改作业时限
   if (!!limit && (limit) * 60 * 1000 < parseTime(job.runningTime)) {
     return "LimitNotValid";
   }

--- a/apps/mis-web/src/server/jobAccessible.ts
+++ b/apps/mis-web/src/server/jobAccessible.ts
@@ -11,52 +11,62 @@
  */
 
 import { asyncClientCall } from "@ddadaal/tsgrpc-client";
+import { parseTime } from "@scow/lib-web/build/utils/datetime";
 import { AccountServiceClient } from "@scow/protos/build/server/account";
 import { JobServiceClient } from "@scow/protos/build/server/job";
 import { PlatformRole, TenantRole, UserInfo, UserRole } from "src/models/User";
 import { getClient } from "src/utils/client";
 
-type Result = "OK" | "NotFound" | "NotAllowed";
+type Result = "OK" | "NotFound" | "NotAllowed" | "LimitNotValid";
 
-export async function checkJobAccessible(jobId: string, cluster: string, info: UserInfo): Promise<Result> {
+export async function checkJobAccessible(
+  jobId: string, cluster: string, info: UserInfo, limit?: number,
+): Promise<Result> {
 
   const client = getClient(JobServiceClient);
 
+
+  const reply = await asyncClientCall(client, "getRunningJobs", {
+    cluster,
+    jobIdList: [jobId],
+  });
+
+  if (reply.jobs.length === 0) {
+    return "NotFound";
+  }
+
+  const job = reply.jobs[0];
+
+  // 如果设置的作业时限比该作业运行时间小， 则改作业不可以修改作业时限
+  if (!!limit && (limit) * 60 * 1000 < parseTime(job.runningTime)) {
+    return "LimitNotValid";
+  }
+
   if (info.platformRoles.includes(PlatformRole.PLATFORM_ADMIN)) {
     return "OK";
-  } else {
-    const reply = await asyncClientCall(client, "getRunningJobs", {
-      cluster,
-      jobIdList: [jobId],
+  }
+
+  // 用户发起了这个作业
+  if (job.user === info.identityId) {
+    return "OK";
+  }
+
+  // 用户是这个作业的账户的管理员或者拥有者
+  if (info.accountAffiliations.some((x) => x.accountName === job.account && x.role !== UserRole.USER)) {
+    return "OK";
+  }
+
+  // 如果用户是租户的管理员，而且这个作业的账户属于这个租户
+  if (info.tenantRoles.includes(TenantRole.TENANT_ADMIN)) {
+    const { results } = await asyncClientCall(getClient(AccountServiceClient), "getAccounts", {
+      accountName: job.account,
+      tenantName: info.tenant,
     });
 
-    if (reply.jobs.length === 0) {
-      return "NotFound";
-    }
-
-    const job = reply.jobs[0];
-
-    // 用户发起了这个作业
-    if (job.user === info.identityId) {
-      return "OK";
-    }
-
-    // 用户是这个作业的账户的管理员或者拥有者
-    if (info.accountAffiliations.some((x) => x.accountName === job.account && x.role !== UserRole.USER)) {
-      return "OK";
-    }
-
-    // 如果用户是租户的管理员，而且这个作业的账户属于这个租户
-    if (info.tenantRoles.includes(TenantRole.TENANT_ADMIN)) {
-      const { results } = await asyncClientCall(getClient(AccountServiceClient), "getAccounts", {
-        accountName: job.account,
-        tenantName: info.tenant,
-      });
-
-      return results.length !== 0 ? "OK" : "NotAllowed";
-    }
-
-    return "NotAllowed";
+    return results.length !== 0 ? "OK" : "NotAllowed";
   }
+
+  return "NotAllowed";
+
 
 }

--- a/apps/mis-web/src/server/jobAccessible.ts
+++ b/apps/mis-web/src/server/jobAccessible.ts
@@ -20,7 +20,7 @@ import { getClient } from "src/utils/client";
 type Result = "OK" | "NotFound" | "NotAllowed" | "LimitNotValid";
 
 export async function checkJobAccessible(
-  jobId: string, cluster: string, info: UserInfo, limit?: number,
+  jobId: string, cluster: string, info: UserInfo, limitMinutes?: number,
 ): Promise<Result> {
 
   const client = getClient(JobServiceClient);
@@ -38,7 +38,7 @@ export async function checkJobAccessible(
   const job = reply.jobs[0];
 
   // 如果设置的作业时限比该作业运行时间小， 则该作业不可以修改作业时限
-  if (!!limit && (limit) * 60 * 1000 < parseTime(job.runningTime)) {
+  if (!!limitMinutes && (limitMinutes) * 60 * 1000 < parseTime(job.runningTime)) {
     return "LimitNotValid";
   }
 

--- a/apps/portal-web/src/models/job.ts
+++ b/apps/portal-web/src/models/job.ts
@@ -10,6 +10,7 @@
  * See the Mulan PSL v2 for more details.
  */
 
+import { parseTime } from "@scow/lib-web/build/utils/datetime";
 import type { RunningJob } from "@scow/protos/build/common/job";
 import dayjs from "dayjs";
 import type { Cluster } from "src/utils/config";
@@ -77,19 +78,6 @@ export function formatTime(milliseconds: number) {
   text += pad(secModulo);
 
   return text;
-}
-
-// Parse the given string in [{days}-][{Hours}:]{MM}:{SS} format and return number of milliseconds
-export function parseTime(time: string) {
-  const list = time.split(/[:-]/).map((x) => +x);
-
-  const seconds = list.at(-1);
-  const minutes = list.at(-2);
-  const hours = list.at(-3) ?? 0;
-  const days = list.at(-4) ?? 0;
-
-  return seconds! * 1000 + minutes! * 60000 + (hours * 3600000) + days * 86400000;
-
 }
 
 

--- a/libs/web/src/utils/datetime.ts
+++ b/libs/web/src/utils/datetime.ts
@@ -41,3 +41,16 @@ export function compareDateTime(a: string, b: string): number {
   return 1;
 
 }
+
+// Parse the given string in [{days}-][{Hours}:]{MM}:{SS} format and return number of milliseconds
+export function parseTime(time: string) {
+  const list = time.split(/[:-]/).map((x) => +x);
+
+  const seconds = list.at(-1);
+  const minutes = list.at(-2);
+  const hours = list.at(-3) ?? 0;
+  const days = list.at(-4) ?? 0;
+
+  return seconds! * 1000 + minutes! * 60000 + (hours * 3600000) + days * 86400000;
+
+}

--- a/protos/server/job.proto
+++ b/protos/server/job.proto
@@ -86,7 +86,7 @@ message GetRunningJobsResponse {
 message ChangeJobTimeLimitRequest {
   string cluster = 1;
   string job_id = 2;
-  int64 delta = 3;
+  int64 limit = 3;
 }
 
 // NOT_FOUND: cluster or job_id is not found.

--- a/protos/server/job.proto
+++ b/protos/server/job.proto
@@ -86,7 +86,7 @@ message GetRunningJobsResponse {
 message ChangeJobTimeLimitRequest {
   string cluster = 1;
   string job_id = 2;
-  int64 limit = 3;
+  int64 limit_minutes = 3;
 }
 
 // NOT_FOUND: cluster or job_id is not found.


### PR DESCRIPTION
## 现状
当前修改作业时限的传参为delta，用户选择是增加或者减少时限
![image](https://github.com/PKUHPC/SCOW/assets/130351655/46414eea-162b-4ba4-894b-ba66f3ca05ba)

且当前未对作业的运行时间和设置的时限做校验，当修改后的时限小于当前作业运行时间时，适配器侧会直接抛出错误将作业终止

## 改动

用户直接输入修改的作业时限

![image](https://github.com/PKUHPC/SCOW/assets/130351655/bcf467a6-c62e-4197-a583-af45fcff8299)

同时mis-web的后端会对当前运行时间和用户设置的作业时限进行比较，当设置的时限未大于当前运行时间时，将会抛出错误，而不是请求适配器侧将作业终止。

请求错误处理如下

![image](https://github.com/PKUHPC/SCOW/assets/130351655/4634b7cd-b642-4b65-aa6f-9abfadbc87dc)

