### PR TITLE
fix(mis-web): 修复 mis-web 中用户和账户列表 tab 数量会随 tab 切换而变化的问题

### DIFF
--- a/.changeset/big-weeks-marry.md
+++ b/.changeset/big-weeks-marry.md
@@ -1,0 +1,5 @@
+---
+"@scow/mis-web": patch
+---
+
+修复 mis-web 中用户和账户列表 tab 数量会随 tab 切换而变化的问题

--- a/apps/mis-web/src/apis/api.mock.ts
+++ b/apps/mis-web/src/apis/api.mock.ts
@@ -150,6 +150,7 @@ export const mockApi: MockApi<typeof api> = {
       {
         userId: "123",
         name: "testuser",
+        email: "testuser@test.com",
         availableAccounts: ["a_123"],
         tenantName: "tenant1",
         createTime: "2022-10-05T23:49:50.000Z",
@@ -158,6 +159,7 @@ export const mockApi: MockApi<typeof api> = {
       {
         userId: "test01",
         name: "test01",
+        email: "test01@test.com",
         availableAccounts: ["a_test", "a_test01"],
         tenantName: "tenant2",
         createTime: "2022-10-05T23:49:50.000Z",
@@ -166,6 +168,7 @@ export const mockApi: MockApi<typeof api> = {
       {
         userId: "test02",
         name: "test02",
+        email: "test02@test.com",
         availableAccounts: ["a_test", "a_test02"],
         tenantName: "tenant2",
         createTime: "2022-10-05T23:49:50.000Z",
@@ -174,6 +177,7 @@ export const mockApi: MockApi<typeof api> = {
       {
         userId: "test03",
         name: "test03",
+        email: "test03@test.com",
         availableAccounts: ["a_test", "a_test03"],
         tenantName: "tenant2",
         createTime: "2022-10-05T23:49:50.000Z",

--- a/apps/mis-web/src/models/UserSchemaModel.ts
+++ b/apps/mis-web/src/models/UserSchemaModel.ts
@@ -37,6 +37,7 @@ export type PlatformTenantsInfo = Static<typeof PlatformTenantsInfo>;
 export const PlatformUserInfo = Type.Object({
   userId: Type.String(),
   name: Type.String(),
+  email: Type.String(),
   availableAccounts: Type.Array(Type.String()),
   tenantName: Type.String(),
   createTime: Type.Optional(Type.String()),

--- a/apps/mis-web/src/pageComponents/accounts/AccountTable.tsx
+++ b/apps/mis-web/src/pageComponents/accounts/AccountTable.tsx
@@ -69,15 +69,19 @@ export const AccountTable: React.FC<Props> = ({
       && (rangeSearchStatus === "ALL" || (rangeSearchStatus === "BLOCKED" ? x.blocked : !x.balance.positive))
   )) : undefined, [data, query, rangeSearchStatus]);
 
+  const searchData = useMemo(() => data ? data.results.filter((x) => (
+    !query.accountName || x.accountName.includes(query.accountName)
+  )) : undefined, [data, query]);
+
   const usersStatusCount = useMemo(() => {
-    if (!filteredData) return { BLOCKED : 0, DEBT : 0, ALL : 0 };
+    if (!searchData) return { BLOCKED : 0, DEBT : 0, ALL : 0 };
     const counts = {
-      BLOCKED: filteredData.filter((user) => user.blocked).length,
-      DEBT: filteredData.filter((user) => !user.balance.positive).length,
-      ALL: filteredData.length,
+      BLOCKED: searchData.filter((user) => user.blocked).length,
+      DEBT: searchData.filter((user) => !user.balance.positive).length,
+      ALL: searchData.length,
     };
     return counts;
-  }, [filteredData]);
+  }, [searchData]);
 
   const handleTableChange = (_, __, sortInfo) => {
     setCurrentSortInfo({ field: sortInfo.field, order: sortInfo.order });

--- a/apps/mis-web/src/pageComponents/admin/AllUsersTable.tsx
+++ b/apps/mis-web/src/pageComponents/admin/AllUsersTable.tsx
@@ -67,7 +67,7 @@ export const AllUsersTable: React.FC<Props> = ({ refreshToken, user }) => {
   const [pageInfo, setPageInfo] = useState<PageInfo>({ page: 1, pageSize: 10 });
   const [sortInfo, setSortInfo] = useState<SortInfo>({ sortField: undefined, sortOrder: undefined });
   const [currentPlatformRole, setCurrentPlatformRole] = useState<PlatformRole | undefined>(undefined);
-  const [allUsers, setAllUsers] = useState<Omit<PlatformUserInfo, "email">[] | undefined>(undefined);
+  const [allUsers, setAllUsers] = useState<PlatformUserInfo[] | undefined>(undefined);
 
   const promiseFn = useCallback(async () => {
 

--- a/apps/mis-web/src/pageComponents/tenant/AdminUserTable.tsx
+++ b/apps/mis-web/src/pageComponents/tenant/AdminUserTable.tsx
@@ -71,20 +71,25 @@ export const AdminUserTable: React.FC<Props> = ({
         rangeSearchRole === "TENANT_ADMIN" ? TenantRole.TENANT_ADMIN : TenantRole.TENANT_FINANCE))
   )) : undefined, [data, query, rangeSearchRole]);
 
+  const searchData = useMemo(() => data ? data.results.filter((x) => (
+    !query.idOrName || x.id.includes(query.idOrName) || x.name.includes(query.idOrName)
+  )) : undefined, [data, query]);
+
+
   const getUsersRoleCount = useCallback((role: FilteredRole): number => {
 
     switch (role) {
     case "TENANT_ADMIN":
-      return filteredData
-        ? filteredData.filter((user) => user.tenantRoles.includes(TenantRole.TENANT_ADMIN)).length : 0;
+      return searchData
+        ? searchData.filter((user) => user.tenantRoles.includes(TenantRole.TENANT_ADMIN)).length : 0;
     case "TENANT_FINANCE":
-      return filteredData
-        ? filteredData.filter((user) => user.tenantRoles.includes(TenantRole.TENANT_FINANCE)).length : 0;
+      return searchData
+        ? searchData.filter((user) => user.tenantRoles.includes(TenantRole.TENANT_FINANCE)).length : 0;
     case "ALL_USERS":
     default:
-      return filteredData ? filteredData.length : 0;
+      return searchData ? searchData.length : 0;
     }
-  }, [filteredData]);
+  }, [searchData]);
 
   const handleTableChange = (_, __, sortInfo) => {
     setCurrentSortInfo({ field: sortInfo.field, order: sortInfo.order });


### PR DESCRIPTION
# 问题
mis-web 中用户列表和账户列表在切换 tab 时会将 tab 作为搜索条件更新数据，从而导致直接从数据统计数量时会出现错误

# 修复
保存仅按搜索框的条件搜索得到的数据，并从该数据计算每个 tab 的数量