### PR TITLE
fix: 显式指定所使用的调度器适配器接口版本

### DIFF
--- a/libs/protos/scheduler-adapter/package.json
+++ b/libs/protos/scheduler-adapter/package.json
@@ -5,7 +5,7 @@
   "main": "build/index.js",
   "private": true,
   "scripts": {
-    "generate": "rimraf generated && buf generate --template buf.gen.yaml https://github.com/PKUHPC/scow-scheduler-adapter-interface.git",
+    "generate": "rimraf generated && buf generate --template buf.gen.yaml https://github.com/PKUHPC/scow-scheduler-adapter-interface.git#tag=v1.0.1",
     "build": "rimraf build && tsc"
   },
   "files": [


### PR DESCRIPTION
在libs/protos/scheduler-adapter/package.json中显式指定所使用的调度器适配器接口版本