### PR TITLE
fix(docs): README中二维码没有正常展示

### DIFF
--- a/.changeset/wet-peaches-double.md
+++ b/.changeset/wet-peaches-double.md
@@ -1,0 +1,5 @@
+---
+"@scow/docs": patch
+---
+
+修改 README 中二维码图片的相对路径地址

--- a/README.en.md
+++ b/README.en.md
@@ -57,4 +57,4 @@ SCOW is distributed under [Mulan Permissive Software License, Version 2](http://
 
 ## Join SCOW Tech Group with a QR Scan
 
-![SCOW Tech Group](../SCOW/docs/static/img/scow_qrcode.png)
+![SCOW Tech Group](docs/static/img/scow_qrcode.png)

--- a/README.md
+++ b/README.md
@@ -57,4 +57,4 @@ SCOW 使用 [木兰宽松许可证, 第2版](http://license.coscl.org.cn/MulanPS
 
 ## 欢迎扫码加入SCOW技术交流群
 
-![SCOW技术交流群二维码](../SCOW/docs/static/img/scow_qrcode.png)
+![SCOW技术交流群二维码](docs/static/img/scow_qrcode.png)


### PR DESCRIPTION
### 问题：
README.md中的二维码无法正常展示
![image](https://github.com/PKUHPC/SCOW/assets/43978285/2ca27692-b773-4ec5-8999-6bacc445e206)
![image](https://github.com/PKUHPC/SCOW/assets/43978285/a3ff6f7b-dfe3-415c-8408-23ca9a60a9f5)


**修改：**
修改二维码的相对路径，不引入仓库名

当前分支可以正常解析路径展示图片
![image](https://github.com/PKUHPC/SCOW/assets/43978285/2204b137-b2e6-4af3-a733-7a1bab69bece)
