### PR TITLE
fix(tests): 修复一些测试问题

### DIFF
--- a/apps/mis-server/package.json
+++ b/apps/mis-server/package.json
@@ -8,7 +8,7 @@
     "dev": "dotenv -e env/.env.dev -- node --watch -r ts-node/register -r tsconfig-paths/register src/index.ts",
     "build": "rimraf build && tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
     "serve": "node build/index.js",
-    "test": "jest",
+    "test": "jest --forceExit",
     "orm": "dotenv -e env/.env.dev -- npx mikro-orm"
   },
   "files": [
@@ -44,6 +44,7 @@
     "@scow/lib-scheduler-adapter": "workspace:*",
     "@scow/utils": "workspace:*",
     "@sinclair/typebox": "0.31.1",
+    "dayjs": "1.11.9",
     "dotenv": "16.3.1",
     "node-cron": "3.0.2",
     "pino": "8.15.0",

--- a/apps/mis-server/src/entities/Account.ts
+++ b/apps/mis-server/src/entities/Account.ts
@@ -10,9 +10,9 @@
  * See the Mulan PSL v2 for more details.
  */
 
-import { Collection, Entity,
-  IdentifiedReference, ManyToOne, OneToMany, OneToOne, PrimaryKey, Property,
-} from "@mikro-orm/core";
+import { BooleanType, Collection, Entity,
+  ManyToOne, OneToMany, OneToOne, PrimaryKey, Property,
+  Ref } from "@mikro-orm/core";
 import { Decimal } from "@scow/lib-decimal";
 import { AccountWhitelist } from "src/entities/AccountWhitelist";
 import { Tenant } from "src/entities/Tenant";
@@ -29,7 +29,7 @@ export class Account {
     accountName: string;
 
   @ManyToOne(() => Tenant, { wrappedReference: true })
-    tenant: IdentifiedReference<Tenant>;
+    tenant: Ref<Tenant>;
 
   @Property()
     blocked: boolean;
@@ -40,7 +40,7 @@ export class Account {
   @OneToOne(() => AccountWhitelist, (u) => u.account, {
     nullable: true, wrappedReference: true, unique: true, owner: true,
   })
-    whitelist?: IdentifiedReference<AccountWhitelist>;
+    whitelist?: Ref<AccountWhitelist>;
 
   @Property({ default: "" })
     comment: string;

--- a/apps/mis-server/src/entities/AccountWhitelist.ts
+++ b/apps/mis-server/src/entities/AccountWhitelist.ts
@@ -10,7 +10,7 @@
  * See the Mulan PSL v2 for more details.
  */
 
-import { Entity, IdentifiedReference, OneToOne, PrimaryKey, Property } from "@mikro-orm/core";
+import { Entity, OneToOne, PrimaryKey, Property, Ref } from "@mikro-orm/core";
 import { Account } from "src/entities/Account";
 import { EntityOrRef, toRef } from "src/utils/orm";
 
@@ -20,7 +20,7 @@ export class AccountWhitelist {
     id!: number;
 
   @OneToOne(() => Account, (a) => a.whitelist, { wrappedReference: true, nullable: false, unique: true })
-    account: IdentifiedReference<Account>;
+    account: Ref<Account>;
 
   @Property()
     time: Date;

--- a/apps/mis-server/src/entities/JobPriceItem.ts
+++ b/apps/mis-server/src/entities/JobPriceItem.ts
@@ -10,7 +10,7 @@
  * See the Mulan PSL v2 for more details.
  */
 
-import { ArrayType, Entity, IdentifiedReference, ManyToOne, PrimaryKey, Property } from "@mikro-orm/core";
+import { ArrayType, Entity, ManyToOne, PrimaryKey, Property, Ref } from "@mikro-orm/core";
 import { Decimal } from "@scow/lib-decimal";
 import { Tenant } from "src/entities/Tenant";
 import { DecimalType } from "src/utils/decimal";
@@ -38,7 +38,7 @@ export class JobPriceItem {
     description: string;
 
   @ManyToOne(() => Tenant, { wrappedReference: true, nullable: true })
-    tenant?: IdentifiedReference<Tenant>;
+    tenant?: Ref<Tenant>;
 
   @Property({ type: DecimalType })
     price: Decimal;

--- a/apps/mis-server/src/entities/StorageQuota.ts
+++ b/apps/mis-server/src/entities/StorageQuota.ts
@@ -10,7 +10,7 @@
  * See the Mulan PSL v2 for more details.
  */
 
-import { Entity, IdentifiedReference, ManyToOne, PrimaryKey, Property } from
+import { Entity, ManyToOne, PrimaryKey, Property, Ref } from
   "@mikro-orm/core";
 import { User } from "src/entities/User";
 import { EntityOrRef, toRef } from "src/utils/orm";
@@ -21,7 +21,7 @@ export class StorageQuota {
     id!: number;
 
   @ManyToOne(() => User, { onDelete: "CASCADE", wrappedReference: true })
-    user: IdentifiedReference<User>;
+    user: Ref<User>;
 
   @Property()
     cluster: string;

--- a/apps/mis-server/src/entities/User.ts
+++ b/apps/mis-server/src/entities/User.ts
@@ -10,8 +10,7 @@
  * See the Mulan PSL v2 for more details.
  */
 
-import { Collection, Entity, Enum, IdentifiedReference,
-  ManyToOne, OneToMany, PrimaryKey, Property } from "@mikro-orm/core";
+import { Collection, Entity, Enum, ManyToOne, OneToMany, PrimaryKey, Property, Ref } from "@mikro-orm/core";
 import { StorageQuota } from "src/entities/StorageQuota";
 import { Tenant } from "src/entities/Tenant";
 import { UserAccount } from "src/entities/UserAccount";
@@ -33,7 +32,7 @@ export class User {
     id!: number;
 
   @ManyToOne(() => Tenant, { wrappedReference: true })
-    tenant: IdentifiedReference<Tenant>;
+    tenant: Ref<Tenant>;
 
   @Property({ unique: true })
     userId: string;

--- a/apps/mis-server/src/entities/UserAccount.ts
+++ b/apps/mis-server/src/entities/UserAccount.ts
@@ -10,8 +10,7 @@
  * See the Mulan PSL v2 for more details.
  */
 
-import { Entity, IdentifiedReference,
-  ManyToOne, PrimaryKey, Property } from "@mikro-orm/core";
+import { Entity, ManyToOne, PrimaryKey, Property, Ref } from "@mikro-orm/core";
 import { Decimal } from "@scow/lib-decimal";
 import { Account } from "src/entities/Account";
 import { User } from "src/entities/User";
@@ -35,10 +34,10 @@ export class UserAccount {
     id!: number;
 
   @ManyToOne(() => User, { onDelete: "CASCADE", wrappedReference: true })
-    user: IdentifiedReference<User>;
+    user: Ref<User>;
 
   @ManyToOne(() => Account, { onDelete: "CASCADE", wrappedReference: true })
-    account: IdentifiedReference<Account>;
+    account: Ref<Account>;
 
   @Property({ columnType: "varchar(10)", comment: Object.values(UserStatus).join(", ") })
     status: UserStatus;

--- a/apps/mis-server/src/utils/orm.ts
+++ b/apps/mis-server/src/utils/orm.ts
@@ -10,7 +10,7 @@
  * See the Mulan PSL v2 for more details.
  */
 
-import { IdentifiedReference, Reference } from "@mikro-orm/core";
+import { Ref, Reference } from "@mikro-orm/core";
 import { EntityManager } from "@mikro-orm/mysql";
 
 export const paginationProps = (page?: number, pageSize: number = 10) => ({
@@ -18,9 +18,9 @@ export const paginationProps = (page?: number, pageSize: number = 10) => ({
   limit: pageSize,
 });
 
-export type EntityOrRef<T> = T | IdentifiedReference<T>;
+export type EntityOrRef<T> = T | Ref<T>;
 
-export function toRef<T extends {}>(t: EntityOrRef<T>): IdentifiedReference<T> {
+export function toRef<T extends {}>(t: EntityOrRef<T>): Ref<T> {
   if (t instanceof Reference) {
     return t;
   } else {

--- a/apps/mis-server/tests/admin/whitelist.test.ts
+++ b/apps/mis-server/tests/admin/whitelist.test.ts
@@ -63,7 +63,7 @@ it("unblocks account when added to whitelist", async () => {
 
   await reloadEntity(em, a);
 
-  expect(a.blocked).toBeFalse();
+  expect(a.blocked).toBeFalsy();
 });
 
 it("blocks account when it is dewhitelisted and balance is < 0", async () => {
@@ -88,12 +88,12 @@ it("blocks account when it is dewhitelisted and balance is < 0", async () => {
     accountName: a.accountName,
   });
 
-  expect(resp.executed).toBeTrue();
+  expect(resp.executed).toBeTruthy();
 
   await em.refresh(a);
   await reloadEntity(em, a);
 
-  expect(a.blocked).toBeTrue();
+  expect(a.blocked).toBeTruthy();
 });
 
 it("blocks account when it is dewhitelisted and balance is = 0", async () => {
@@ -118,12 +118,12 @@ it("blocks account when it is dewhitelisted and balance is = 0", async () => {
     accountName: a.accountName,
   });
 
-  expect(resp.executed).toBeTrue();
+  expect(resp.executed).toBeTruthy();
 
   await em.refresh(a);
   await reloadEntity(em, a);
 
-  expect(a.blocked).toBeTrue();
+  expect(a.blocked).toBeTruthy();
 });
 
 it("charges user but don't block account if account is whitelist", async () => {
@@ -150,7 +150,7 @@ it("charges user but don't block account if account is whitelist", async () => {
   expect(currentBalance.toNumber()).toBe(-1);
   expect(previousBalance.toNumber()).toBe(1);
 
-  expect(a.blocked).toBeFalse();
+  expect(a.blocked).toBeFalsy();
 
 });
 

--- a/apps/mis-server/tests/charging/charging.test.ts
+++ b/apps/mis-server/tests/charging/charging.test.ts
@@ -130,7 +130,7 @@ it("pays account with negative amount to block account", async () => {
   expect(moneyToNumber(reply.currentBalance!)).toBe(0);
 
   await reloadEntity(em, account);
-  expect(account.blocked).toBe(true);
+  expect(account.blocked).toBeTruthy();
 });
 
 it("concurrently pays", async () => {

--- a/apps/mis-server/tests/charging/charging.test.ts
+++ b/apps/mis-server/tests/charging/charging.test.ts
@@ -17,6 +17,7 @@ import * as grpc from "@grpc/grpc-js";
 import { SqlEntityManager } from "@mikro-orm/mysql";
 import { Decimal, moneyToNumber, numberToMoney } from "@scow/lib-decimal";
 import { ChargeRequest, ChargingServiceClient, PaymentRecord, PayRequest } from "@scow/protos/build/server/charging";
+import dayjs from "dayjs";
 import { createServer } from "src/app";
 import { Account } from "src/entities/Account";
 import { ChargeRecord } from "src/entities/ChargeRecord";
@@ -124,12 +125,12 @@ it("pays account with negative amount to block account", async () => {
     type: "test",
   });
 
-  await reloadEntity(em, account);
 
   expect(moneyToNumber(reply.previousBalance!)).toBe(5);
   expect(moneyToNumber(reply.currentBalance!)).toBe(0);
-  expect(account.blocked).toBe(true);
 
+  await reloadEntity(em, account);
+  expect(account.blocked).toBe(true);
 });
 
 it("concurrently pays", async () => {
@@ -309,10 +310,13 @@ it("returns payment records", async () => {
   expect(account.balance.toNumber()).toBe(10);
   expect(account.tenant.getProperty("balance").toNumber()).toBe(20);
 
+  // Set a future time to ensure all latest records are fetched
+  const endTime = dayjs().add(1, "day").toISOString();
+
   // accountOfTenant
   const reply1 = await asyncClientCall(client, "getPaymentRecords", {
     startTime: startTime.toISOString(),
-    endTime: new Date().toISOString(),
+    endTime,
     target:{ $case:"accountOfTenant", accountOfTenant:{ accountName: account.accountName,
       tenantName: account.tenant.getProperty("name") } },
   });
@@ -332,7 +336,7 @@ it("returns payment records", async () => {
   const reply2 = await asyncClientCall(client, "getPaymentRecords", {
     target:{ $case:"tenant", tenant:{ tenantName: account.tenant.getProperty("name") } },
     startTime: startTime.toISOString(),
-    endTime: new Date().toISOString(),
+    endTime,
   });
 
   expect(reply2.results).toHaveLength(1);
@@ -351,7 +355,7 @@ it("returns payment records", async () => {
   const reply3 = await asyncClientCall(client, "getPaymentRecords", {
     target:{ $case: "allTenants", allTenants:{} },
     startTime: startTime.toISOString(),
-    endTime: new Date().toISOString(),
+    endTime,
   });
 
   expect(reply3.results).toHaveLength(2);
@@ -376,7 +380,7 @@ it("returns payment records", async () => {
   // accountsOfTenant
   const reply4 = await asyncClientCall(client, "getPaymentRecords", {
     startTime: startTime.toISOString(),
-    endTime: new Date().toISOString(),
+    endTime,
     target:{ $case:"accountsOfTenant", accountsOfTenant:{
       tenantName: account.tenant.getProperty("name") } },
   });

--- a/apps/mis-server/tests/init/customStrategy.test.ts
+++ b/apps/mis-server/tests/init/customStrategy.test.ts
@@ -73,7 +73,7 @@ import { dropDatabase } from "tests/data/helpers";
 afterEach(async () => {
   await dropDatabase(server.ext.orm);
   await server.close();
-  fs.rmSync(folderPath, { recursive: true });
+  await fs.promises.rm(folderPath, { recursive: true });
 });
 
 

--- a/apps/portal-server/tests/file/utils.ts
+++ b/apps/portal-server/tests/file/utils.ts
@@ -122,7 +122,7 @@ export async function createVscodeLastSubmitFile(sftp: SFTPWrapper, filePath: st
     nodeCount: 1,
     coreCount: 2,
     maxTime: 10,
-    submitTime: "2021-12-22T16:16:02",
+    submitTime: "2021-12-22T16:16:02.000Z",
     customAttributes: { selectVersion: "code-server/4.9.0", sbatchOptions: "--time 10" },
   };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 patchedDependencies:
   react-typed-i18n@2.3.0:
     hash: eybujl4up7xenffji6zpg43f3u
@@ -134,16 +138,16 @@ importers:
         version: 1.8.21
       '@mikro-orm/cli':
         specifier: 5.7.14
-        version: 5.7.14(@mikro-orm/mariadb@5.7.14)(@mikro-orm/migrations@5.7.14)(@mikro-orm/mysql@5.7.14)(@mikro-orm/seeder@5.7.14)
+        version: 5.7.14(@mikro-orm/migrations@5.7.14)(@mikro-orm/mysql@5.7.14)
       '@mikro-orm/core':
         specifier: 5.7.14
-        version: 5.7.14(@mikro-orm/mariadb@5.7.14)(@mikro-orm/migrations@5.7.14)(@mikro-orm/mysql@5.7.14)(@mikro-orm/seeder@5.7.14)
+        version: 5.7.14(@mikro-orm/migrations@5.7.14)(@mikro-orm/mysql@5.7.14)
       '@mikro-orm/migrations':
         specifier: 5.7.14
         version: 5.7.14(@mikro-orm/core@5.7.14)
       '@mikro-orm/mysql':
         specifier: 5.7.14
-        version: 5.7.14(@mikro-orm/core@5.7.14)(@mikro-orm/migrations@5.7.14)(@mikro-orm/seeder@5.7.14)
+        version: 5.7.14(@mikro-orm/core@5.7.14)(@mikro-orm/migrations@5.7.14)
       '@scow/config':
         specifier: workspace:*
         version: link:../../libs/config
@@ -406,6 +410,9 @@ importers:
       '@sinclair/typebox':
         specifier: 0.31.1
         version: 0.31.1
+      dayjs:
+        specifier: 1.11.9
+        version: 1.11.9
       dotenv:
         specifier: 16.3.1
         version: 16.3.1
@@ -5822,6 +5829,63 @@ packages:
       - tedious
     dev: false
 
+  /@mikro-orm/cli@5.7.14(@mikro-orm/migrations@5.7.14)(@mikro-orm/mysql@5.7.14):
+    resolution: {integrity: sha512-+Npl7TGQvJBli8rVmFpBOJ/5ivWL8Ui2YxszMAK2n2hwFXxPomk3ySccG4E9KTsvEdph4KGA08UONlNB1VIquQ==}
+    engines: {node: '>= 14.0.0'}
+    hasBin: true
+    peerDependencies:
+      '@mikro-orm/better-sqlite': ^5.0.0
+      '@mikro-orm/entity-generator': ^5.0.0
+      '@mikro-orm/mariadb': ^5.0.0
+      '@mikro-orm/migrations': ^5.0.0
+      '@mikro-orm/migrations-mongodb': ^5.0.0
+      '@mikro-orm/mongodb': ^5.0.0
+      '@mikro-orm/mysql': ^5.0.0
+      '@mikro-orm/postgresql': ^5.0.0
+      '@mikro-orm/seeder': ^5.0.0
+      '@mikro-orm/sqlite': ^5.0.0
+    peerDependenciesMeta:
+      '@mikro-orm/better-sqlite':
+        optional: true
+      '@mikro-orm/entity-generator':
+        optional: true
+      '@mikro-orm/mariadb':
+        optional: true
+      '@mikro-orm/migrations':
+        optional: true
+      '@mikro-orm/migrations-mongodb':
+        optional: true
+      '@mikro-orm/mongodb':
+        optional: true
+      '@mikro-orm/mysql':
+        optional: true
+      '@mikro-orm/postgresql':
+        optional: true
+      '@mikro-orm/seeder':
+        optional: true
+      '@mikro-orm/sqlite':
+        optional: true
+    dependencies:
+      '@jercle/yargonaut': 1.1.5
+      '@mikro-orm/core': 5.7.14(@mikro-orm/migrations@5.7.14)(@mikro-orm/mysql@5.7.14)
+      '@mikro-orm/knex': 5.7.14(@mikro-orm/core@5.7.14)(@mikro-orm/migrations@5.7.14)(mysql2@3.5.2)
+      '@mikro-orm/migrations': 5.7.14(@mikro-orm/core@5.7.14)
+      '@mikro-orm/mysql': 5.7.14(@mikro-orm/core@5.7.14)(@mikro-orm/migrations@5.7.14)
+      fs-extra: 11.1.1
+      tsconfig-paths: 4.2.0
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - better-sqlite3
+      - mssql
+      - mysql
+      - mysql2
+      - pg
+      - pg-native
+      - sqlite3
+      - supports-color
+      - tedious
+    dev: false
+
   /@mikro-orm/core@5.7.14(@mikro-orm/mariadb@5.7.14)(@mikro-orm/migrations@5.7.14)(@mikro-orm/mysql@5.7.14)(@mikro-orm/seeder@5.7.14):
     resolution: {integrity: sha512-og2TJ4mRdGKF8ok/xSdGNbznm+WFF6VJosJnneulmY4VirRNfDfp7uNPBOinewigS4Q8Ntdirmponx4KrOoMBg==}
     engines: {node: '>= 14.0.0'}
@@ -5871,6 +5935,53 @@ packages:
       reflect-metadata: 0.1.13
     dev: false
 
+  /@mikro-orm/core@5.7.14(@mikro-orm/migrations@5.7.14)(@mikro-orm/mysql@5.7.14):
+    resolution: {integrity: sha512-og2TJ4mRdGKF8ok/xSdGNbznm+WFF6VJosJnneulmY4VirRNfDfp7uNPBOinewigS4Q8Ntdirmponx4KrOoMBg==}
+    engines: {node: '>= 14.0.0'}
+    peerDependencies:
+      '@mikro-orm/better-sqlite': ^5.0.0
+      '@mikro-orm/entity-generator': ^5.0.0
+      '@mikro-orm/mariadb': ^5.0.0
+      '@mikro-orm/migrations': ^5.0.0
+      '@mikro-orm/migrations-mongodb': ^5.0.0
+      '@mikro-orm/mongodb': ^5.0.0
+      '@mikro-orm/mysql': ^5.0.0
+      '@mikro-orm/postgresql': ^5.0.0
+      '@mikro-orm/seeder': ^5.0.0
+      '@mikro-orm/sqlite': ^5.0.0
+    peerDependenciesMeta:
+      '@mikro-orm/better-sqlite':
+        optional: true
+      '@mikro-orm/entity-generator':
+        optional: true
+      '@mikro-orm/mariadb':
+        optional: true
+      '@mikro-orm/migrations':
+        optional: true
+      '@mikro-orm/migrations-mongodb':
+        optional: true
+      '@mikro-orm/mongodb':
+        optional: true
+      '@mikro-orm/mysql':
+        optional: true
+      '@mikro-orm/postgresql':
+        optional: true
+      '@mikro-orm/seeder':
+        optional: true
+      '@mikro-orm/sqlite':
+        optional: true
+    dependencies:
+      '@mikro-orm/migrations': 5.7.14(@mikro-orm/core@5.7.14)
+      '@mikro-orm/mysql': 5.7.14(@mikro-orm/core@5.7.14)(@mikro-orm/migrations@5.7.14)
+      acorn-loose: 8.3.0
+      acorn-walk: 8.2.0
+      dotenv: 16.3.1
+      fs-extra: 11.1.1
+      globby: 11.1.0
+      mikro-orm: 5.7.14
+      reflect-metadata: 0.1.13
+    dev: false
+
   /@mikro-orm/knex@5.7.14(@mikro-orm/core@5.7.14)(@mikro-orm/migrations@5.7.14)(mysql2@3.5.2):
     resolution: {integrity: sha512-dLw80JiOfQ6YBtKXI3j0C31lYfbWlytZUpXFM4tEKlMbAMmSbPqDgZpiF3luxBKTg3JpsnGSK0urBOxL1c/m+g==}
     engines: {node: '>= 14.0.0'}
@@ -5902,7 +6013,7 @@ packages:
       sqlite3:
         optional: true
     dependencies:
-      '@mikro-orm/core': 5.7.14(@mikro-orm/mariadb@5.7.14)(@mikro-orm/migrations@5.7.14)(@mikro-orm/mysql@5.7.14)(@mikro-orm/seeder@5.7.14)
+      '@mikro-orm/core': 5.7.14(@mikro-orm/migrations@5.7.14)(@mikro-orm/mysql@5.7.14)
       '@mikro-orm/migrations': 5.7.14(@mikro-orm/core@5.7.14)
       fs-extra: 11.1.1
       knex: 2.5.1(mysql2@3.5.2)
@@ -5953,7 +6064,7 @@ packages:
     peerDependencies:
       '@mikro-orm/core': ^5.0.0
     dependencies:
-      '@mikro-orm/core': 5.7.14(@mikro-orm/mariadb@5.7.14)(@mikro-orm/migrations@5.7.14)(@mikro-orm/mysql@5.7.14)(@mikro-orm/seeder@5.7.14)
+      '@mikro-orm/core': 5.7.14(@mikro-orm/migrations@5.7.14)(@mikro-orm/mysql@5.7.14)
       '@mikro-orm/knex': 5.7.14(@mikro-orm/core@5.7.14)(@mikro-orm/migrations@5.7.14)(mysql2@3.5.2)
       fs-extra: 11.1.1
       knex: 2.5.1(mysql2@3.5.2)
@@ -5964,6 +6075,37 @@ packages:
       - mssql
       - mysql
       - mysql2
+      - pg
+      - pg-native
+      - sqlite3
+      - supports-color
+      - tedious
+    dev: false
+
+  /@mikro-orm/mysql@5.7.14(@mikro-orm/core@5.7.14)(@mikro-orm/migrations@5.7.14):
+    resolution: {integrity: sha512-6VfVOMhKcqM72p197G9n+3suWx7fuaoKD4Fcl3rjILkiSS8uFNutgCoRdrjg/2TMEZSgywkZdorwVfPyH+1kbw==}
+    engines: {node: '>= 14.0.0'}
+    peerDependencies:
+      '@mikro-orm/core': ^5.0.0
+      '@mikro-orm/entity-generator': ^5.0.0
+      '@mikro-orm/migrations': ^5.0.0
+      '@mikro-orm/seeder': ^5.0.0
+    peerDependenciesMeta:
+      '@mikro-orm/entity-generator':
+        optional: true
+      '@mikro-orm/migrations':
+        optional: true
+      '@mikro-orm/seeder':
+        optional: true
+    dependencies:
+      '@mikro-orm/core': 5.7.14(@mikro-orm/migrations@5.7.14)(@mikro-orm/mysql@5.7.14)
+      '@mikro-orm/knex': 5.7.14(@mikro-orm/core@5.7.14)(@mikro-orm/migrations@5.7.14)(mysql2@3.5.2)
+      '@mikro-orm/migrations': 5.7.14(@mikro-orm/core@5.7.14)
+      mysql2: 3.5.2
+    transitivePeerDependencies:
+      - better-sqlite3
+      - mssql
+      - mysql
       - pg
       - pg-native
       - sqlite3
@@ -20420,7 +20562,3 @@ packages:
     name: tiny-inflate
     version: 1.0.3
     dev: false
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false


### PR DESCRIPTION
1. `apps/mis-server/tests/charging/charging.test.ts`的`concurrently pays`中，增加充值记录后查询新增的充值记录的endTime设置为当前时间往后一天，确保能获取到最新的记录
2. 所有关于测试一个Entity中的boolean属性是否为true/false的改为使用`toBeTruthy()`或者`toBeFalsy()`。因为当前配置下修改Entity的boolean属性后，重新读取出来的entity的这个属性为`1`或者`0`。无法重现这个问题。但是由于一般使用boolean字段都是使用是否为truthy值（包括true/1）来使用，一般不会主动判断是否`=== true/false`来使用，所以对业务逻辑影响不大。
3. mis-server的test命令增加`--forceExit`强制退出jest进程，暂时忽略仍有后台线程的情况。
4. （测试无关改动）将deprecated的`IdentifiableReference`改为`Reference`