### PR TITLE
chore: protos增加breaking命令用于检查当前修改是否是破坏性修改

### DIFF
--- a/protos/package.json
+++ b/protos/package.json
@@ -8,6 +8,7 @@
   "license": "Mulan PSL v2",
   "repository": "https://github.com/PKUHPC/SCOW",
   "scripts": {
-    "lint": "buf lint"
+    "lint": "buf lint",
+    "breaking": "buf breaking --against '../.git#subdir=protos'"
   }
 }


### PR DESCRIPTION
在protos下运行`pnpm breaking`即可对比当前文件以及当前分支最新的proto文件，并检查当前修改是否是破坏性修改。