### PR TITLE
fix(mis-web): 修复账户添加用户提示语

### DIFF
--- a/.changeset/honest-spies-think.md
+++ b/.changeset/honest-spies-think.md
@@ -1,0 +1,6 @@
+---
+"@scow/mis-server": patch
+"@scow/mis-web": patch
+---
+
+修复账户添加用户提示语

--- a/apps/mis-server/src/services/user.ts
+++ b/apps/mis-server/src/services/user.ts
@@ -144,10 +144,19 @@ export const userServiceServer = plugin((server) => {
         userId, tenant: { name: tenantName },
       });
 
-      if (!account || !user) {
+      if (!user) {
         throw <ServiceError>{
           code: Status.NOT_FOUND,
-          message: `Account ${accountName} or user ${userId}, tenant ${tenantName} is not found.`,
+          message: `User ${userId} or tenant ${tenantName} is not found.`,
+          details:"USER_OR_TENANT_NOT_FOUND",
+        };
+      }
+
+      if (!account) {
+        throw <ServiceError>{
+          code: Status.NOT_FOUND,
+          message: `Account ${accountName} or tenant ${tenantName} is not found.`,
+          details:"ACCOUNT_OR_TENANT_NOT_FOUND",
         };
       }
 

--- a/apps/mis-web/src/pageComponents/users/AddUserButton.tsx
+++ b/apps/mis-web/src/pageComponents/users/AddUserButton.tsx
@@ -95,9 +95,13 @@ export const AddUserButton: React.FC<Props> = ({ refresh, accountName, token }) 
         }
       })
       .httpError(404, ({ code }) => {
-        if (code === "ACCOUNT_NOT_FOUND") {
-          message.error("账户不存在");
-        } else if (code === "USER_NOT_FOUND") {
+        if (code === "USER_ALREADY_EXIST_IN_OTHER_TENANT") {
+          message.error(`用户${name}已属于其他租户`);
+        }
+        else if (code === "ACCOUNT_OR_TENANT_NOT_FOUND") {
+          message.error("租户或账户不存在");
+        } 
+        else if (code === "USER_NOT_FOUND") {
           if (useBuiltinCreateUser()) {
             setModalShow(false);
             setNewUserInfo({ identityId, name });

--- a/apps/mis-web/src/pages/api/users/addToAccount.ts
+++ b/apps/mis-web/src/pages/api/users/addToAccount.ts
@@ -91,6 +91,12 @@ export default /* #__PURE__*/typeboxRoute(AddUserToAccountSchema, async (req, re
 
         if (e.details === "USER_OR_TENANT_NOT_FOUND") {
 
+          /**
+           * 后端接口addUserToAccount返回USER_OR_TENANT_NOT_FOUND
+           * 说明操作者的租户下的不存在要添加的这个用户
+           * 该用户存不存在于scow系统中在上面的checkNameMatch函数中已通过检查
+           * */ 
+
           return { 404: { code: "USER_ALREADY_EXIST_IN_OTHER_TENANT" as const } };
         } else {
           

--- a/apps/mis-web/src/pages/api/users/addToAccount.ts
+++ b/apps/mis-web/src/pages/api/users/addToAccount.ts
@@ -88,7 +88,7 @@ export default /* #__PURE__*/typeboxRoute(AddUserToAccountSchema, async (req, re
     .catch(handlegRPCError({
       [Status.ALREADY_EXISTS]: () => ({ 409: null }),
       [Status.NOT_FOUND]: (e) => { 
-        console.log("e", e.details);
+
         if (e.details === "USER_OR_TENANT_NOT_FOUND") {
 
           return { 404: { code: "USER_ALREADY_EXIST_IN_OTHER_TENANT" as const } };

--- a/apps/mis-web/src/pages/api/users/addToAccount.ts
+++ b/apps/mis-web/src/pages/api/users/addToAccount.ts
@@ -39,7 +39,8 @@ export const AddUserToAccountSchema = typeboxRouteSchema({
 
     404: Type.Object({
       code: Type.Union([
-        Type.Literal("ACCOUNT_NOT_FOUND"),
+        Type.Literal("ACCOUNT_OR_TENANT_NOT_FOUND"),
+        Type.Literal("USER_ALREADY_EXIST_IN_OTHER_TENANT"),
         Type.Literal("USER_NOT_FOUND"),
       ]),
     }),
@@ -86,6 +87,16 @@ export default /* #__PURE__*/typeboxRoute(AddUserToAccountSchema, async (req, re
   }).then(() => ({ 204: null }))
     .catch(handlegRPCError({
       [Status.ALREADY_EXISTS]: () => ({ 409: null }),
-      [Status.NOT_FOUND]: () => ({ 404: { code: "ACCOUNT_NOT_FOUND" as const } }),
+      [Status.NOT_FOUND]: (e) => { 
+        console.log("e", e.details);
+        if (e.details === "USER_OR_TENANT_NOT_FOUND") {
+
+          return { 404: { code: "USER_ALREADY_EXIST_IN_OTHER_TENANT" as const } };
+        } else {
+          
+          return { 404: { code: "ACCOUNT_OR_TENANT_NOT_FOUND" as const } }; 
+        }
+      }
+      ,
     }));
 });


### PR DESCRIPTION
## 之前：账户添加不属于本租户的用户时，页面提示为：
![image](https://github.com/PKUHPC/SCOW/assets/74037789/e7926ae9-e225-4e18-95d1-330e6cc8addd)
## 现在：
![image](https://github.com/PKUHPC/SCOW/assets/74037789/277c5531-5b5b-4082-ac0a-b7dd81d95d92)
