### PR TITLE
fix(mis): 暴露操作集群时后端返回的错误信息

### DIFF
--- a/.changeset/big-hats-return.md
+++ b/.changeset/big-hats-return.md
@@ -1,0 +1,6 @@
+---
+"@scow/mis-server": patch
+"@scow/mis-web": patch
+---
+
+暴露操作集群时后端返回的错误信息

--- a/apps/mis-server/src/plugins/clusters.ts
+++ b/apps/mis-server/src/plugins/clusters.ts
@@ -119,11 +119,11 @@ export const clustersPlugin = plugin(async (f) => {
 
       if (failed.length > 0) {
         logger.error("Cluster ops fails at clusters %o", failed);
+        const reason = failed.map((x) => clusters[x.cluster].displayName + ": " + x.error).join("; ");
         throw new ServiceError({
           code: status.INTERNAL,
-          details: failed.map((x) => x.cluster).join(","),
+          details: reason,
           metadata: scowErrorMetadata(CLUSTEROPS_ERROR_CODE),
-          // metadata: scowErrorMetadata(CLUSTEROPS_ERROR_CODE, {failedClusters: failed.join(",")})
         });
       }
 

--- a/apps/mis-server/src/services/user.ts
+++ b/apps/mis-server/src/services/user.ts
@@ -15,7 +15,7 @@ import { plugin } from "@ddadaal/tsgrpc-server";
 import { ServiceError } from "@grpc/grpc-js";
 import { Status } from "@grpc/grpc-js/build/src/constants";
 import { addUserToAccount, changeEmail as libChangeEmail, createUser, getCapabilities, getUser, removeUserFromAccount,
-} 
+}
   from "@scow/lib-auth";
 import { decimalToMoney } from "@scow/lib-decimal";
 import {
@@ -159,6 +159,8 @@ export const userServiceServer = plugin((server) => {
 
       await server.ext.clusters.callOnAll(logger, async (client) => {
         return await asyncClientCall(client.user, "addUserToAccount", { userId, accountName });
+      }).catch(async (e) => {
+        throw e;
       });
 
       const newUserAccount = new UserAccount({
@@ -663,7 +665,7 @@ export const userServiceServer = plugin((server) => {
           code: Status.NOT_FOUND, message: `User ${userId} is not found.`,
         };
       }
-        
+
       user.email = newEmail;
       await em.flush();
 

--- a/apps/mis-web/src/pageComponents/users/AddUserButton.tsx
+++ b/apps/mis-web/src/pageComponents/users/AddUserButton.tsx
@@ -125,8 +125,8 @@ export const AddUserButton: React.FC<Props> = ({ refresh, accountName, token }) 
           }
         }
       })
-      .httpError(409, () => {
-        message.error("用户已经存在于此账户中！");
+      .httpError(409, (e) => {
+        message.error(e.message);
       })
       .then(() => {
         message.success("添加成功！");

--- a/apps/mis-web/src/pages/_app.tsx
+++ b/apps/mis-web/src/pages/_app.tsx
@@ -52,13 +52,13 @@ const FailEventHandler: React.FC = () => {
         userStore.logout();
         return;
       }
-
+      console.log(e);
       if (e.data?.code === "CLUSTEROPS_ERROR") {
         modal.error({
           title: "操作失败",
           content: `多集群操作出现错误，部分集群未同步修改(${
-            e.data.details?.split(",").map((x) => publicConfig.CLUSTERS[x].name)
-          }), 请联系管理员!`,
+            e.data.details
+          })`,
         });
         return;
       }

--- a/apps/mis-web/src/pages/api/users/addToAccount.ts
+++ b/apps/mis-web/src/pages/api/users/addToAccount.ts
@@ -48,9 +48,9 @@ export const AddUserToAccountSchema = typeboxRouteSchema({
       ]),
     }),
 
-    /** 用户已经存在 */
+    /** 用户或账户存在问题 */
     409: Type.Object({
-      code: Type.Literal("ACCOUT_OR_USER_ERROR"),
+      code: Type.Literal("ACCOUNT_OR_USER_ERROR"),
       message: Type.Optional(Type.String()),
     }),
 
@@ -92,8 +92,8 @@ export default /* #__PURE__*/typeboxRoute(AddUserToAccountSchema, async (req, re
     userId: identityId,
   }).then(() => ({ 204: null }))
     .catch(handlegRPCError({
-      [Status.ALREADY_EXISTS]: () => ({ 409: { code: "ACCOUT_OR_USER_ERROR" as const, message:"用户已经存在于此账户中！" } }),
+      [Status.ALREADY_EXISTS]: () => ({ 409: { code: "ACCOUNT_OR_USER_ERROR" as const, message:"用户已经存在于此账户中！" } }),
       [Status.NOT_FOUND]: () => ({ 404: { code: "ACCOUNT_NOT_FOUND" as const } }),
-      [Status.INTERNAL]: (e) => { return ({ 409: { code: "ACCOUT_OR_USER_ERROR" as const, message: e.details } }); },
+      [Status.INTERNAL]: (e) => { return ({ 409: { code: "ACCOUNT_OR_USER_ERROR" as const, message: e.details } }); },
     }));
 });

--- a/apps/mis-web/src/pages/api/users/addToAccount.ts
+++ b/apps/mis-web/src/pages/api/users/addToAccount.ts
@@ -37,6 +37,10 @@ export const AddUserToAccountSchema = typeboxRouteSchema({
       code: Type.Literal("ID_NAME_NOT_MATCH"),
     }),
 
+    401: Type.Object({
+      code: Type.Literal("ID_NAME_NOT_MATCH"),
+    }),
+
     404: Type.Object({
       code: Type.Union([
         Type.Literal("ACCOUNT_NOT_FOUND"),
@@ -45,7 +49,10 @@ export const AddUserToAccountSchema = typeboxRouteSchema({
     }),
 
     /** 用户已经存在 */
-    409: Type.Null(),
+    409: Type.Object({
+      code: Type.Literal("ACCOUT_OR_USER_ERROR"),
+      message: Type.Optional(Type.String()),
+    }),
 
   },
 });
@@ -57,7 +64,7 @@ export default /* #__PURE__*/typeboxRoute(AddUserToAccountSchema, async (req, re
     const acccountBelonged = u.accountAffiliations.find((x) => x.accountName === accountName);
 
     return u.platformRoles.includes(PlatformRole.PLATFORM_ADMIN) ||
-          (acccountBelonged && acccountBelonged.role !== UserRole.USER) || 
+          (acccountBelonged && acccountBelonged.role !== UserRole.USER) ||
           u.tenantRoles.includes(TenantRole.TENANT_ADMIN);
   });
 
@@ -85,7 +92,8 @@ export default /* #__PURE__*/typeboxRoute(AddUserToAccountSchema, async (req, re
     userId: identityId,
   }).then(() => ({ 204: null }))
     .catch(handlegRPCError({
-      [Status.ALREADY_EXISTS]: () => ({ 409: null }),
+      [Status.ALREADY_EXISTS]: () => ({ 409: { code: "ACCOUT_OR_USER_ERROR" as const, message:"用户已经存在于此账户中！" } }),
       [Status.NOT_FOUND]: () => ({ 404: { code: "ACCOUNT_NOT_FOUND" as const } }),
+      [Status.INTERNAL]: (e) => { return ({ 409: { code: "ACCOUT_OR_USER_ERROR" as const, message: e.details } }); },
     }));
 });


### PR DESCRIPTION
原本涉及adapter的部分接口，未能展示从slurm返回的错误，如创建账户时，用户名中有大写，截图：
![image](https://github.com/PKUHPC/SCOW/assets/25954437/c0cdd969-b228-44d5-ad83-c5724fc94357)

现在修改返回信息，将其暴露：
![image](https://github.com/PKUHPC/SCOW/assets/25954437/408ad710-d77f-49d6-9b64-fe2987bf0a18)

账户的用户管理，添加的用户名中有大写，报错如下：
![image](https://github.com/PKUHPC/SCOW/assets/25954437/033a8f5a-1dee-457a-9625-b4fcec3064ea)

修改后：
![image](https://github.com/PKUHPC/SCOW/assets/25954437/2b60c375-52aa-45d2-8471-a35dc6f8b0c7)

