### PR TITLE
fix(portal-server): 修复桌面功能以 root 创建文件夹导致工作目录权限错误问题

### DIFF
--- a/.changeset/cold-items-whisper.md
+++ b/.changeset/cold-items-whisper.md
@@ -1,0 +1,5 @@
+---
+"@scow/portal-server": patch
+---
+
+修复桌面功能以 root 创建文件夹导致工作目录权限错误问题

--- a/apps/portal-server/src/utils/desktops.ts
+++ b/apps/portal-server/src/utils/desktops.ts
@@ -56,7 +56,7 @@ export async function getUserDesktopsFilePath(
   const desktopDir = getDesktopConfig(cluser).desktopsDir;
   const userDesktopDir = join(userHomeDir, desktopDir);
   // make sure desktopsDir exists
-  await ssh.mkdir(userDesktopDir);
+  await executeAsUser(ssh, userId, logger, true, "mkdir", ["-p", userDesktopDir]);
   return join(userDesktopDir, "desktops.json");
 }
 

--- a/apps/portal-server/tests/utils/desktop.test.ts
+++ b/apps/portal-server/tests/utils/desktop.test.ts
@@ -154,7 +154,7 @@ it("should return an array of desktops from host", async () => {
   (getUserHomedir as jest.Mock).mockReturnValue(join("/home/test", desktopTestsFolder()));
 
   const desktops = await listUserDesktopsFromHost(target, testCluster, userId, console);
-  expect(executeAsUser).toHaveBeenCalledOnce();
+  expect(executeAsUser).toHaveBeenCalledTimes(4);
   expect(desktops).toEqual(
     {
       host: target,


### PR DESCRIPTION
## 问题
使用时，如果一个新用户在没有提交作业或者交互式应用时，进入到桌面页面，会在工作目录下以root身份创建桌面信息保存目录。而这会导致用户之后使用其他相关工作目录功能报错。

## 改动
创建userDesktopDir时 以用户身份操作而不是使用root身份创建