### PR TITLE
fix(portal-web): 去掉 legacyBehavior，会影响 target=“_blank” 在新窗口或标签中打开链接的效果

### DIFF
--- a/.changeset/warm-ducks-pretend.md
+++ b/.changeset/warm-ducks-pretend.md
@@ -1,0 +1,5 @@
+---
+"@scow/portal-web": patch
+---
+
+去掉 legacyBehavior，会影响 target=\_blank 在新窗口或标签中打开链接的效果

--- a/apps/portal-web/src/pageComponents/filemanager/FileManager.tsx
+++ b/apps/portal-web/src/pageComponents/filemanager/FileManager.tsx
@@ -394,7 +394,7 @@ export const FileManager: React.FC<Props> = ({ cluster, path, urlPrefix }) => {
           </Button>
           {
             publicConfig.ENABLE_SHELL ? (
-              <Link href={`/shell/${cluster.id}/${loginNode}${path}`} target="_blank" legacyBehavior>
+              <Link href={`/shell/${cluster.id}/${loginNode}${path}`} target="_blank">
                 <Button icon={<MacCommandOutlined />}>
                   在终端中打开
                 </Button>


### PR DESCRIPTION
目前使用的next版本13.4.10，如果增加了legacyBehavior，会影响target="_blank"的核心效果（即在新窗口或标签中打开链接），此pr去掉FileManager中的该属性，保证能在打开终端时新开页面