### PR TITLE
fix(mis-server): getAllUsers接口增加email字段

### DIFF
--- a/.changeset/chilly-forks-dress.md
+++ b/.changeset/chilly-forks-dress.md
@@ -1,0 +1,5 @@
+---
+"@scow/mis-server": patch
+---
+
+getAllUsers 接口增加 email 字段

--- a/.changeset/sweet-masks-join.md
+++ b/.changeset/sweet-masks-join.md
@@ -1,0 +1,5 @@
+---
+"@scow/grpc-api": patch
+---
+
+getAllUsers 接口增加 email 字段

--- a/apps/mis-server/src/services/user.ts
+++ b/apps/mis-server/src/services/user.ts
@@ -542,6 +542,7 @@ export const userServiceServer = plugin((server) => {
         platformUsers: users.map((x) => ({
           userId: x.userId,
           name: x.name,
+          email: x.email,
           availableAccounts: x.accounts.getItems()
             .filter((ua) => ua.status === UserStatus.UNBLOCKED)
             .map((ua) => {

--- a/protos/server/user.proto
+++ b/protos/server/user.proto
@@ -254,10 +254,11 @@ message GetUsersResponse {
 message PlatformUserInfo {
   string user_id = 1;
   string name = 2;
-  repeated string available_accounts = 3;
-  string tenant_name = 4;
-  google.protobuf.Timestamp create_time = 5;
-  repeated PlatformRole platform_roles = 6;
+  string email = 3;
+  repeated string available_accounts = 4;
+  string tenant_name = 5;
+  google.protobuf.Timestamp create_time = 6;
+  repeated PlatformRole platform_roles = 7;
 }
 
 enum SortDirection {

--- a/protos/server/user.proto
+++ b/protos/server/user.proto
@@ -254,11 +254,11 @@ message GetUsersResponse {
 message PlatformUserInfo {
   string user_id = 1;
   string name = 2;
-  string email = 3;
-  repeated string available_accounts = 4;
-  string tenant_name = 5;
-  google.protobuf.Timestamp create_time = 6;
-  repeated PlatformRole platform_roles = 7;
+  repeated string available_accounts = 3;
+  string tenant_name = 4;
+  google.protobuf.Timestamp create_time = 5;
+  repeated PlatformRole platform_roles = 6;
+  string email = 7;
 }
 
 enum SortDirection {


### PR DESCRIPTION
mis-server中的getAllUsers接口增加email字段，方便其它服务调用scow接口时，获取用户email信息并发送邮件
本地接口测试如下：
<img width="777" alt="1698648883337" src="https://github.com/PKUHPC/SCOW/assets/25954437/093f9d3a-8b23-4753-b08b-08dd34312bd9">
