### PR TITLE
feat(auth): 登录界面UI新增根据不同域名展示不同内容

### DIFF
--- a/.changeset/fuzzy-drinks-march.md
+++ b/.changeset/fuzzy-drinks-march.md
@@ -1,0 +1,6 @@
+---
+"@scow/auth": patch
+"@scow/docs": patch
+---
+
+登录界面 UI 新增根据不同域名展示不同内容

--- a/.changeset/twenty-phones-warn.md
+++ b/.changeset/twenty-phones-warn.md
@@ -1,0 +1,6 @@
+---
+"@scow/auth": patch
+"@scow/docs": patch
+---
+
+登录界面新增根据域名显示不同的背景颜色和背景图片

--- a/apps/auth/config/auth.yml
+++ b/apps/auth/config/auth.yml
@@ -85,9 +85,23 @@ ssh:
 # auth 界面 ui 配置
 ui:
   # 登录界面背景图
-  backgroundImagePath: "./assets/background.png"
+  backgroundImage:
+
+    defaultPath: "./assets/background.png"
+
+    # 对具体hostname生效的生效，可以不填
+    # hostnameMap:
+    #   a.com: "./assets/background1.png"
+
   # 登录界面背景色，当背景图无法加载时，背景色起效
-  backgroundFallbackColor: "#8c8c8c"
+  backgroundFallbackColor:
+
+    defaultColor: "#8c8c8c"
+
+    # 对具体hostname生效的生效，可以不填
+    # hostnameMap:
+    #   a.com: "#fff"
+    
   # 登录界面 logo 图,
   logo:
     # 如果没有配置自定义 logo, 则使用 type 选择 SCOW Logo

--- a/apps/auth/config/auth.yml
+++ b/apps/auth/config/auth.yml
@@ -84,47 +84,110 @@ ssh:
 
 # auth 界面 ui 配置
 ui:
-  # 登录界面背景图
-  backgroundImage:
+  default:
+    # 登录界面背景图
+    backgroundImagePath: "./assets/background.png"
 
-    defaultPath: "./assets/background.png"
+    # 登录界面背景色，当背景图无法加载时，背景色起效
+    backgroundFallbackColor: "#8c8c8c"
 
-    # 对具体hostname生效的生效，可以不填
-    # hostnameMap:
-    #   a.com: "./assets/background1.png"
+    # 登录界面 logo 图,
+    logo:
+      # 如果没有配置自定义 logo, 则使用 type 选择 SCOW Logo
+      # light: 亮色模式下的 logo, dark: 黑暗模式下的 logo
+      scowLogoType: "dark"
+      # 自定义 logo, 默认为空
+      customLogoPath: ""
+      # 自定义点击 logo 跳转地址
+      customLogoLink: "https://icode.pku.edu.cn/SCOW/"
 
-  # 登录界面背景色，当背景图无法加载时，背景色起效
-  backgroundFallbackColor:
+    # 登录界面 slogan 配置
+    slogan:
+      # 登录界面 slogan 文字颜色
+      color: "white"
+      # 登录界面 slogan title
+      title: "开源算力中心门户和管理平台"
+      # title:
+      #   i18n:
+      #     default: "开源算力中心门户和管理平台"
+      #     zh_cn: "开源算力中心门户和管理平台"
+      # 多条 slogan 文本
+      texts:
+        - "图形化界面，使用方便"
+        - "功能丰富，管理简单"
+        - "一体化部署，开箱即用"
+        - "标准化平台，支持算力融合"
+        - "开源中立，独立自主"
+      #   texts:
+      #     - i18n:
+      #         default: "图形化界面，使用方便"
+      #         en: "Graphical user interface, user-friendly"
+      #         zh_cn: "图形化界面，使用方便"
+      #     - i18n:
+      #         default: "功能丰富，管理简单"
+      #         en: "Feature-rich, easy management"
+      #         zh_cn: "功能丰富，管理简单"
+      #     - i18n:
+      #         default: "一体化部署，开箱即用"
+      #         en: "Integrated deployment, ready to use out of the box"
+      #         zh_cn: "一体化部署，开箱即用"
+      #     - i18n:
+      #         default: "标准化平台，支持算力融合"
+      #         en: "Standardized platform, supporting compute integration"
+      #         zh_cn: "标准化平台，支持算力融合"
+      #     - i18n:
+      #         default: "开源中立，独立自主"
+      #         en: "Open-source neutrality, independent and autonomous"
+      #         zh_cn: "开源中立，独立自主"
+      #     - i18n:
+      #         default: "体验账号/密码如下，欢迎试用体验SCOW各项功能"
+      #         en: "Trial account details are as follows; you are welcome to try and experience the functionalities of SCOW."
+      #         zh_cn: "体验账号/密码如下，欢迎试用体验SCOW各项功能"
+      #     - i18n:
+      #         default: "管理员：demo_admin / demo_admin"
+      #         en: "Administrator: demo_admin / demo_admin"
+      #         zh_cn: "管理员：demo_admin / demo_admin"
+      #     - i18n:
+      #         default: "普通用户：demo_user / demo_user"
+      #         en: "Regular User: demo_user / demo_user"
+      #         zh_cn: "普通用户：demo_user / demo_user"
 
