### PR TITLE
fix(mis): 限制创建账户时的拥有者仅为当前租户下的用户

### DIFF
--- a/.changeset/seven-gorillas-play.md
+++ b/.changeset/seven-gorillas-play.md
@@ -1,0 +1,6 @@
+---
+"@scow/mis-server": patch
+"@scow/mis-web": patch
+---
+
+限制创建账户时的拥有者仅为当前租户下的用户

--- a/apps/mis-server/src/services/account.ts
+++ b/apps/mis-server/src/services/account.ts
@@ -127,11 +127,11 @@ export const accountServiceServer = plugin((server) => {
 
     createAccount: async ({ request, em, logger }) => {
       const { accountName, tenantName, ownerId, comment } = request;
-      const user = await em.findOne(User, { userId: ownerId });
+      const user = await em.findOne(User, { userId: ownerId, tenant: { name: tenantName } });
 
       if (!user) {
         throw <ServiceError> {
-          code: Status.NOT_FOUND, message: `User ${ownerId} is not found`,
+          code: Status.NOT_FOUND, message: `User ${user} under tenant ${tenantName} does not exist`,
         };
       }
 

--- a/apps/mis-web/src/pages/tenant/accounts/create.tsx
+++ b/apps/mis-web/src/pages/tenant/accounts/create.tsx
@@ -29,8 +29,12 @@ interface FormProps {
   comment?: string;
 }
 
+interface CreateAccountFormProps {
+  tenantName: string;
+}
 
-const CreateAccountForm: React.FC = () => {
+
+const CreateAccountForm: React.FC<CreateAccountFormProps> = ({ tenantName }) => {
 
   const [form] = Form.useForm<FormProps>();
 
@@ -43,7 +47,7 @@ const CreateAccountForm: React.FC = () => {
     setLoading(true);
 
     await api.createAccount({ body: { accountName, ownerId, ownerName, comment } })
-      .httpError(404, () => { message.error(`用户${ownerId}不存在。`); })
+      .httpError(404, () => { message.error(`租户 ${tenantName} 下不存在用户 ${ownerId}。`); })
       .httpError(409, () => { message.error("账户名已经被占用"); })
       .httpError(400, () => { message.error("用户ID和名字不匹配。"); })
       .then(() => {
@@ -105,13 +109,13 @@ const CreateAccountForm: React.FC = () => {
 };
 
 export const CreateAccountPage: NextPage = requireAuth((i) => i.tenantRoles.includes(TenantRole.TENANT_ADMIN))(
-  () => {
+  ({ userStore }) => {
     return (
       <div>
         <Head title="创建账户" />
         <PageTitle titleText="创建账户" />
         <FormLayout>
-          <CreateAccountForm />
+          <CreateAccountForm tenantName={userStore.user.tenant} />
         </FormLayout>
       </div>
     );


### PR DESCRIPTION
1. 限制创建账户的拥有者为当前租户下的用户，并优化提示信息为 租户 xxx 下用户 xxx 不存在
![image](https://github.com/PKUHPC/SCOW/assets/140392039/a15c7feb-d1d0-4b52-af8d-04da5cd1ec72)