### PR TITLE
fix(web): 修改web端获取hostname的值，由获取带port的host改为hostname

### DIFF
--- a/.changeset/few-icons-happen.md
+++ b/.changeset/few-icons-happen.md
@@ -1,0 +1,6 @@
+---
+"@scow/portal-web": patch
+"@scow/lib-web": patch
+---
+
+将 web 获取的 hostname 由 host 变为 hostname，不带 port

--- a/.changeset/mean-donkeys-try.md
+++ b/.changeset/mean-donkeys-try.md
@@ -1,0 +1,5 @@
+---
+"@scow/config": patch
+---
+
+ui.yaml 配置中的 hostnameMap 只可设置不带 port 的 hostname

--- a/apps/auth/src/auth/bindOtpHtml.ts
+++ b/apps/auth/src/auth/bindOtpHtml.ts
@@ -17,7 +17,7 @@ import { join } from "path";
 import { config, FAVICON_URL } from "src/config/env";
 import { uiConfig } from "src/config/ui";
 import { AuthTextsType, languages } from "src/i18n";
-import { parseHostname } from "src/utils/parseHostname";
+import { getHostname } from "src/utils/getHostname";
 
 
 export async function renderBindOtpHtml(
@@ -34,7 +34,7 @@ export async function renderBindOtpHtml(
   },
 ) {
 
-  const hostname = parseHostname(req);
+  const hostname = getHostname(req);
 
   // 获取当前语言ID及对应的绑定OTP页面文本
   const languageId = getLanguageCookie(req.raw);

--- a/apps/auth/src/auth/loginHtml.ts
+++ b/apps/auth/src/auth/loginHtml.ts
@@ -19,7 +19,7 @@ import { authConfig, OtpStatusOptions, ScowLogoType } from "src/config/auth";
 import { config, FAVICON_URL, LOGO_URL } from "src/config/env";
 import { uiConfig } from "src/config/ui";
 import { AuthTextsType, languages } from "src/i18n";
-import { parseHostname } from "src/utils/parseHostname";
+import { getHostname } from "src/utils/getHostname";
 
 export async function serveLoginHtml(
   err: boolean, callbackUrl: string, req: FastifyRequest, rep: FastifyReply,
@@ -27,7 +27,7 @@ export async function serveLoginHtml(
   verifyOtpFail?: boolean,
 ) {
 
-  const hostname = parseHostname(req);
+  const hostname = getHostname(req);
   const authUiHostnameConfig = (hostname && authConfig.ui?.hostnameMap?.[hostname]) || undefined;
   const authUiDefaultConfig = authConfig.ui?.default;
 

--- a/apps/auth/src/utils/getHostname.ts
+++ b/apps/auth/src/utils/getHostname.ts
@@ -12,25 +12,12 @@
 
 import { FastifyRequest } from "fastify";
 
-export function parseHostname(req: FastifyRequest): string | undefined {
 
-  if (!req.headers.referer) {
-    return undefined;
-  }
-
-  try {
-    const url = new URL(req.headers.referer);
-    return url.hostname;
-  } catch {
-    return undefined;
-  }
+export function getHostname(req: FastifyRequest | undefined) {
+  const host = getHost(req);
+  return host?.includes(":") ? host?.split(":")[0] : host;
 }
 
-
-// export function parseHostname(req: FastifyRequest | undefined) {
-//   return getHost(req)?.includes(":") ? getHost(req)?.split(":")[0] : getHost(req);
-// }
-
-// export function getHost(req: FastifyRequest | undefined) {
-//   return req?.headers?.host;
-// }
+export function getHost(req: FastifyRequest | undefined) {
+  return req?.headers?.host;
+}

--- a/apps/auth/src/utils/getHostname.ts
+++ b/apps/auth/src/utils/getHostname.ts
@@ -25,3 +25,12 @@ export function parseHostname(req: FastifyRequest): string | undefined {
     return undefined;
   }
 }
+
+
+// export function parseHostname(req: FastifyRequest | undefined) {
+//   return getHost(req)?.includes(":") ? getHost(req)?.split(":")[0] : getHost(req);
+// }
+
+// export function getHost(req: FastifyRequest | undefined) {
+//   return req?.headers?.host;
+// }

--- a/apps/portal-web/src/pages/_app.tsx
+++ b/apps/portal-web/src/pages/_app.tsx
@@ -192,7 +192,6 @@ MyApp.getInitialProps = async (appContext: AppContext) => {
     }
 
     const hostname = getHostname(appContext.ctx.req);
-    console.log("hostname:", hostname);
 
     extra.primaryColor = (hostname && runtimeConfig.UI_CONFIG?.primaryColor?.hostnameMap?.[hostname])
       ?? runtimeConfig.UI_CONFIG?.primaryColor?.defaultColor ?? runtimeConfig.DEFAULT_PRIMARY_COLOR;

--- a/docs/docs/deploy/config/auth/config.md
+++ b/docs/docs/deploy/config/auth/config.md
@@ -18,23 +18,11 @@ ui:
   default:
     # 登录界面背景图，设置为""(空字符串)则无背景图
     # 可选配置，默认加载 install.yml 同级的 /public/assets 目录下的 background.png 作为背景图
-    backgroundImage:
-
-      defaultPath: "./assets/background.png"
-
-      # 对具体hostname生效的生效，可以不填
-      # hostnameMap:
-      #   a.com: "./assets/background1.png"
+    backgroundImagePath: "./assets/background.png"
 
     # 登录界面背景色，当背景图无法加载时，背景色起效
     # 可选配置，默认为 #8c8c8c
-    backgroundFallbackColor:
-
-      defaultColor: "#8c8c8c"
-
-      # 对具体hostname生效的生效，可以不填
-      # hostnameMap:
-      #   a.com: "#fff"
+    backgroundFallbackColor: "#8c8c8c" 
       
     # 登录界面 logo，可选配置
     logo:

--- a/libs/config/src/ui.ts
+++ b/libs/config/src/ui.ts
@@ -20,10 +20,10 @@ export const UiConfigSchema = Type.Object({
   footer: Type.Optional(Type.Object({
     defaultText: Type.Optional(Type.String({ description: "默认的footer文本" })),
     hostnameMap: Type.Optional(Type.Record(Type.String(), Type.String(),
-      { description: "根据域名（hostname，即在网页控制台执行location.host返回的值）不同，显示在footer上的文本" })),
+      { description: "根据域名(hostname，不包括port)不同，显示在footer上的文本" })),
     hostnameTextMap: Type.Optional(Type.Record(Type.String(), Type.String(),
       {
-        description: "根据域名（hostname，即在网页控制台执行location.host返回的值）不同，显示在footer上的文本",
+        description: "根据域名(hostname，不包括port)不同，显示在footer上的文本",
         deprecated: true,
       })),
   })),
@@ -31,7 +31,7 @@ export const UiConfigSchema = Type.Object({
   primaryColor: Type.Optional(Type.Object({
     defaultColor: Type.String({ description: "默认主题色", default: DEFAULT_PRIMARY_COLOR }),
     hostnameMap: Type.Optional(Type.Record(Type.String(), Type.String(),
-      { description: "根据域名（hostname，即在网页控制台执行location.host返回的值）不同，应用的主题色" })),
+      { description: "根据域名(hostname，不包括port)不同，应用的主题色" })),
   })),
 });
 

--- a/libs/web/src/routes/icon/icon.ts
+++ b/libs/web/src/routes/icon/icon.ts
@@ -14,7 +14,7 @@ import { existsSync } from "fs";
 import { NextApiRequest, NextApiResponse } from "next";
 import { join } from "path";
 import { sendFile, validatePayload } from "src/routes/icon/utils";
-import { getHostname } from "src/utils/getHostname";
+import { getHost } from "src/utils/getHostname";
 import { z } from "zod";
 
 const filenameMap = {
@@ -39,7 +39,7 @@ export const serveIcon = async (
   if (!query) { return; }
 
   // find the domain icons
-  const domain = getHostname(req);
+  const domain = getHost(req);
 
   if (domain) {
     const domainIconPath = join(configIconPath, domain, filenameMap[query.type]);

--- a/libs/web/src/routes/icon/logo.ts
+++ b/libs/web/src/routes/icon/logo.ts
@@ -14,7 +14,7 @@ import { existsSync } from "fs";
 import { NextApiRequest, NextApiResponse } from "next";
 import { join } from "path";
 import { sendFile, validatePayload } from "src/routes/icon/utils";
-import { getHostname } from "src/utils/getHostname";
+import { getHost } from "src/utils/getHostname";
 import { z } from "zod";
 
 const QuerySchema = z.object({
@@ -61,7 +61,7 @@ export const serveLogo = async (
   }
 
   // find the domain icons
-  const domain = getHostname(req);
+  const domain = getHost(req);
 
   if (domain) {
 

--- a/libs/web/src/utils/getHostname.ts
+++ b/libs/web/src/utils/getHostname.ts
@@ -13,5 +13,10 @@
 import { IncomingMessage } from "http";
 
 export function getHostname(req: IncomingMessage | undefined) {
+  return getHost(req)?.includes(":") ? getHost(req)?.split(":")[0] : getHost(req);
+}
+
+export function getHost(req: IncomingMessage | undefined) {
   return req?.headers?.host;
 }
+

--- a/libs/web/src/utils/getHostname.ts
+++ b/libs/web/src/utils/getHostname.ts
@@ -13,10 +13,10 @@
 import { IncomingMessage } from "http";
 
 export function getHostname(req: IncomingMessage | undefined) {
-  return getHost(req)?.includes(":") ? getHost(req)?.split(":")[0] : getHost(req);
+  const host = getHost(req);
+  return host?.includes(":") ? host?.split(":")[0] : host;
 }
 
 export function getHost(req: IncomingMessage | undefined) {
   return req?.headers?.host;
 }
-


### PR DESCRIPTION
做了什么：
1、修改web端获取hostname的值，由获取带port的host改为hostname
2、修改auth获取hostname的方式，由从refer中获取改为从header中获取，与mis-web、portal-web保持一致

config/ui.yaml 的参考配置如下
```yaml  title="ui.yaml"
# footer部分的配置。可以不填。
# 对portal-web、mis-web和auth的登录界面有效
footer:

  # 对所有域名生效的footer文本，默认为空字符串
  defaultText: ""

  # 对具体hostname生效的footer文本，可以不填
  hostnameMap:
    # 从a.com的访问显示footer文本为a.com的文本
    # a.com: a.com的文本
    183.214.11.32: 183.214.11.32的文本
    172.16.20.122: 172.16.20.122的文本

# 主题色配置。可以不填
# 对portal-web和mis-web有效
primaryColor:

  # 对所有域名生效的主题色。默认为#94070A
  defaultColor: "#94070A"

  # 对具体hostname生效的生效，可以不填
  hostnameMap:
    # 从a.com的访问的主题色为#000000
    # a.com: "#000000"
    183.214.11.32: "#0ff"
    #'172.16.20.122': "#ff0"
```

效果如下：
<img width="840" alt="1697783630713" src="https://github.com/PKUHPC/SCOW/assets/25954437/51081378-6000-4d50-9219-7256f2cacf0f">

<img width="820" alt="1697784107210" src="https://github.com/PKUHPC/SCOW/assets/25954437/ce374791-a1a7-4230-987a-b4fc6c4446ac">


