### PR TITLE
fix(auth): 修复 auth logo 路径不正确的问题

### DIFF
--- a/.changeset/honest-mails-brake.md
+++ b/.changeset/honest-mails-brake.md
@@ -1,0 +1,6 @@
+---
+"@scow/auth": patch
+"@scow/cli": patch
+---
+
+修复 auth logo 在修改系统相对路径后无法显示的问题

--- a/apps/auth/src/auth/loginHtml.ts
+++ b/apps/auth/src/auth/loginHtml.ts
@@ -45,7 +45,8 @@ export async function serveLoginHtml(
       authConfig.ui?.backgroundImagePath ?? "./assets/background.png"),
     backgroundFallbackColor: authConfig.ui?.backgroundFallbackColor || "#8c8c8c",
     faviconUrl: join(config.BASE_PATH, FAVICON_URL),
-    logoUrl: !!authConfig.ui?.logo.customLogoPath === false ? join(config.BASE_PATH, LOGO_URL + logoPreferDarkParam)
+    logoUrl: !!authConfig.ui?.logo.customLogoPath === false ?
+      join(config.PORTAL_BASE_PATH, LOGO_URL + logoPreferDarkParam)
       : join(config.BASE_PATH, config.PUBLIC_PATH, authConfig.ui?.logo.customLogoPath ?? ""),
     logoLink: authConfig.ui?.logo.customLogoLink ?? "",
     callbackUrl,

--- a/apps/auth/src/config/env.ts
+++ b/apps/auth/src/config/env.ts
@@ -31,6 +31,7 @@ export const config = envConfig({
   LOG_PRETTY: bool({ desc: "以可读的方式输出log", default: false }),
 
   BASE_PATH: str({ desc: "整个系统的base path", default: "/" }),
+  PORTAL_BASE_PATH: str({ desc: "门户系统的 base path", default: "/" }),
 
   AUTH_BASE_PATH: str({ desc: "认证系统相对于整个系统的base path", default: "/auth" }),
 

--- a/apps/cli/src/compose/index.ts
+++ b/apps/cli/src/compose/index.ts
@@ -161,11 +161,14 @@ export const createComposeSpec = (config: InstallConfigSchema) => {
       volumes: authVolumes,
     });
   } else {
+    const portalBasePath = join(BASE_PATH, PORTAL_PATH);
+
     addService("auth", {
       image: scowImage,
       environment: {
         "SCOW_LAUNCH_APP": "auth",
         "BASE_PATH": BASE_PATH,
+        "PORTAL_BASE_PATH": portalBasePath,
         ...serviceLogEnv,
       },
       ports: config.auth.portMappings?.auth ? { [config.auth.portMappings?.auth]: 5000 } : {},


### PR DESCRIPTION
# 问题
之前 auth 登录界面的 logo 加载的路径是 BASE_PATH + LOGO_URL，但实际上 logo 的请求是发送到了 portal web 中。所以正确的路径应该是 PORTAL_BASE_PATH + LOGO_URL

# 修复方式
为 auth 添加环境变量 PORTAL_BASE_PATH，然后在加载 logo 的 url 修改为 PORTAL_BASE_PATH + LOGO_URL

由于增加了 auth 的环境变量，所以需要更新 cli 更新方式：https://pkuhpc.github.io/SCOW/docs/deploy/install/scow-cli