### PR TITLE
fix: 英文label太长和placeholder、文字显示不全

### DIFF
--- a/.changeset/big-geese-obey.md
+++ b/.changeset/big-geese-obey.md
@@ -1,0 +1,7 @@
+---
+"@scow/portal-web": patch
+"@scow/mis-web": patch
+"@scow/auth": patch
+---
+
+修复了一些因国际化英文 label 太长被输入框遮挡；修复了登录页的验证码 placeholder 太长和文字超出屏幕的问题。

--- a/apps/auth/src/i18n/en.ts
+++ b/apps/auth/src/i18n/en.ts
@@ -17,7 +17,7 @@ export default {
     username: "Username",
     password: "Password",
     otpVCode: "OTP Verification Code",
-    inputVCode: "Please enter the verification code",
+    inputVCode: "verification code",
     refreshError: "Refresh failed, please click to retry.",
     invalidVCode: "Invalid verification code, please re-enter.",
     invalidInput: "Invalid username / password, please check.",

--- a/apps/auth/views/login.liquid
+++ b/apps/auth/views/login.liquid
@@ -122,7 +122,7 @@
           {% endif %}
         </div>
       </div>
-      <div class="w-1/2 h-screen pl-48 pb-28 flex justify-center flex-col hidden-xs">
+      <div class="w-1/2 h-screen pl-48 flex justify-center flex-col hidden-xs">
           <div class="text-4xl font-semibold mb-12"  style="color: {{ sloganColor }}">{{ sloganTitle }}</div>
           {% for sloganText in sloganTextArr %}
             <div class="text-2xl mb-8"  style="color: {{ sloganColor }}">{{ sloganText }}</div>

--- a/apps/mis-web/src/pages/admin/tenants/create.tsx
+++ b/apps/mis-web/src/pages/admin/tenants/create.tsx
@@ -132,7 +132,7 @@ const CreateTenantPageForm: React.FC = () => {
     <Form
       form={form}
       wrapperCol={{ span: 20 }}
-      labelCol={{ span: 4 }}
+      labelCol={{ span:4, style: { whiteSpace:"normal", textAlign:"left", lineHeight:"16px" } }}
       labelAlign="left"
       onFinish={onOk}
     >

--- a/apps/mis-web/src/pages/tenant/accounts/create.tsx
+++ b/apps/mis-web/src/pages/tenant/accounts/create.tsx
@@ -75,7 +75,7 @@ const CreateAccountForm: React.FC<CreateAccountFormProps> = ({ tenantName }) => 
     <Form
       form={form}
       wrapperCol={{ span: 20 }}
-      labelCol={{ span: 4 }}
+      labelCol={{ span:4, style: { whiteSpace:"normal", textAlign:"left", lineHeight:"16px" } }}
       labelAlign="right"
       onFinish={submit}
     >

--- a/apps/mis-web/src/pages/tenant/users/create.tsx
+++ b/apps/mis-web/src/pages/tenant/users/create.tsx
@@ -109,9 +109,9 @@ const CreateUserPageForm: React.FC = () => {
     <Form
       form={form}
       wrapperCol={{ span: 20 }}
-      labelCol={{ span: 4 }}
-      labelAlign="right"
+      labelAlign="left"
       onFinish={onOk}
+      labelCol={{ span:4, style: { whiteSpace:"normal", textAlign:"left", lineHeight:"16px" } }}
     >
       <CreateUserForm />
       <Form.Item wrapperCol={{ span: 6, offset: 4 }}>

--- a/apps/portal-web/src/pageComponents/desktop/NewDesktopTableModal.tsx
+++ b/apps/portal-web/src/pageComponents/desktop/NewDesktopTableModal.tsx
@@ -103,7 +103,8 @@ export const NewDesktopTableModal: React.FC<Props> = ({
         form={form}
         onFinish={onOk}
         wrapperCol={{ span: 20 }}
-        labelCol={{ span: 4 }}
+        labelCol={{ span:4, style: { whiteSpace:"normal", textAlign:"left", lineHeight:"16px" } }}
+
       >
         <Form.Item label={t(p("modal.loginNode"))} name="loginNode" rules={[{ required: true }]}>
           <Select

--- a/apps/portal-web/src/pageComponents/profile/ChangePasswordModal.tsx
+++ b/apps/portal-web/src/pageComponents/profile/ChangePasswordModal.tsx
@@ -82,7 +82,8 @@ export const ChangePasswordModal: React.FC<Props> = ({
         form={form}
         onFinish={onFinish}
         wrapperCol={{ span: 20 }}
-        labelCol={{ span: 4 }}
+        labelCol={{ span:4, style: { whiteSpace:"normal", textAlign:"left", lineHeight:"16px" } }}
+
       >
         <Form.Item
           rules={[{ required: true }]}


### PR DESCRIPTION
##  之前：英文label太长和placeholder、登录页文字显示不全
![image](https://github.com/PKUHPC/SCOW/assets/74037789/46318cd2-f04c-4be2-bad1-db11d1182453)
![image](https://github.com/PKUHPC/SCOW/assets/74037789/7cbc649d-f3cd-4dd2-a424-03c61cdbfb26)
![image](https://github.com/PKUHPC/SCOW/assets/74037789/acdf133e-cf9e-4c23-acff-2ea76d2a5340)
![image](https://github.com/PKUHPC/SCOW/assets/74037789/16481f18-4059-43de-a037-d772cc605b7d)
![image](https://github.com/PKUHPC/SCOW/assets/74037789/f5730d83-9dd7-4962-9ae4-1e5a59fc0768)
![image](https://github.com/PKUHPC/SCOW/assets/74037789/0628e418-99a2-4152-9735-4e817aac98db)
![image](https://github.com/PKUHPC/SCOW/assets/74037789/a2646dca-47da-4da3-b632-e2f7f4e422a5)
![image](https://github.com/PKUHPC/SCOW/assets/74037789/bf8e47ea-f089-4223-9706-467ab58ea092)
## 现在：label太长就换行，减少了placeholder，登录页文字下移
![image](https://github.com/PKUHPC/SCOW/assets/74037789/a6cf8435-4284-4f45-a983-a649b5206422)
![image](https://github.com/PKUHPC/SCOW/assets/74037789/b35f1490-a66a-45e9-96d8-7b865a68d5fc)
![image](https://github.com/PKUHPC/SCOW/assets/74037789/e0f6a7b8-3e57-48b7-969c-d2eb33762160)
![image](https://github.com/PKUHPC/SCOW/assets/74037789/e87e2059-dcc2-431c-8e7c-ec8fc4d47268)
![image](https://github.com/PKUHPC/SCOW/assets/74037789/7c1d2202-f496-4f51-9b71-51f8e9d4a32e)
![image](https://github.com/PKUHPC/SCOW/assets/74037789/bae4f2d1-0d2c-4cae-905a-f386b5defa4c)

