### PR TITLE
feat(mis): 修改作业时限优化和BUG修复

### DIFF
--- a/.changeset/lazy-zebras-hear.md
+++ b/.changeset/lazy-zebras-hear.md
@@ -1,0 +1,7 @@
+---
+"@scow/mis-server": patch
+"@scow/mis-web": patch
+"@scow/lib-web": patch
+---
+
+优化修改作业时限，修复修改作业时限 bug 让修改作业时限时指定查询运行中状态的作业

--- a/apps/mis-server/src/services/job.ts
+++ b/apps/mis-server/src/services/job.ts
@@ -238,12 +238,18 @@ export const jobServiceServer = plugin((server) => {
           if (jobIdList.length > 0) {
             const jobInfoList: AdapterJobInfo[] = [];
             for (const jobId of jobIdList) {
-              const jobInfo = await asyncClientCall(client.job, "getJobById", { fields, jobId: Number(jobId) })
+              const jobInfo = await asyncClientCall(client.job, "getJobById", {
+                fields,
+                jobId: Number(jobId),
+              })
                 .catch((e) => {
                   logger.info("GetJobById with JobId: %s failed", jobId, e);
                   return { job: undefined };
                 });
-              if (jobInfo.job) jobInfoList.push(jobInfo.job);
+              // TODO 确认能否返回两条同一id
+              if (jobInfo.job &&
+                (jobInfo.job.state === "RUNNING" || jobInfo.job.state === "PENDING"))
+                jobInfoList.push(jobInfo.job);
             }
             return jobInfoList;
           } else {

--- a/apps/mis-server/src/services/job.ts
+++ b/apps/mis-server/src/services/job.ts
@@ -23,7 +23,6 @@ import {
   JobFilter,
   JobServiceServer, JobServiceService,
 } from "@scow/protos/build/server/job";
-import { JobInfo as AdapterJobInfo } from "@scow/scheduler-adapter-protos/build/protos/job";
 import { charge, pay } from "src/bl/charging";
 import { getActiveBillingItems } from "src/bl/PriceMap";
 import { misConfig } from "src/config/mis";
@@ -235,32 +234,17 @@ export const jobServiceServer = plugin((server) => {
             "nodes_alloc", "node_list", "reason", "account", "cpus_alloc", "gpus_alloc",
             "qos", "submit_time", "time_limit_minutes", "working_directory",
           ];
-          if (jobIdList.length > 1) {
-            const jobInfoList: AdapterJobInfo[] = [];
-            for (const jobId of jobIdList) {
-              const jobInfo = await asyncClientCall(client.job, "getJobById", {
-                fields,
-                jobId: Number(jobId),
-              })
-                .catch((e) => {
-                  logger.info("GetJobById with JobId: %s failed", jobId, e);
-                  return { job: undefined };
-                });
-              if (jobInfo.job) jobInfoList.push(jobInfo.job);
-            }
-            return jobInfoList;
-          // 修改作业时限时
-          } else if (jobIdList.length === 1) {
-            const jobId = parseInt(jobIdList[0]);
-            return await asyncClientCall(client.job, "getJobs", {
-              fields,
-              filter: { users: userId ? [userId] : [], accounts: accountNames, states: ["RUNNING", "PENDING"]},
-            }).then((x) => x.jobs.filter((job) => job.jobId === jobId));
+
+          const runningJobs = await asyncClientCall(client.job, "getJobs", {
+            fields,
+            filter: { users: userId ? [userId] : [], accounts: accountNames, states: ["RUNNING", "PENDING"]},
+          }).then((x) => x.jobs);
+
+          if (jobIdList.length > 0) {
+            const filteredJobs = runningJobs.filter((job) => jobIdList.includes(job.jobId.toString()));
+            return filteredJobs;
           } else {
-            return await asyncClientCall(client.job, "getJobs", {
-              fields,
-              filter: { users: userId ? [userId] : [], accounts: accountNames, states: ["RUNNING", "PENDING"]},
-            }).then((x) => x.jobs);
+            return runningJobs;
           }
         },
       );

--- a/apps/mis-web/src/i18n/en.ts
+++ b/apps/mis-web/src/i18n/en.ts
@@ -94,6 +94,11 @@ export default {
     normal: "Available",
     view: "View",
     waitingMessage: "The operation may take some time. Your patience is appreciated.",
+    timeUnits: {
+      minute: "MINUTE",
+      hour: "HOUR",
+      day: "DAY",
+    },
   },
   dashboard: {
     title: "Dashboard",
@@ -391,12 +396,14 @@ export default {
     },
     job: {
       ChangeJobTimeLimitModal: {
+        currentTimeLimit: "Current Job Time Limit",
         modifyLimit: "Modify Job Time Limit",
         success: "All modifications to time limits were successful.",
         fail: "Some modifications to job time limits failed.",
         setLimit: "Set Job Time Limit",
         modifyWork: "Failed Job Modifications",
         timeLimeError: "The job time limit must exceed the job's actual runtime.",
+        timeExplanation: "The time set here represents the total duration of the job execution.",
       },
       editableJobBillingTable: {
         alreadyUsed: "This ID has already been used.",

--- a/apps/mis-web/src/i18n/zh_cn.ts
+++ b/apps/mis-web/src/i18n/zh_cn.ts
@@ -50,7 +50,7 @@ export default {
     modify:"修改",
     cancel:"取消",
     cluster:"集群",
-    workId:"作业Id",
+    workId:"作业ID",
     minute:"分钟",
     name:"姓名",
     set:"设置",
@@ -94,6 +94,11 @@ export default {
     normal: "正常",
     view: "查看",
     waitingMessage: "操作所需时间较长，请耐心等待",
+    timeUnits: {
+      minute: "分钟",
+      hour: "小时",
+      day: "天",
+    },
   },
   dashboard: {
     title: "仪表盘",
@@ -391,12 +396,14 @@ export default {
     },
     job:{
       ChangeJobTimeLimitModal:{
+        currentTimeLimit: "当前作业时限",
         modifyLimit:"修改作业时限",
         success:"修改时限全部成功完成。",
         fail:"部分作业修改时限失败。",
         setLimit:"设置作业时限",
         modifyWork:"修改失败的作业",
         timeLimeError: "设置作业时限需要大于该作业的运行时长。",
+        timeExplanation: "此处设置的时间为作业执行的总时间",
       },
       editableJobBillingTable:{
         alreadyUsed:"此Id已经被使用",

--- a/apps/mis-web/src/pageComponents/job/ChangeJobTimeLimitModal.tsx
+++ b/apps/mis-web/src/pageComponents/job/ChangeJobTimeLimitModal.tsx
@@ -102,7 +102,10 @@ export const ChangeJobTimeLimitModal: React.FC<Props> = ({ open, onClose, data, 
 
         await Promise.all(data.map(async (r) => {
           await api.changeJobTimeLimit({ body: {
-            cluster: r.cluster.id, limitMinutes: limitTimeMinutes, jobId: r.jobId } })
+            cluster: r.cluster.id,
+            limitMinutes: limitTimeMinutes,
+            jobId: r.jobId,
+          } })
             .httpError(400, (e) => {
               if (e.code === "TIME_LIME_NOT_VALID") {
                 message.error(t(p("timeLimeError")));
@@ -193,7 +196,8 @@ export const ChangeJobTimeLimitModal: React.FC<Props> = ({ open, onClose, data, 
         arrayContainsElement(completionStatus?.current?.failed)
           ? (
             <Form.Item label={t(p("modifyWork"))}>
-              {completionStatus.current!.failed.map((x) => <strong key={x.jobId}>{x.jobId}</strong>)}
+              {/* {completionStatus.current!.failed.map((x) => <strong key={x.jobId}>{x.jobId}</strong>)} */}
+              <strong>{completionStatus.current!.failed.map((x) => x.jobId).join(", ")}</strong>
             </Form.Item>
           ) : undefined
       }

--- a/apps/mis-web/src/pageComponents/job/ChangeJobTimeLimitModal.tsx
+++ b/apps/mis-web/src/pageComponents/job/ChangeJobTimeLimitModal.tsx
@@ -77,9 +77,10 @@ export const ChangeJobTimeLimitModal: React.FC<Props> = ({ open, onClose, data, 
 
   const selectAfter = (
     <Select
-      defaultValue={timeUnitsI18nTexts[TimeUnits.MINUTE]}
-      options={Object.values(timeUnitsI18nTexts).map((x) => ({ label: timeUnitsI18nTexts[x], value: x }))}
-      onChange={(value: TimeUnits) => setTimeUnit(value)}
+      labelInValue
+      defaultValue={{ value: TimeUnits.MINUTE, label: timeUnitsI18nTexts[TimeUnits.MINUTE] }}
+      options={Object.keys(timeUnitsI18nTexts).map((x) => ({ label: timeUnitsI18nTexts[x], value: x }))}
+      onChange={(v) => setTimeUnit(v.value)}
     />
   );
 
@@ -94,8 +95,8 @@ export const ChangeJobTimeLimitModal: React.FC<Props> = ({ open, onClose, data, 
       destroyOnClose
       onOk={async () => {
         const { limitValue } = await form.validateFields();
-
         const limitTimeMinutes = parseMinutes(limitValue, timeUnit);
+
         setLoading(true);
 
         completionStatus.current = { total: data.length, success: 0, failed: []};
@@ -196,7 +197,6 @@ export const ChangeJobTimeLimitModal: React.FC<Props> = ({ open, onClose, data, 
         arrayContainsElement(completionStatus?.current?.failed)
           ? (
             <Form.Item label={t(p("modifyWork"))}>
-              {/* {completionStatus.current!.failed.map((x) => <strong key={x.jobId}>{x.jobId}</strong>)} */}
               <strong>{completionStatus.current!.failed.map((x) => x.jobId).join(", ")}</strong>
             </Form.Item>
           ) : undefined

--- a/apps/mis-web/src/pageComponents/job/ChangeJobTimeLimitModal.tsx
+++ b/apps/mis-web/src/pageComponents/job/ChangeJobTimeLimitModal.tsx
@@ -11,8 +11,9 @@
  */
 
 import { arrayContainsElement } from "@scow/lib-web/build/utils/array";
+import { parseMinutes, TimeUnits } from "@scow/lib-web/build/utils/datetime";
 import { getI18nConfigCurrentText } from "@scow/lib-web/build/utils/i18n";
-import { App, Divider, Form, InputNumber, Modal, Progress } from "antd";
+import { App, Divider, Form, InputNumber, Modal, Progress, Select } from "antd";
 import { useRef, useState } from "react";
 import { api } from "src/apis";
 import { prefix, useI18n, useI18nTranslateToString } from "src/i18n";
@@ -28,7 +29,7 @@ interface Props {
 }
 
 interface FormProps {
-  limitMinutes: number;
+  limitValue: number;
 }
 
 interface CompletionStatus {
@@ -67,6 +68,21 @@ export const ChangeJobTimeLimitModal: React.FC<Props> = ({ open, onClose, data, 
     onClose();
   };
 
+  const [timeUnit, setTimeUnit] = useState<TimeUnits>(TimeUnits.MINUTE);
+  const timeUnitsI18nTexts = {
+    [TimeUnits.MINUTE]: t("common.timeUnits.minute"),
+    [TimeUnits.HOUR]: t("common.timeUnits.hour"),
+    [TimeUnits.DAY]: t("common.timeUnits.day"),
+  };
+
+  const selectAfter = (
+    <Select
+      defaultValue={timeUnitsI18nTexts[TimeUnits.MINUTE]}
+      options={Object.values(timeUnitsI18nTexts).map((x) => ({ label: timeUnitsI18nTexts[x], value: x }))}
+      onChange={(value: TimeUnits) => setTimeUnit(value)}
+    />
+  );
+
   return (
     <Modal
       open={open}
@@ -77,13 +93,16 @@ export const ChangeJobTimeLimitModal: React.FC<Props> = ({ open, onClose, data, 
       confirmLoading={loading}
       destroyOnClose
       onOk={async () => {
-        const { limitMinutes } = await form.validateFields();
+        const { limitValue } = await form.validateFields();
+
+        const limitTimeMinutes = parseMinutes(limitValue, timeUnit);
         setLoading(true);
 
         completionStatus.current = { total: data.length, success: 0, failed: []};
 
         await Promise.all(data.map(async (r) => {
-          await api.changeJobTimeLimit({ body: { cluster: r.cluster.id, limitMinutes, jobId: r.jobId } })
+          await api.changeJobTimeLimit({ body: {
+            cluster: r.cluster.id, limitMinutes: limitTimeMinutes, jobId: r.jobId } })
             .httpError(400, (e) => {
               if (e.code === "TIME_LIME_NOT_VALID") {
                 message.error(t(p("timeLimeError")));
@@ -116,23 +135,39 @@ export const ChangeJobTimeLimitModal: React.FC<Props> = ({ open, onClose, data, 
 
       }}
     >
-      <Form form={form} initialValues={{ limitMinutes: 1 }}>
+      <Form form={form} initialValues={{ limitValue: 1 }}>
         {
           Array.from(dataGroupedByCluster.entries()).map(([cluster, data]) => (
             <>
               <Form.Item label={t(pCommon("cluster"))}>
                 <strong>{getI18nConfigCurrentText(cluster.name, languageId)}</strong>
               </Form.Item>
-              <Form.Item label={t(pCommon("userId"))}>
-                <strong>{data.map((x) => x.jobId).join(", ")}</strong>
+              <Form.Item label={t(pCommon("workId"))}>
+                <strong>
+                  {data.map((x) => x.name).join(", ")}
+                  <span>
+                    &nbsp;&nbsp;(ID:&nbsp;{data.map((x) => x.jobId).join(", ")})
+                  </span>
+                </strong>
+              </Form.Item>
+              <Form.Item label={t(p("currentTimeLimit"))}>
+                <strong>{data.map((x) => x.timeLimit).join(", ")}</strong>
               </Form.Item>
               <Divider />
             </>
           ))
         }
-        <Form.Item<FormProps> label={t(p("setLimit"))} rules={[{ required: true }]}>
-          <Form.Item name="limitMinutes" noStyle>
-            <InputNumber min={1} step={1} addonAfter={t(pCommon("minute"))} />
+        <Form.Item<FormProps>
+          label={t(p("setLimit"))}
+          rules={[{ required: true }]}
+          tooltip={(
+            <>
+              <span>{t(p("timeExplanation"))}</span>
+            </>
+          )}
+        >
+          <Form.Item name="limitValue" noStyle>
+            <InputNumber min={1} step={1} addonAfter={selectAfter} />
           </Form.Item>
         </Form.Item>
       </Form>

--- a/apps/mis-web/src/pages/api/job/changeJobTimeLimit.ts
+++ b/apps/mis-web/src/pages/api/job/changeJobTimeLimit.ts
@@ -66,7 +66,6 @@ export default typeboxRoute(ChangeJobTimeLimitSchema,
     const client = getClient(JobServiceClient);
 
     // check if the user can change the job time limit
-
     const { job, jobAccessible } = await checkJobAccessible(jobId, cluster, info);
 
     if (jobAccessible === "NotAllowed") {
@@ -89,6 +88,7 @@ export default typeboxRoute(ChangeJobTimeLimitSchema,
         jobId: +jobId, accountName: job.account, limitMinutes,
       },
     };
+
     return await asyncClientCall(client, "changeJobTimeLimit", {
       cluster,
       limitMinutes,

--- a/apps/mis-web/src/pages/api/job/changeJobTimeLimit.ts
+++ b/apps/mis-web/src/pages/api/job/changeJobTimeLimit.ts
@@ -66,7 +66,7 @@ export default typeboxRoute(ChangeJobTimeLimitSchema,
     const client = getClient(JobServiceClient);
 
     // check if the user can change the job time limit
-    const { job, jobAccessible } = await checkJobAccessible(jobId, cluster, info);
+    const { job, jobAccessible } = await checkJobAccessible(jobId, cluster, info, limitMinutes);
 
     if (jobAccessible === "NotAllowed") {
       return { 403: null };

--- a/libs/web/src/utils/datetime.ts
+++ b/libs/web/src/utils/datetime.ts
@@ -66,3 +66,25 @@ export function parseTime(time: string) {
   return seconds! * 1000 + minutes! * 60000 + (hours * 3600000) + days * 86400000;
 
 }
+
+
+export enum TimeUnits {
+  MINUTE = "MINUTE",
+  HOUR = "HOUR",
+  DAY = "DAY",
+}
+// Parse the given number of time value and time unit, return number of minutes
+export const parseMinutes = (time: number, unit: TimeUnits): number => {
+
+  switch (unit) {
+  case TimeUnits.MINUTE:
+    return time;
+  case TimeUnits.HOUR:
+    return time * 60;
+  case TimeUnits.DAY:
+    return time * 60 * 24;
+  }
+
+};
+
+


### PR DESCRIPTION
### 做了什么

**修改作业时限优化**
界面内容及细节优化，增加时间单位选择

修改前（用户ID应为作业ID，国际化项目名称对应错误）
![修改作业时限修改前单独](https://github.com/PKUHPC/SCOW/assets/43978285/6ee9101b-5910-482f-9eec-76e58231ed63)
![之前修改作业时限多作业](https://github.com/PKUHPC/SCOW/assets/43978285/50179b1b-eef8-4a9c-8844-0a393d0d394d)

修改后
![image](https://github.com/PKUHPC/SCOW/assets/43978285/bef88ce5-159c-49b4-a918-d1fc7da7306b)
![image](https://github.com/PKUHPC/SCOW/assets/43978285/2d2641eb-d538-4409-a87e-a54c33156ae2)


**BUG修复**
在生产环境中出现了修改作业时限时，同一集群下有两个相同作业id且其中一个状态为已结束，导致修改作业失败
 👇
修改作业时限时也需要指定查询作业运行中状态
修改作业时限也采用getJobs接口，并对jobId进行过滤