-    defaultColor: "#8c8c8c"
+    # 登陆界面底部 Power By 字体颜色配置
+    footerTextColor: "white"
 
-    # 对具体hostname生效的生效，可以不填
-    # hostnameMap:
-    #   a.com: "#fff"
-    
-  # 登录界面 logo 图,
-  logo:
-    # 如果没有配置自定义 logo, 则使用 type 选择 SCOW Logo
-    # light: 亮色模式下的 logo, dark: 黑暗模式下的 logo
-    scowLogoType: "dark"
-    # 自定义 logo, 默认为空
-    customLogoPath: ""
-    # 自定义点击 logo 跳转地址
-    customLogoLink: "https://icode.pku.edu.cn/SCOW/"
+  # 根据不域名进行不同的展示，对具体hostname生效的生效，可以不填
+  # hostnameMap:
 
-  # 登录界面 slogan 配置
-  slogan:
-    # 登录界面 slogan 文字颜色
-    color: "white"
-    # 登录界面 slogan title
-    title: "开源算力中心门户和管理平台"
-    # 多条 slogan 文本
-    texts:
-      - "图形化界面，使用方便"
-      - "功能丰富，管理简单"
-      - "一体化部署，开箱即用"
-      - "标准化平台，支持算力融合"
-      - "开源中立，独立自主"
+  #   a.com:
+  #     # 登录界面背景图
+  #     backgroundImagePath: "./assets/background1.png"
 
-  # 登陆界面底部 Power By 字体颜色配置
-  footerTextColor: "white"
+  #     # 登录界面背景色，当背景图无法加载时，背景色起效
+  #     backgroundFallbackColor: "#000"
+
+  #     # 登录界面 logo 图,
+  #     logo:
+  #       # 如果没有配置自定义 logo, 则使用 type 选择 SCOW Logo
+  #       # light: 亮色模式下的 logo, dark: 黑暗模式下的 logo
+  #       scowLogoType: "light"
+  #       # 自定义 logo, 默认为空
+  #       customLogoPath: ""
+  #       # 自定义点击 logo 跳转地址
+  #       customLogoLink: "https://icode.pku.edu.cn/SCOW/"
+
+  #     # 登录界面 slogan 配置
+  #     slogan:
+  #       # 登录界面 slogan 文字颜色
+  #       color: "black"
+  #       # 登录界面 slogan title
+  #       title: "开源算力中心门户和管理平台"
+  #       # 多条 slogan 文本
+  #       texts:
+  #         - "图形化界面，使用方便."
+  #         - "功能丰富，管理简单."
+  #         - "一体化部署，开箱即用."
+  #         - "标准化平台，支持算力融合."
+  #         - "开源中立，独立自主."
+
+  #     # 登陆界面底部 Power By 字体颜色配置
+  #     footerTextColor: "black"

--- a/apps/auth/src/auth/bindOtpHtml.ts
+++ b/apps/auth/src/auth/bindOtpHtml.ts
@@ -17,21 +17,7 @@ import { join } from "path";
 import { config, FAVICON_URL } from "src/config/env";
 import { uiConfig } from "src/config/ui";
 import { AuthTextsType, languages } from "src/i18n";
