### PR TITLE
fix(portal): 集群节点下的大文件size无法正确展示

### DIFF
--- a/.changeset/polite-flowers-leave.md
+++ b/.changeset/polite-flowers-leave.md
@@ -1,0 +1,5 @@
+---
+"@scow/grpc-api": patch
+---
+
+修改 FILEINFO 中文件 size 的类型为 unit 64

--- a/protos/portal/file.proto
+++ b/protos/portal/file.proto
@@ -94,7 +94,7 @@ message FileInfo {
   FileType type = 2;
   string mtime = 3;
   uint32 mode = 4;
-  uint32 size = 5;
+  uint64 size = 5;
 }
 
 // PERMISSION_DENIED: directory is not accessible


### PR DESCRIPTION
### 问题

web端的grpc protobuf中定义文件size类型为`unit 32`
导致KB数大于`unit 32`大小的文件size无法正确展示

protobuf中定义的文件size类型修改为`unit 64`

### 修改后
大size文件也可以正常展示
![正常](https://github.com/PKUHPC/SCOW/assets/43978285/d7921413-6439-44d5-9ae0-e1d136fa0896)
