### PR TITLE
fix(web): 用户、账户、作业显示方式和名称统一

### DIFF
--- a/.changeset/six-worms-repair.md
+++ b/.changeset/six-worms-repair.md
@@ -1,0 +1,7 @@
+---
+"@scow/mis-server": patch
+"@scow/portal-web": patch
+"@scow/mis-web": patch
+---
+
+用户、账户、作业称呼统一

--- a/apps/mis-server/src/services/account.ts
+++ b/apps/mis-server/src/services/account.ts
@@ -225,7 +225,7 @@ export const accountServiceServer = plugin((server) => {
             comment: x.comment,
             operatorId: x.operatorId,
             addTime: x.time.toISOString(),
-            ownerId: accountOwner.id + "",
+            ownerId: accountOwner.userId + "",
             ownerName: accountOwner.name,
             balance: decimalToMoney(x.account.$.balance),
           };

--- a/apps/mis-server/tests/admin/whitelist.test.ts
+++ b/apps/mis-server/tests/admin/whitelist.test.ts
@@ -177,7 +177,7 @@ it("get whitelisted accounts", async () => {
   expect(resp.accounts).toIncludeSameMembers([
     {
       "accountName": "hpca",
-      "ownerId": "1",
+      "ownerId": "a",
       "ownerName": "AName",
       "operatorId": "123",
       "comment": "",

--- a/apps/mis-web/src/pageComponents/accounts/AccountTable.tsx
+++ b/apps/mis-web/src/pageComponents/accounts/AccountTable.tsx
@@ -133,7 +133,7 @@ export const AccountTable: React.FC<Props> = ({
         <Table.Column<AdminAccountInfo>
           dataIndex="ownerName"
           title="拥有者"
-          render={(_, r) => `${r.ownerName}（${r.ownerId}）`}
+          render={(_, r) => `${r.ownerName}（ID:${r.ownerId}）`}
         />
         <Table.Column<AdminAccountInfo>
           dataIndex="userCount"

--- a/apps/mis-web/src/pageComponents/accounts/AccountTable.tsx
+++ b/apps/mis-web/src/pageComponents/accounts/AccountTable.tsx
@@ -133,7 +133,7 @@ export const AccountTable: React.FC<Props> = ({
         <Table.Column<AdminAccountInfo>
           dataIndex="ownerName"
           title="拥有者"
-          render={(_, r) => `${r.ownerName}（ID:${r.ownerId}）`}
+          render={(_, r) => `${r.ownerName}（ID: ${r.ownerId}）`}
         />
         <Table.Column<AdminAccountInfo>
           dataIndex="userCount"

--- a/apps/mis-web/src/pageComponents/admin/AllTenantsTable.tsx
+++ b/apps/mis-web/src/pageComponents/admin/AllTenantsTable.tsx
@@ -29,6 +29,7 @@ export const AllTenantsTable: React.FC<Props> = ({ refreshToken }) => {
   const promiseFn = useCallback(async () => {
     return await api.getAllTenants({}); }, []);
   const { data, isLoading, reload } = useAsync({ promiseFn, watch: refreshToken });
+
   return (
     <div>
       <TenantInfoTable

--- a/apps/mis-web/src/pageComponents/admin/AllTenantsTable.tsx
+++ b/apps/mis-web/src/pageComponents/admin/AllTenantsTable.tsx
@@ -53,10 +53,6 @@ const TenantInfoTable: React.FC<TenantInfoTableProps> = ({
 
   const columns: ColumnsType<PlatformTenantsInfo> = [
     {
-      dataIndex: "tenantId",
-      title: "租户ID",
-    },
-    {
       dataIndex: "tenantName",
       title: "租户名称",
     },

--- a/apps/mis-web/src/pageComponents/job/HistoryJobTable.tsx
+++ b/apps/mis-web/src/pageComponents/job/HistoryJobTable.tsx
@@ -171,7 +171,7 @@ export const JobTable: React.FC<Props> = ({
                     <Form.Item label="集群" name="clusters">
                       <ClusterSelector />
                     </Form.Item>
-                    <Form.Item label="集群作业ID" name="jobId">
+                    <Form.Item label="作业ID" name="jobId">
                       <InputNumber style={{ minWidth: "160px" }} min={1} />
                     </Form.Item>
                   </>

--- a/apps/mis-web/src/pageComponents/job/RunningJobTable.tsx
+++ b/apps/mis-web/src/pageComponents/job/RunningJobTable.tsx
@@ -160,7 +160,7 @@ export const RunningJobQueryTable: React.FC<Props> = ({
                     <Form.Item label="集群" name="cluster">
                       <SingleClusterSelector />
                     </Form.Item>
-                    <Form.Item label="集群作业ID" name="jobId">
+                    <Form.Item label="作业ID" name="jobId">
                       <InputNumber style={{ minWidth: "160px" }} min={1} />
                     </Form.Item>
                   </>

--- a/apps/mis-web/src/pageComponents/tenant/AccountWhitelistTable.tsx
+++ b/apps/mis-web/src/pageComponents/tenant/AccountWhitelistTable.tsx
@@ -129,7 +129,7 @@ export const AccountWhitelistTable: React.FC<Props> = ({
           <Table.Column<WhitelistedAccount>
             dataIndex="ownerId"
             title="拥有者"
-            render={(_, r) => `${r.ownerName} (id: ${r.ownerId})`}
+            render={(_, r) => `${r.ownerName} (ID: ${r.ownerId})`}
           />
           <Table.Column<WhitelistedAccount>
             dataIndex="balance"

--- a/apps/portal-web/src/pageComponents/job/AllJobsTable.tsx
+++ b/apps/portal-web/src/pageComponents/job/AllJobsTable.tsx
@@ -110,7 +110,7 @@ export const AllJobQueryTable: React.FC<Props> = ({
               allowClear={false}
             />
           </Form.Item>
-          <Form.Item label="集群作业ID" name="jobId">
+          <Form.Item label="作业ID" name="jobId">
             <InputNumber style={{ minWidth: "160px" }} min={1} />
           </Form.Item>
           <Form.Item>

--- a/apps/portal-web/src/pageComponents/job/RunningJobTable.tsx
+++ b/apps/portal-web/src/pageComponents/job/RunningJobTable.tsx
@@ -84,7 +84,7 @@ export const RunningJobQueryTable: React.FC<Props> = ({
           <Form.Item label="集群" name="cluster">
             <SingleClusterSelector />
           </Form.Item>
-          <Form.Item label="集群作业ID" name="jobId">
+          <Form.Item label="作业ID" name="jobId">
             <InputNumber style={{ minWidth: "160px" }} min={1} />
           </Form.Item>
           <Form.Item>


### PR DESCRIPTION
## 统一展示用户和作业显示方式和名称
## 之前：
![image](https://github.com/PKUHPC/SCOW/assets/74037789/85890ae4-9c03-484a-beea-384a6f6f5a27)
![image](https://github.com/PKUHPC/SCOW/assets/74037789/02d4fb97-e888-4a28-8c32-240c4d8af328)
![image](https://github.com/PKUHPC/SCOW/assets/74037789/f91a8827-e515-4419-ab35-3609cd6d496e)
![image](https://github.com/PKUHPC/SCOW/assets/74037789/42b48615-29b0-4634-bac1-ed320db30cc3)
## 现在：
![image](https://github.com/PKUHPC/SCOW/assets/74037789/c25d985c-0953-4102-899d-2a44c3677720)
![image](https://github.com/PKUHPC/SCOW/assets/74037789/06abe224-1de3-4037-b3e6-8e28f5c71257)
![image](https://github.com/PKUHPC/SCOW/assets/74037789/ad9bc5d1-9450-49b9-a4e1-5f01907c8c38)
![image](https://github.com/PKUHPC/SCOW/assets/74037789/01241037-9004-406f-9a51-b3b8a79af04c)