-
-
-function parseHostname(req: FastifyRequest): string | undefined {
-
-  if (!req.headers.referer) {
-    return undefined;
-  }
-
-  try {
-    const url = new URL(req.headers.referer);
-    return url.hostname;
-  } catch {
-    return undefined;
-  }
-}
+import { parseHostname } from "src/utils/parseHostname";
 
 
 export async function renderBindOtpHtml(

--- a/apps/auth/src/auth/loginHtml.ts
+++ b/apps/auth/src/auth/loginHtml.ts
@@ -19,6 +19,7 @@ import { authConfig, OtpStatusOptions, ScowLogoType } from "src/config/auth";
 import { config, FAVICON_URL, LOGO_URL } from "src/config/env";
 import { uiConfig } from "src/config/ui";
 import { AuthTextsType, languages } from "src/i18n";
+import { parseHostname } from "src/utils/parseHostname";
 
 
 export async function serveLoginHtml(
@@ -26,6 +27,10 @@ export async function serveLoginHtml(
   verifyCaptchaFail?: boolean,
   verifyOtpFail?: boolean,
 ) {
+
+  const hostname = parseHostname(req);
+
+  console.log("123123", req.headers.referer);
 
   const enableCaptcha = authConfig.captcha.enabled;
   const enableTotp = authConfig.otp?.enabled;
@@ -55,8 +60,10 @@ export async function serveLoginHtml(
     eyeImagePath: join(config.BASE_PATH, config.AUTH_BASE_PATH, "/public/assets/icons/eye.png"),
     eyeCloseImagePath: join(config.BASE_PATH, config.AUTH_BASE_PATH, "/public/assets/icons/eye-close.png"),
     backgroundImagePath: join(config.BASE_PATH, config.PUBLIC_PATH,
-      authConfig.ui?.backgroundImagePath ?? "./assets/background.png"),
-    backgroundFallbackColor: authConfig.ui?.backgroundFallbackColor || "#8c8c8c",
+      (hostname && authConfig.ui?.backgroundImage.hostnameMap?.[hostname])
+      ?? authConfig.ui?.backgroundImage.defaultPath ?? "./assets/background.png"),
+    backgroundFallbackColor: (hostname && authConfig.ui?.backgroundFallbackColor.hostnameMap?.[hostname])
+      || authConfig.ui?.backgroundFallbackColor.defaultColor || "#8c8c8c",
     faviconUrl: join(config.BASE_PATH, FAVICON_URL),
     logoUrl: !!authConfig.ui?.logo.customLogoPath === false ?
       join(config.PORTAL_BASE_PATH, LOGO_URL + logoPreferDarkParam)

--- a/apps/auth/src/auth/loginHtml.ts
+++ b/apps/auth/src/auth/loginHtml.ts
@@ -21,7 +21,6 @@ import { uiConfig } from "src/config/ui";
 import { AuthTextsType, languages } from "src/i18n";
 import { parseHostname } from "src/utils/parseHostname";
 
-
 export async function serveLoginHtml(
   err: boolean, callbackUrl: string, req: FastifyRequest, rep: FastifyReply,
   verifyCaptchaFail?: boolean,
@@ -29,12 +28,13 @@ export async function serveLoginHtml(
 ) {
 
   const hostname = parseHostname(req);
-
-  console.log("123123", req.headers.referer);
+  const authUiHostnameConfig = (hostname && authConfig.ui?.hostnameMap?.[hostname]) || undefined;
+  const authUiDefaultConfig = authConfig.ui?.default;
 
   const enableCaptcha = authConfig.captcha.enabled;
   const enableTotp = authConfig.otp?.enabled;
-  const logoPreferDarkParam = authConfig.ui?.logo.scowLogoType === ScowLogoType.light ? "false" : "true";
+  const logoPreferDarkParam = (authUiHostnameConfig?.logo?.scowLogoType
+    || authUiDefaultConfig?.logo.scowLogoType) === ScowLogoType.light ? "false" : "true";
 
   // 显示绑定otp按钮：otp.enabled为true && (密钥存于ldap时 || (otp.type===remote && 配置了otp.remote.redirectUrl))
   const showBindOtpButton = authConfig.otp?.enabled && (authConfig.otp?.type === OtpStatusOptions.ldap
@@ -48,8 +48,9 @@ export async function serveLoginHtml(
   const authTexts: AuthTextsType = languages[languageId];
 
   // 获取sloganI18nText
-  const sloganTitle = getI18nConfigCurrentText(authConfig.ui?.slogan.title, languageId);
-  const sloganTextArr = authConfig.ui?.slogan.texts.map((text) => {
+  const sloganTitle = getI18nConfigCurrentText(
+    authUiHostnameConfig?.slogan?.title ?? authUiDefaultConfig?.slogan.title, languageId);
+  const sloganTextArr = (authUiHostnameConfig?.slogan?.texts ?? authUiDefaultConfig?.slogan.texts)?.map((text) => {
     return getI18nConfigCurrentText(text, languageId);
   });
 
@@ -60,20 +61,20 @@ export async function serveLoginHtml(
     eyeImagePath: join(config.BASE_PATH, config.AUTH_BASE_PATH, "/public/assets/icons/eye.png"),
     eyeCloseImagePath: join(config.BASE_PATH, config.AUTH_BASE_PATH, "/public/assets/icons/eye-close.png"),
     backgroundImagePath: join(config.BASE_PATH, config.PUBLIC_PATH,
-      (hostname && authConfig.ui?.backgroundImage.hostnameMap?.[hostname])
-      ?? authConfig.ui?.backgroundImage.defaultPath ?? "./assets/background.png"),
-    backgroundFallbackColor: (hostname && authConfig.ui?.backgroundFallbackColor.hostnameMap?.[hostname])
-      || authConfig.ui?.backgroundFallbackColor.defaultColor || "#8c8c8c",
+      authUiHostnameConfig?.backgroundImagePath
+      ?? authUiDefaultConfig?.backgroundImagePath ?? "./assets/background.png"),
+    backgroundFallbackColor: authUiHostnameConfig?.backgroundFallbackColor
+      || authUiDefaultConfig?.backgroundFallbackColor || "#8c8c8c",
     faviconUrl: join(config.BASE_PATH, FAVICON_URL),
-    logoUrl: !!authConfig.ui?.logo.customLogoPath === false ?
-      join(config.PORTAL_BASE_PATH, LOGO_URL + logoPreferDarkParam)
-      : join(config.BASE_PATH, config.PUBLIC_PATH, authConfig.ui?.logo.customLogoPath ?? ""),
-    logoLink: authConfig.ui?.logo.customLogoLink ?? "",
+    logoUrl: !!(authUiHostnameConfig?.logo?.customLogoPath || authUiDefaultConfig?.logo.customLogoPath) === false ?
+      join(config.PORTAL_BASE_PATH, LOGO_URL + logoPreferDarkParam) : join(config.BASE_PATH, config.PUBLIC_PATH,
+        (authUiHostnameConfig?.logo?.customLogoPath || authUiDefaultConfig?.logo.customLogoPath) ?? ""),
+    logoLink: authUiHostnameConfig?.logo?.customLogoLink ?? authUiDefaultConfig?.logo.customLogoLink ?? "",
     callbackUrl,
-    sloganColor: authConfig.ui?.slogan.color || "white",
+    sloganColor: authUiHostnameConfig?.slogan?.color || authUiDefaultConfig?.slogan?.color || "white",
     sloganTitle: sloganTitle || "",
     sloganTextArr: sloganTextArr || [],
-    footerTextColor: authConfig.ui?.footerTextColor || "white",
+    footerTextColor: authUiHostnameConfig?.footerTextColor || authUiDefaultConfig?.footerTextColor || "white",
     themeColor: uiConfig.primaryColor?.defaultColor ?? DEFAULT_PRIMARY_COLOR,
     err,
     ...captchaInfo,

--- a/apps/auth/src/config/auth.ts
+++ b/apps/auth/src/config/auth.ts
@@ -171,8 +171,16 @@ export const OtpLdapSchema = Type.Object({
 }, { description: "将otp密钥存在ldap需要配置信息" });
 
 export const UiConfigSchema = Type.Object({
-  backgroundImagePath: Type.String({ description: "默认背景图片", default: "./assets/background.png" }),
-  backgroundFallbackColor: Type.String({ description: "默认背景颜色", default: "#8c8c8c" }),
+  backgroundImage: Type.Object({
+    defaultPath: Type.String({ description: "默认背景图片", default: "./assets/background.png" }),
+    hostnameMap: Type.Optional(Type.Record(Type.String(), Type.String(),
+      { description: "根据不同域名（hostname,不包括port），显示的背景图片" })),
+  }),
+  backgroundFallbackColor: Type.Object({
+    defaultColor: Type.String({ description: "默认背景颜色", default: "#8c8c8c" }),
+    hostnameMap: Type.Optional(Type.Record(Type.String(), Type.String(),
+      { description: "根据不同域名（hostname,不包括port），显示的背景颜色" })),
+  }),
   logo: Type.Object({
     scowLogoType: Type.Enum(ScowLogoType, { description: "scow logo 类型", default: ScowLogoType.dark }),
     customLogoPath: Type.Optional(Type.String({ description: "用户自定义 logo 图片" })),

--- a/apps/auth/src/config/auth.ts
+++ b/apps/auth/src/config/auth.ts
@@ -171,27 +171,36 @@ export const OtpLdapSchema = Type.Object({
 }, { description: "将otp密钥存在ldap需要配置信息" });
 
 export const UiConfigSchema = Type.Object({
-  backgroundImage: Type.Object({
-    defaultPath: Type.String({ description: "默认背景图片", default: "./assets/background.png" }),
-    hostnameMap: Type.Optional(Type.Record(Type.String(), Type.String(),
-      { description: "根据不同域名（hostname,不包括port），显示的背景图片" })),
+  default: Type.Object({
+    backgroundImagePath: Type.String({ description: "默认背景图片", default: "./assets/background.png" }),
+    backgroundFallbackColor: Type.String({ description: "默认背景颜色", default: "#8c8c8c" }),
+    logo: Type.Object({
+      scowLogoType: Type.Enum(ScowLogoType, { description: "scow logo 类型", default: ScowLogoType.dark }),
+      customLogoPath: Type.Optional(Type.String({ description: "用户自定义 logo 图片" })),
+      customLogoLink: Type.Optional(Type.String({ description: "用户自定义点击 logo 跳转链接" })),
+    }, { default: {} }),
+    slogan: Type.Object({
+      color: Type.String({ description: "默认标语文字颜色", default: "white" }),
+      title: createI18nStringSchema("默认标语标题", ""),
+      texts: Type.Array(createI18nStringSchema(""), { description: "默认 slogan 正文数组", default: []}),
+    }, { default: {} }),
+    footerTextColor: Type.String({ description: "默认 footer 文字颜色", default: "white" }),
   }),
-  backgroundFallbackColor: Type.Object({
-    defaultColor: Type.String({ description: "默认背景颜色", default: "#8c8c8c" }),
-    hostnameMap: Type.Optional(Type.Record(Type.String(), Type.String(),
-      { description: "根据不同域名（hostname,不包括port），显示的背景颜色" })),
-  }),
-  logo: Type.Object({
-    scowLogoType: Type.Enum(ScowLogoType, { description: "scow logo 类型", default: ScowLogoType.dark }),
-    customLogoPath: Type.Optional(Type.String({ description: "用户自定义 logo 图片" })),
-    customLogoLink: Type.Optional(Type.String({ description: "用户自定义点击 logo 跳转链接" })),
-  }, { default: {} }),
-  slogan: Type.Object({
-    color: Type.String({ description: "默认标语文字颜色", default: "white" }),
-    title: createI18nStringSchema("默认标语标题", ""),
-    texts: Type.Array(createI18nStringSchema(""), { description: "默认 slogan 正文数组", default: []}),
-  }, { default: {} }),
-  footerTextColor: Type.String({ description: "默认 footer 文字颜色", default: "white" }),
+  hostnameMap: Type.Optional(Type.Record(Type.String(), Type.Object({
+    backgroundImagePath: Type.Optional(Type.String({ description: "默认背景图片" })),
+    backgroundFallbackColor: Type.Optional(Type.String({ description: "默认背景颜色" })),
+    logo: Type.Optional(Type.Object({
+      scowLogoType: Type.Optional(Type.Enum(ScowLogoType, { description: "scow logo 类型" })),
+      customLogoPath: Type.Optional(Type.String({ description: "用户自定义 logo 图片" })),
+      customLogoLink: Type.Optional(Type.String({ description: "用户自定义点击 logo 跳转链接" })),
+    })),
+    slogan: Type.Optional(Type.Object({
+      color: Type.String({ description: "默认标语文字颜色" }),
+      title: createI18nStringSchema("默认标语标题", ""),
+      texts: Type.Array(createI18nStringSchema(""), { description: "默认 slogan 正文数组" }),
+    })),
+    footerTextColor: Type.Optional(Type.String({ description: "默认 footer 文字颜色" })),
+  }))),
 });
 
 export const OtpConfigSchema = Type.Object({

--- a/apps/auth/src/utils/parseHostname.ts
+++ b/apps/auth/src/utils/parseHostname.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2022 Peking University and Peking University Institute for Computing and Digital Economy
+ * SCOW is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *          http://license.coscl.org.cn/MulanPSL2
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PSL v2 for more details.
+ */
+
+import { FastifyRequest } from "fastify";
+
+export function parseHostname(req: FastifyRequest): string | undefined {
+
+  if (!req.headers.referer) {
+    return undefined;
+  }
+
+  try {
+    const url = new URL(req.headers.referer);
+    return url.hostname;
+  } catch {
+    return undefined;
+  }
+}

--- a/dev/vagrant/config/auth.yml
+++ b/dev/vagrant/config/auth.yml
@@ -148,9 +148,23 @@ ldap:
 # auth 界面 ui 配置
 ui:
   # 登录界面背景图
-  backgroundImagePath: "./assets/background.png"
+  backgroundImage:
+
+    defaultPath: "./assets/background.png"
+
+    # 对具体hostname生效的生效，可以不填
+    # hostnameMap:
+    #   a.com: "./assets/background1.png"
+
   # 登录界面背景色，当背景图无法加载时，背景色起效
-  backgroundFallbackColor: "#8c8c8c"
+  backgroundFallbackColor:
+
+    defaultColor: "#8c8c8c"
+
+    # 对具体hostname生效的生效，可以不填
+    # hostnameMap:
+    #   a.com: "#fff"
+
   # 登录界面 logo 图,
   logo:
     # 如果没有配置自定义 logo, 则使用 type 选择 SCOW Logo

--- a/dev/vagrant/config/auth.yml
+++ b/dev/vagrant/config/auth.yml
@@ -147,84 +147,110 @@ ldap:
 
 # auth 界面 ui 配置
 ui:
-  # 登录界面背景图
-  backgroundImage:
+  default:
+    # 登录界面背景图
+    backgroundImagePath: "./assets/background.png"
 
-    defaultPath: "./assets/background.png"
+    # 登录界面背景色，当背景图无法加载时，背景色起效
+    backgroundFallbackColor: "#8c8c8c"
 
-    # 对具体hostname生效的生效，可以不填
-    # hostnameMap:
-    #   a.com: "./assets/background1.png"
+    # 登录界面 logo 图,
+    logo:
+      # 如果没有配置自定义 logo, 则使用 type 选择 SCOW Logo
+      # light: 亮色模式下的 logo, dark: 黑暗模式下的 logo
+      scowLogoType: "dark"
+      # 自定义 logo, 默认为空
+      customLogoPath: ""
+      # 自定义点击 logo 跳转地址
+      customLogoLink: "https://icode.pku.edu.cn/SCOW/"
 
-  # 登录界面背景色，当背景图无法加载时，背景色起效
-  backgroundFallbackColor:
+    # 登录界面 slogan 配置
+    slogan:
+      # 登录界面 slogan 文字颜色
+      color: "white"
+      # 登录界面 slogan title
+      title: "开源算力中心门户和管理平台"
+      # title:
+      #   i18n:
+      #     default: "开源算力中心门户和管理平台"
+      #     zh_cn: "开源算力中心门户和管理平台"
+      # 多条 slogan 文本
+      texts:
+        - "图形化界面，使用方便"
+        - "功能丰富，管理简单"
+        - "一体化部署，开箱即用"
+        - "标准化平台，支持算力融合"
+        - "开源中立，独立自主"
+      #   texts:
+      #     - i18n:
+      #         default: "图形化界面，使用方便"
+      #         en: "Graphical user interface, user-friendly"
+      #         zh_cn: "图形化界面，使用方便"
+      #     - i18n:
+      #         default: "功能丰富，管理简单"
+      #         en: "Feature-rich, easy management"
+      #         zh_cn: "功能丰富，管理简单"
+      #     - i18n:
+      #         default: "一体化部署，开箱即用"
+      #         en: "Integrated deployment, ready to use out of the box"
+      #         zh_cn: "一体化部署，开箱即用"
+      #     - i18n:
+      #         default: "标准化平台，支持算力融合"
+      #         en: "Standardized platform, supporting compute integration"
+      #         zh_cn: "标准化平台，支持算力融合"
+      #     - i18n:
+      #         default: "开源中立，独立自主"
+      #         en: "Open-source neutrality, independent and autonomous"
+      #         zh_cn: "开源中立，独立自主"
+      #     - i18n:
+      #         default: "体验账号/密码如下，欢迎试用体验SCOW各项功能"
+      #         en: "Trial account details are as follows; you are welcome to try and experience the functionalities of SCOW."
+      #         zh_cn: "体验账号/密码如下，欢迎试用体验SCOW各项功能"
+      #     - i18n:
+      #         default: "管理员：demo_admin / demo_admin"
+      #         en: "Administrator: demo_admin / demo_admin"
+      #         zh_cn: "管理员：demo_admin / demo_admin"
+      #     - i18n:
+      #         default: "普通用户：demo_user / demo_user"
+      #         en: "Regular User: demo_user / demo_user"
+      #         zh_cn: "普通用户：demo_user / demo_user"
 
-    defaultColor: "#8c8c8c"
+    # 登陆界面底部 Power By 字体颜色配置
+    footerTextColor: "white"
 
-    # 对具体hostname生效的生效，可以不填
-    # hostnameMap:
-    #   a.com: "#fff"
+  # 根据不域名进行不同的展示，对具体hostname生效的生效，可以不填
+  # hostnameMap:
 
-  # 登录界面 logo 图,
-  logo:
-    # 如果没有配置自定义 logo, 则使用 type 选择 SCOW Logo
-    # light: 亮色模式下的 logo, dark: 黑暗模式下的 logo
-    scowLogoType: "dark"
-    # 自定义 logo, 默认为空
-    customLogoPath: ""
-    # 自定义点击 logo 跳转地址
-    customLogoLink: "https://icode.pku.edu.cn/SCOW/"
+  #   a.com:
+  #     # 登录界面背景图
+  #     backgroundImagePath: "./assets/background1.png"
 
-  # 登录界面 slogan 配置
-  slogan:
-    # 登录界面 slogan 文字颜色
-    color: "white"
-    # 登录界面 slogan title
-    title: "开源算力中心门户和管理平台"
-    # title:
-    #   i18n:
-    #     default: "开源算力中心门户和管理平台"
-    #     zh_cn: "开源算力中心门户和管理平台"
-    # 多条 slogan 文本
-    texts:
-      - "图形化界面，使用方便"
-      - "功能丰富，管理简单"
-      - "一体化部署，开箱即用"
-      - "标准化平台，支持算力融合"
-      - "开源中立，独立自主"
-    #   texts:
-    #     - i18n:
-    #         default: "图形化界面，使用方便"
-    #         en: "Graphical user interface, user-friendly"
-    #         zh_cn: "图形化界面，使用方便"
-    #     - i18n:
-    #         default: "功能丰富，管理简单"
-    #         en: "Feature-rich, easy management"
-    #         zh_cn: "功能丰富，管理简单"
-    #     - i18n:
-    #         default: "一体化部署，开箱即用"
-    #         en: "Integrated deployment, ready to use out of the box"
-    #         zh_cn: "一体化部署，开箱即用"
-    #     - i18n:
-    #         default: "标准化平台，支持算力融合"
-    #         en: "Standardized platform, supporting compute integration"
-    #         zh_cn: "标准化平台，支持算力融合"
-    #     - i18n:
-    #         default: "开源中立，独立自主"
-    #         en: "Open-source neutrality, independent and autonomous"
-    #         zh_cn: "开源中立，独立自主"
-    #     - i18n:
-    #         default: "体验账号/密码如下，欢迎试用体验SCOW各项功能"
-    #         en: "Trial account details are as follows; you are welcome to try and experience the functionalities of SCOW."
-    #         zh_cn: "体验账号/密码如下，欢迎试用体验SCOW各项功能"
-    #     - i18n:
-    #         default: "管理员：demo_admin / demo_admin"
-    #         en: "Administrator: demo_admin / demo_admin"
-    #         zh_cn: "管理员：demo_admin / demo_admin"
-    #     - i18n:
-    #         default: "普通用户：demo_user / demo_user"
-    #         en: "Regular User: demo_user / demo_user"
-    #         zh_cn: "普通用户：demo_user / demo_user"
+  #     # 登录界面背景色，当背景图无法加载时，背景色起效
+  #     backgroundFallbackColor: "#000"
 
-  # 登陆界面底部 Power By 字体颜色配置
-  footerTextColor: "white"
+  #     # 登录界面 logo 图,
+  #     logo:
+  #       # 如果没有配置自定义 logo, 则使用 type 选择 SCOW Logo
+  #       # light: 亮色模式下的 logo, dark: 黑暗模式下的 logo
+  #       scowLogoType: "light"
+  #       # 自定义 logo, 默认为空
+  #       customLogoPath: ""
+  #       # 自定义点击 logo 跳转地址
+  #       customLogoLink: "https://icode.pku.edu.cn/SCOW/"
+
+  #     # 登录界面 slogan 配置
+  #     slogan:
+  #       # 登录界面 slogan 文字颜色
+  #       color: "black"
+  #       # 登录界面 slogan title
+  #       title: "开源算力中心门户和管理平台"
+  #       # 多条 slogan 文本
+  #       texts:
+  #         - "图形化界面，使用方便."
+  #         - "功能丰富，管理简单."
+  #         - "一体化部署，开箱即用."
+  #         - "标准化平台，支持算力融合."
+  #         - "开源中立，独立自主."
+
+  #     # 登陆界面底部 Power By 字体颜色配置
+  #     footerTextColor: "black"

--- a/docs/docs/deploy/config/auth/config.md
+++ b/docs/docs/deploy/config/auth/config.md
@@ -16,10 +16,24 @@ title: 内置认证系统配置
 ui:
   # 登录界面背景图，设置为""(空字符串)则无背景图
   # 可选配置，默认加载 install.yml 同级的 /public/assets 目录下的 background.png 作为背景图
-  backgroundImagePath: "./assets/background.png"
+  backgroundImage:
+
+    defaultPath: "./assets/background.png"
+
+    # 对具体hostname生效的生效，可以不填
+    # hostnameMap:
+    #   a.com: "./assets/background1.png"
+
   # 登录界面背景色，当背景图无法加载时，背景色起效
   # 可选配置，默认为 #8c8c8c
-  backgroundFallbackColor: "#8c8c8c"
+  backgroundFallbackColor:
+
+    defaultColor: "#8c8c8c"
+
+    # 对具体hostname生效的生效，可以不填
+    # hostnameMap:
+    #   a.com: "#fff"
+    
   # 登录界面 logo，可选配置
   logo:
     # 未配置自定义 logo（customLogoPath） 时，默认使用 SCOW Logo

--- a/docs/docs/deploy/config/auth/config.md
+++ b/docs/docs/deploy/config/auth/config.md
@@ -13,59 +13,98 @@ title: 内置认证系统配置
 其中关于背景图片路径和自定义 logo 图片路径的设置可以参考[公共文件](https://pkuhpc.github.io/SCOW/docs/deploy/config/customization/public-files)进行配置。需要强调的是该路径是相对于公共文件的路径。
 ```yaml
 # auth 界面 ui 配置
+# 可根据不同域名进行不同的展示，当对应域名没有相应配置时采用 default 配置
 ui:
-  # 登录界面背景图，设置为""(空字符串)则无背景图
-  # 可选配置，默认加载 install.yml 同级的 /public/assets 目录下的 background.png 作为背景图
-  backgroundImage:
+  default:
+    # 登录界面背景图，设置为""(空字符串)则无背景图
+    # 可选配置，默认加载 install.yml 同级的 /public/assets 目录下的 background.png 作为背景图
+    backgroundImage:
 
-    defaultPath: "./assets/background.png"
+      defaultPath: "./assets/background.png"
 
-    # 对具体hostname生效的生效，可以不填
-    # hostnameMap:
-    #   a.com: "./assets/background1.png"
+      # 对具体hostname生效的生效，可以不填
+      # hostnameMap:
+      #   a.com: "./assets/background1.png"
 
-  # 登录界面背景色，当背景图无法加载时，背景色起效
-  # 可选配置，默认为 #8c8c8c
-  backgroundFallbackColor:
+    # 登录界面背景色，当背景图无法加载时，背景色起效
+    # 可选配置，默认为 #8c8c8c
+    backgroundFallbackColor:
 
-    defaultColor: "#8c8c8c"
+      defaultColor: "#8c8c8c"
 
-    # 对具体hostname生效的生效，可以不填
-    # hostnameMap:
-    #   a.com: "#fff"
-    
-  # 登录界面 logo，可选配置
-  logo:
-    # 未配置自定义 logo（customLogoPath） 时，默认使用 SCOW Logo
-    # light: 亮色模式下的 logo, dark: 黑暗模式下的 logo
-    # 可选配置，默认为黑暗模式 logo
-    scowLogoType: "dark"
-    # 可选配置，自定义 logo 的图片路径。与背景图一致，路径时相对于公共文件的路径
-    customLogoPath: ""
-    # 可选配置，自定义点击 logo 跳转地址
-    customLogoLink: "https://icode.pku.edu.cn/SCOW/"
+      # 对具体hostname生效的生效，可以不填
+      # hostnameMap:
+      #   a.com: "#fff"
+      
+    # 登录界面 logo，可选配置
+    logo:
+      # 未配置自定义 logo（customLogoPath） 时，默认使用 SCOW Logo
+      # light: 亮色模式下的 logo, dark: 黑暗模式下的 logo
+      # 可选配置，默认为黑暗模式 logo
+      scowLogoType: "dark"
+      # 可选配置，自定义 logo 的图片路径。与背景图一致，路径时相对于公共文件的路径
+      customLogoPath: ""
+      # 可选配置，自定义点击 logo 跳转地址
+      customLogoLink: "https://icode.pku.edu.cn/SCOW/"
 
-  # 登录界面 slogan 配置
-  # 可选配置，默认右侧无 slogan
-  slogan:
-    # 登录界面 slogan 文字颜色
+    # 登录界面 slogan 配置
+    # 可选配置，默认右侧无 slogan
+    slogan:
+      # 登录界面 slogan 文字颜色
+      # 可选配置，默认为白色字体
+      color: "white"
+      # 登录界面 slogan title
+      # 可选配置，默认无 slogan 标题
+      title: "开源算力中心门户和管理平台"
+      # 多条 slogan 文本
+      # 可选配置，默认 slogan 为空数组
+      texts:
+        - "图形化界面，使用方便"
+        - "功能丰富，管理简单"
+        - "一体化部署，开箱即用"
+        - "标准化平台，支持算力融合"
+        - "开源中立，独立自主"
+
+    # 登陆界面底部 Power By 字体颜色配置
     # 可选配置，默认为白色字体
-    color: "white"
-    # 登录界面 slogan title
-    # 可选配置，默认无 slogan 标题
-    title: "开源算力中心门户和管理平台"
-    # 多条 slogan 文本
-    # 可选配置，默认 slogan 为空数组
-    texts:
-      - "图形化界面，使用方便"
-      - "功能丰富，管理简单"
-      - "一体化部署，开箱即用"
-      - "标准化平台，支持算力融合"
-      - "开源中立，独立自主"
+    footerTextColor: "white"
 
-  # 登陆界面底部 Power By 字体颜色配置
-  # 可选配置，默认为白色字体
-  footerTextColor: "white"
+  # 根据不域名进行不同的展示，对具体hostname生效的生效，可以不填
+  # hostnameMap:
+
+  #   a.com:
+  #     # 登录界面背景图
+  #     backgroundImagePath: "./assets/background1.png"
+
+  #     # 登录界面背景色，当背景图无法加载时，背景色起效
+  #     backgroundFallbackColor: "#000"
+
+  #     # 登录界面 logo 图,
+  #     logo:
+  #       # 如果没有配置自定义 logo, 则使用 type 选择 SCOW Logo
+  #       # light: 亮色模式下的 logo, dark: 黑暗模式下的 logo
+  #       scowLogoType: "light"
+  #       # 自定义 logo, 默认为空
+  #       customLogoPath: ""
+  #       # 自定义点击 logo 跳转地址
+  #       customLogoLink: "https://icode.pku.edu.cn/SCOW/"
+
+  #     # 登录界面 slogan 配置
+  #     slogan:
+  #       # 登录界面 slogan 文字颜色
+  #       color: "black"
+  #       # 登录界面 slogan title
+  #       title: "开源算力中心门户和管理平台"
+  #       # 多条 slogan 文本
+  #       texts:
+  #         - "图形化界面，使用方便."
+  #         - "功能丰富，管理简单."
+  #         - "一体化部署，开箱即用."
+  #         - "标准化平台，支持算力融合."
+  #         - "开源中立，独立自主."
+
+  #     # 登陆界面底部 Power By 字体颜色配置
+  #     footerTextColor: "black"
 ```
 
 ## 允许回调主机名


### PR DESCRIPTION
# 需求
要求 auth 登录界面相关 UI 配置全部修改为可以根据不同域名展示不同内容
# 修改后
auth.yaml，新增 default 和 hostnameMap 配置，当用户没有配置 hostnameMap 或者配置了 hostnameMap 却没有配置对应域名下的相关 ui 配置时采用默认配置

```yaml
# auth 界面 ui 配置
ui:
  default:
    # 登录界面背景图
    backgroundImagePath: "./assets/background.png"

    # 登录界面背景色，当背景图无法加载时，背景色起效
    backgroundFallbackColor: "#8c8c8c"

    # 登录界面 logo 图,
    logo:
      # 如果没有配置自定义 logo, 则使用 type 选择 SCOW Logo
      # light: 亮色模式下的 logo, dark: 黑暗模式下的 logo
      scowLogoType: "dark"
      # 自定义 logo, 默认为空
      customLogoPath: ""
      # 自定义点击 logo 跳转地址
      customLogoLink: "https://icode.pku.edu.cn/SCOW/"

    # 登录界面 slogan 配置
    slogan:
      # 登录界面 slogan 文字颜色
      color: "white"
      # 登录界面 slogan title
      title: "开源算力中心门户和管理平台"
      # title:
      #   i18n:
      #     default: "开源算力中心门户和管理平台"
      #     zh_cn: "开源算力中心门户和管理平台"
      # 多条 slogan 文本
      texts:
        - "图形化界面，使用方便"
        - "功能丰富，管理简单"
        - "一体化部署，开箱即用"
        - "标准化平台，支持算力融合"
        - "开源中立，独立自主"

    # 登陆界面底部 Power By 字体颜色配置
    footerTextColor: "white"

  # 根据不域名进行不同的展示，对具体hostname生效的生效，可以不填
  # hostnameMap:

  #   a.com:
  #     # 登录界面背景图
  #     backgroundImagePath: "./assets/background1.png"

  #     # 登录界面背景色，当背景图无法加载时，背景色起效
  #     backgroundFallbackColor: "#000"

  #     # 登录界面 logo 图,
  #     logo:
  #       # 如果没有配置自定义 logo, 则使用 type 选择 SCOW Logo
  #       # light: 亮色模式下的 logo, dark: 黑暗模式下的 logo
  #       scowLogoType: "light"
  #       # 自定义 logo, 默认为空
  #       customLogoPath: ""
  #       # 自定义点击 logo 跳转地址
  #       customLogoLink: "https://icode.pku.edu.cn/SCOW/"

  #     # 登录界面 slogan 配置
  #     slogan:
  #       # 登录界面 slogan 文字颜色
  #       color: "black"
  #       # 登录界面 slogan title
  #       title: "开源算力中心门户和管理平台"
  #       # 多条 slogan 文本
  #       texts:
  #         - "图形化界面，使用方便."
  #         - "功能丰富，管理简单."
  #         - "一体化部署，开箱即用."
  #         - "标准化平台，支持算力融合."
  #         - "开源中立，独立自主."

  #     # 登陆界面底部 Power By 字体颜色配置
  #     footerTextColor: "black"

```