### PR TITLE
fix(auth): auth登录成功后，重定向回mis和portal时加上一个登录标记

### DIFF
--- a/.changeset/dirty-cobras-happen.md
+++ b/.changeset/dirty-cobras-happen.md
@@ -4,4 +4,4 @@
 "@scow/auth": patch
 ---
 
-auth 登录跳转回 web 页面时，增加 isFromLogin 参数以区分用户登录操作和切换门户/管理系统
+auth 登录跳转回 web 页面时，判断referer是否包含 AUTH_EXTERNAL_URL + '/public/auth'以区分用户登录操作和切换门户/管理系统

--- a/.changeset/dirty-cobras-happen.md
+++ b/.changeset/dirty-cobras-happen.md
@@ -1,0 +1,7 @@
+---
+"@scow/portal-web": patch
+"@scow/mis-web": patch
+"@scow/auth": patch
+---
+
+auth 登录跳转回 web 页面时，增加 isFromLogin 参数以区分用户登录操作和切换门户/管理系统

--- a/apps/auth/src/auth/callback.ts
+++ b/apps/auth/src/auth/callback.ts
@@ -59,7 +59,7 @@ export async function validateCallbackHostname(callbackUrl: string, req: Fastify
 
 export async function redirectToWeb(callbackUrl: string, token: string, rep: FastifyReply) {
 
-  const searchParams = new URLSearchParams({ token, isLogin: "true" });
+  const searchParams = new URLSearchParams({ token, isFromLogin: "true" });
 
   await rep.redirect(302, `${callbackUrl}?${searchParams.toString()}`);
 }

--- a/apps/auth/src/auth/callback.ts
+++ b/apps/auth/src/auth/callback.ts
@@ -59,7 +59,7 @@ export async function validateCallbackHostname(callbackUrl: string, req: Fastify
 
 export async function redirectToWeb(callbackUrl: string, token: string, rep: FastifyReply) {
 
-  const searchParams = new URLSearchParams({ token });
+  const searchParams = new URLSearchParams({ token, isLogin: "true" });
 
   await rep.redirect(302, `${callbackUrl}?${searchParams.toString()}`);
 }

--- a/apps/auth/src/auth/callback.ts
+++ b/apps/auth/src/auth/callback.ts
@@ -59,7 +59,7 @@ export async function validateCallbackHostname(callbackUrl: string, req: Fastify
 
 export async function redirectToWeb(callbackUrl: string, token: string, rep: FastifyReply) {
 
-  const searchParams = new URLSearchParams({ token, isFromLogin: "true" });
+  const searchParams = new URLSearchParams({ token });
 
   await rep.redirect(302, `${callbackUrl}?${searchParams.toString()}`);
 }

--- a/apps/mis-web/src/pages/api/auth/callback.ts
+++ b/apps/mis-web/src/pages/api/auth/callback.ts
@@ -15,7 +15,7 @@ import { setTokenCookie } from "src/auth/cookie";
 import { validateToken } from "src/auth/token";
 import { OperationResult, OperationType } from "src/models/operationLog";
 import { callLog } from "src/server/operationLog";
-import { publicConfig } from "src/utils/config";
+import { publicConfig, runtimeConfig } from "src/utils/config";
 import { parseIp } from "src/utils/server";
 
 export const AuthCallbackSchema = typeboxRouteSchema({
@@ -37,7 +37,7 @@ export default typeboxRoute(AuthCallbackSchema, async (req, res) => {
 
   const { token } = req.query;
 
-  const isFromLogin = req.headers?.referer?.indexOf("/public/auth") !== -1;
+  const isFromLogin = req.headers?.referer?.indexOf(runtimeConfig.AUTH_EXTERNAL_URL + "/public/auth") !== -1;
   const info = await validateToken(token);
 
   if (info) {

--- a/apps/mis-web/src/pages/api/auth/callback.ts
+++ b/apps/mis-web/src/pages/api/auth/callback.ts
@@ -37,7 +37,7 @@ export default typeboxRoute(AuthCallbackSchema, async (req, res) => {
 
   const { token } = req.query;
 
-  const isFromLogin = req.headers?.referer?.indexOf(runtimeConfig.AUTH_EXTERNAL_URL + "/public/auth") !== -1;
+  const isFromLogin = req.headers?.referer?.includes(runtimeConfig.AUTH_EXTERNAL_URL + "/public/auth");
   const info = await validateToken(token);
 
   if (info) {

--- a/apps/mis-web/src/pages/api/auth/callback.ts
+++ b/apps/mis-web/src/pages/api/auth/callback.ts
@@ -38,6 +38,8 @@ export default typeboxRoute(AuthCallbackSchema, async (req, res) => {
 
   const { token, isFromLogin } = req.query;
 
+  console.log("=================", req.headers.referer, "=====================");
+
   const info = await validateToken(token);
 
   if (info) {

--- a/apps/mis-web/src/pages/api/auth/callback.ts
+++ b/apps/mis-web/src/pages/api/auth/callback.ts
@@ -23,7 +23,7 @@ export const AuthCallbackSchema = typeboxRouteSchema({
 
   query: Type.Object({
     token: Type.String(),
-    isLogin: Type.Optional(Type.Boolean()),
+    isFromLogin: Type.Optional(Type.Boolean()),
   }),
 
   responses: {
@@ -36,14 +36,14 @@ export const AuthCallbackSchema = typeboxRouteSchema({
 
 export default typeboxRoute(AuthCallbackSchema, async (req, res) => {
 
-  const { token, isLogin } = req.query;
+  const { token, isFromLogin } = req.query;
 
   const info = await validateToken(token);
 
   if (info) {
     // set token cache
     setTokenCookie({ res }, token);
-    if (isLogin) {
+    if (isFromLogin) {
       const logInfo = {
         operatorUserId: info.identityId,
         operatorIp: parseIp(req) ?? "",

--- a/apps/mis-web/src/pages/api/auth/callback.ts
+++ b/apps/mis-web/src/pages/api/auth/callback.ts
@@ -23,6 +23,7 @@ export const AuthCallbackSchema = typeboxRouteSchema({
 
   query: Type.Object({
     token: Type.String(),
+    isLogin: Type.Optional(Type.Boolean()),
   }),
 
   responses: {
@@ -35,19 +36,21 @@ export const AuthCallbackSchema = typeboxRouteSchema({
 
 export default typeboxRoute(AuthCallbackSchema, async (req, res) => {
 
-  const { token } = req.query;
+  const { token, isLogin } = req.query;
 
   const info = await validateToken(token);
 
   if (info) {
     // set token cache
     setTokenCookie({ res }, token);
-    const logInfo = {
-      operatorUserId: info.identityId,
-      operatorIp: parseIp(req) ?? "",
-      operationTypeName: OperationType.login,
-    };
-    await callLog(logInfo, OperationResult.SUCCESS);
+    if (isLogin) {
+      const logInfo = {
+        operatorUserId: info.identityId,
+        operatorIp: parseIp(req) ?? "",
+        operationTypeName: OperationType.login,
+      };
+      await callLog(logInfo, OperationResult.SUCCESS);
+    }
     res.redirect(publicConfig.BASE_PATH);
   } else {
     return { 403: null };

--- a/apps/mis-web/src/pages/api/auth/callback.ts
+++ b/apps/mis-web/src/pages/api/auth/callback.ts
@@ -23,7 +23,6 @@ export const AuthCallbackSchema = typeboxRouteSchema({
 
   query: Type.Object({
     token: Type.String(),
-    isFromLogin: Type.Optional(Type.Boolean()),
   }),
 
   responses: {
@@ -36,10 +35,9 @@ export const AuthCallbackSchema = typeboxRouteSchema({
 
 export default typeboxRoute(AuthCallbackSchema, async (req, res) => {
 
-  const { token, isFromLogin } = req.query;
+  const { token } = req.query;
 
-  console.log("=================", req.headers.referer, "=====================");
-
+  const isFromLogin = req.headers?.referer?.indexOf("/public/auth") !== -1;
   const info = await validateToken(token);
 
   if (info) {

--- a/apps/portal-web/src/pages/api/auth/callback.ts
+++ b/apps/portal-web/src/pages/api/auth/callback.ts
@@ -40,7 +40,7 @@ export default route(AuthCallbackSchema, async (req, res) => {
 
   const { token } = req.query;
 
-  const isFromLogin = req.headers?.referer?.indexOf(runtimeConfig.AUTH_EXTERNAL_URL + "/public/auth") !== -1;
+  const isFromLogin = req.headers?.referer?.includes(runtimeConfig.AUTH_EXTERNAL_URL + "/public/auth");
 
   // query the token and get the username
   const info = await validateToken(token);

--- a/apps/portal-web/src/pages/api/auth/callback.ts
+++ b/apps/portal-web/src/pages/api/auth/callback.ts
@@ -25,7 +25,6 @@ export const AuthCallbackSchema = typeboxRouteSchema({
 
   query: Type.Object({
     token: Type.String(),
-    isFromLogin: Type.Optional(Type.Boolean()),
   }),
 
   responses: {
@@ -39,7 +38,9 @@ export const AuthCallbackSchema = typeboxRouteSchema({
 
 export default route(AuthCallbackSchema, async (req, res) => {
 
-  const { token, isFromLogin } = req.query;
+  const { token } = req.query;
+
+  const isFromLogin = req.headers?.referer?.indexOf("/public/auth") !== -1;
 
   // query the token and get the username
   const info = await validateToken(token);

--- a/apps/portal-web/src/pages/api/auth/callback.ts
+++ b/apps/portal-web/src/pages/api/auth/callback.ts
@@ -23,7 +23,10 @@ import { parseIp } from "src/utils/server";
 export const AuthCallbackSchema = typeboxRouteSchema({
   method: "GET",
 
-  query: Type.Object({ token: Type.String() }),
+  query: Type.Object({
+    token: Type.String(),
+    isFromLogin: Type.Optional(Type.Boolean()),
+  }),
 
   responses: {
     200: Type.Null(),
@@ -36,7 +39,7 @@ export const AuthCallbackSchema = typeboxRouteSchema({
 
 export default route(AuthCallbackSchema, async (req, res) => {
 
-  const { token } = req.query;
+  const { token, isFromLogin } = req.query;
 
   // query the token and get the username
   const info = await validateToken(token);
@@ -44,12 +47,14 @@ export default route(AuthCallbackSchema, async (req, res) => {
   if (info) {
     // set token cache
     setTokenCookie({ res }, token);
-    const logInfo = {
-      operatorUserId: info.identityId,
-      operatorIp: parseIp(req) ?? "",
-      operationTypeName: OperationType.login,
-    };
-    await callLog(logInfo, OperationResult.SUCCESS);
+    if (isFromLogin) {
+      const logInfo = {
+        operatorUserId: info.identityId,
+        operatorIp: parseIp(req) ?? "",
+        operationTypeName: OperationType.login,
+      };
+      await callLog(logInfo, OperationResult.SUCCESS);
+    }
     res.redirect(publicConfig.BASE_PATH);
   } else {
     return { 403: null };

--- a/apps/portal-web/src/pages/api/auth/callback.ts
+++ b/apps/portal-web/src/pages/api/auth/callback.ts
@@ -16,7 +16,7 @@ import { setTokenCookie } from "src/auth/cookie";
 import { validateToken } from "src/auth/token";
 import { OperationResult, OperationType } from "src/models/operationLog";
 import { callLog } from "src/server/operationLog";
-import { publicConfig } from "src/utils/config";
+import { publicConfig, runtimeConfig } from "src/utils/config";
 import { route } from "src/utils/route";
 import { parseIp } from "src/utils/server";
 
@@ -40,7 +40,7 @@ export default route(AuthCallbackSchema, async (req, res) => {
 
   const { token } = req.query;
 
-  const isFromLogin = req.headers?.referer?.indexOf("/public/auth") !== -1;
+  const isFromLogin = req.headers?.referer?.indexOf(runtimeConfig.AUTH_EXTERNAL_URL + "/public/auth") !== -1;
 
   // query the token and get the username
   const info = await validateToken(token);


### PR DESCRIPTION
## 目前：
用户登录操作日志记录在portal-web和mis-web的 /api/auth/callback  路由下， 但此路由除了用户登录会跳转之外， 在右上角点击跳转门户或者管理系统时也会走一次，导致用户登录记录不够准确。

## 改动：
在auth服务登录跳转至/api/auth/callback时，判断referer里是否包含AUTH_EXTERNAL_URL + /public/auth区分该跳转来源于登录操作，包含时才记录一次用户登录。