### PR TITLE
fix(lib-operation-log): 移除不必要的操作日志记录成功 log

### DIFF
--- a/.changeset/mean-carrots-fetch.md
+++ b/.changeset/mean-carrots-fetch.md
@@ -1,0 +1,5 @@
+---
+"@scow/lib-operation-log": patch
+---
+
+移除不必要的操作日志记录成功 log

--- a/libs/operation-log/src/index.ts
+++ b/libs/operation-log/src/index.ts
@@ -78,7 +78,6 @@ export const createOperationLogClient = (
         // @ts-ignore
         operationEvent: { $case: operationTypeName, [operationTypeName]: { ...operationTypePayload } },
       }).then(
-        () => { logger.debug("Operation Log call completed"); },
         (e) => {
           logger.error(e, "Error when calling Operation Log");
         },


### PR DESCRIPTION
操作日志记录很频繁，导致mis-web和portal-web的log文件里全是无效的“Operation Log call completed”信息，现将其移除