### PR TITLE
feat(mis): 操作日志搜索时间精度到秒，展示操作者姓名以及每页默认展示 50 条记录

### DIFF
--- a/.changeset/thirty-avocados-admire.md
+++ b/.changeset/thirty-avocados-admire.md
@@ -1,0 +1,5 @@
+---
+"@scow/grpc-api": patch
+---
+
+新增 getUsersByIds 接口以供操作日志查询操作者姓名

--- a/.changeset/warm-radios-itch.md
+++ b/.changeset/warm-radios-itch.md
@@ -1,0 +1,6 @@
+---
+"@scow/mis-server": patch
+"@scow/mis-web": patch
+---
+
+操作日志搜索时间精度到秒，展示操作者姓名以及每页默认展示 50 条记录

--- a/apps/mis-server/src/services/user.ts
+++ b/apps/mis-server/src/services/user.ts
@@ -554,6 +554,19 @@ export const userServiceServer = plugin((server) => {
       }];
     },
 
+    getUsersByIds: async ({ request, em }) => {
+      const { userIds } = request;
+
+      const users = await em.find(User, { userId: { $in: userIds } });
+
+      return [{
+        users: users.map((x) => ({
+          userId: x.userId,
+          userName: x.name,
+        })),
+      }];
+    },
+
     getPlatformUsersCounts: async ({ em }) => {
 
       const totalCount = await em.count(User);

--- a/apps/mis-web/src/apis/api.mock.ts
+++ b/apps/mis-web/src/apis/api.mock.ts
@@ -410,6 +410,7 @@ export const mockApi: MockApi<typeof api> = {
   getOperationLog: async () => ({ results: [{
     operationLogId: 99,
     operatorUserId: "testUser",
+    operatorUserName: "testUser",
     operatorIp: "localhost",
     operationCode: "000000",
     operationType: OperationType.login,

--- a/apps/mis-web/src/components/OperationLogTable.tsx
+++ b/apps/mis-web/src/components/OperationLogTable.tsx
@@ -60,7 +60,7 @@ export const OperationLogTable: React.FC<Props> = ({ user, queryType, accountNam
 
   const [form] = Form.useForm<FilterForm>();
 
-  const [pageInfo, setPageInfo] = useState<PageInfo>({ page: 1, pageSize: 10 });
+  const [pageInfo, setPageInfo] = useState<PageInfo>({ page: 1, pageSize: 50 });
 
   const getOperatorUserIds = () => {
     if (queryType === OperationLogQueryType.USER) {
@@ -76,8 +76,8 @@ export const OperationLogTable: React.FC<Props> = ({ user, queryType, accountNam
       operatorUserIds: getOperatorUserIds().join(","),
       operationType: query.operationType,
       operationResult: query.operationResult,
-      startTime: query.operationTime?.[0].startOf("day").toISOString(),
-      endTime: query.operationTime?.[1].endOf("day").toISOString(),
+      startTime: query.operationTime?.[0].toISOString(),
+      endTime: query.operationTime?.[1].toISOString(),
       operationTargetAccountName: accountName,
       page: pageInfo.page,
       pageSize: pageInfo.pageSize,
@@ -129,7 +129,7 @@ export const OperationLogTable: React.FC<Props> = ({ user, queryType, accountNam
             </Form.Item>
           )}
           <Form.Item label="操作时间" name="operationTime">
-            <DatePicker.RangePicker allowClear={false} presets={defaultPresets} />
+            <DatePicker.RangePicker showTime allowClear={false} presets={defaultPresets} />
           </Form.Item>
           <Form.Item>
             <Button type="primary" htmlType="submit">搜索</Button>
@@ -168,7 +168,11 @@ export const OperationLogTable: React.FC<Props> = ({ user, queryType, accountNam
           title="操作时间"
           render={formatDateTime}
         />
-        <Table.Column<OperationLog> dataIndex="operatorUserId" title="操作员" />
+        <Table.Column<OperationLog>
+          dataIndex="operatorUserId"
+          title="操作员"
+          render={(_, r) => (`${r.operatorUserId} (${r.operatorUserName})`)}
+        />
         <Table.Column<OperationLog> dataIndex="operatorIp" title="操作IP" />
       </Table>
     </div>

--- a/apps/mis-web/src/models/operationLog.ts
+++ b/apps/mis-web/src/models/operationLog.ts
@@ -77,6 +77,7 @@ export const OperationType: OperationTypeEnum = {
 export const OperationLog = Type.Object({
   operationLogId: Type.Number(),
   operatorUserId: Type.String(),
+  operatorUserName: Type.String(),
   operatorIp: Type.String(),
   operationCode: Type.String(),
   operationType: Type.Enum(OperationType),

--- a/apps/mis-web/src/pages/api/log/getOperationLog.ts
+++ b/apps/mis-web/src/pages/api/log/getOperationLog.ts
@@ -141,10 +141,20 @@ export default typeboxRoute(GetOperationLogsSchema, async (req, res) => {
 
   const { results, totalCount } = resp;
 
+  const userIds = Array.from(new Set(results.map((x) => x.operatorUserId)));
+
+  const client = getClient(UserServiceClient);
+  const { users } = await asyncClientCall(client, "getUsersByIds", {
+    userIds,
+  });
+
+  const userMap = new Map(users.map((x) => [x.userId, x.userName]));
+
   const operationLogs = results.map((x) => {
     return {
       operationLogId: x.operationLogId,
       operatorUserId: x.operatorUserId,
+      operatorUserName: userMap.get(x.operatorUserId),
       operatorIp: x.operatorIp,
       operationResult: x.operationResult,
       operationTime: x.operationTime,

--- a/protos/server/user.proto
+++ b/protos/server/user.proto
@@ -244,7 +244,7 @@ message GetUserInfoResponse {
   string tenant_name = 5;
   string email = 6;
   google.protobuf.Timestamp create_time = 7;
-  
+
 }
 
 message GetUsersResponse {
@@ -284,6 +284,20 @@ message GetAllUsersRequest {
 message GetAllUsersResponse {
   uint64 total_count = 1;
   repeated PlatformUserInfo platform_users = 2;
+}
+
+message GetUsersByIdsRequest {
+  repeated string user_ids = 1;
+}
+
+message GetUsersByIdsResponse {
+
+  message UserInfo {
+    string user_id = 1;
+    string user_name = 2;
+  }
+
+  repeated UserInfo users = 1;
 }
 
 message GetPlatformUsersCountsRequest {
@@ -354,6 +368,7 @@ message ChangeEmailResponse {
 }
 
 
+
 service UserService {
 
   rpc GetUsers(GetUsersRequest) returns (GetUsersResponse);
@@ -369,6 +384,8 @@ service UserService {
   rpc GetUserStatus(GetUserStatusRequest) returns (GetUserStatusResponse);
   rpc QueryUsedStorageQuota(QueryUsedStorageQuotaRequest)
       returns (QueryUsedStorageQuotaResponse);
+
+  rpc GetUsersByIds(GetUsersByIdsRequest) returns (GetUsersByIdsResponse);
 
   //新增用户，在数据库中增加用户，然后调用auth服务在ldap中增加该用户，
   //并将公钥插入用户的authorized_keys


### PR DESCRIPTION
## 改动：
1. 操作日志搜索精确到秒
2. 新增了一个接口负责将操作日志的userId查询对应的userName展示
3. 操作日志table每页默认展示50条记录

![image](https://github.com/PKUHPC/SCOW/assets/130351655/4ff9217c-f040-4555-a5c6-3821bd7e5708)