### PR TITLE
feat(portal-web): 门户系统文件管理新增文件编辑功能

### DIFF
--- a/.changeset/small-cars-approve.md
+++ b/.changeset/small-cars-approve.md
@@ -1,0 +1,7 @@
+---
+"@scow/portal-web": minor
+"@scow/config": minor
+"@scow/cli": minor
+---
+
+门户系统文件管理新增文件编辑功能

--- a/apps/cli/assets/config/portal.yaml
+++ b/apps/cli/assets/config/portal.yaml
@@ -49,12 +49,12 @@ shell: true
 #   preview:
 #     # 大小限制
 #     # 可接受的格式为nginx的client_max_body_size可接受的值，默认为 50m
-#     limitSize: "40m"
+#     limitSize: "50m"
 #   # 文件编辑功能
 #   edit:
 #     # 文件编辑大小限制
 #     # 可接受的格式为nginx的client_max_body_size可接受的值，默认为 1m
-#     limitSize: "2m"
+#     limitSize: "1m"
 
 # 提交作业的默认工作目录。使用{{ name }}代替作业名称。相对于用户的家目录
 # submitJobDefaultPwd: scow/jobs/{{ name }}

--- a/apps/cli/assets/config/portal.yaml
+++ b/apps/cli/assets/config/portal.yaml
@@ -43,9 +43,11 @@ homeText:
 # 是否启用终端功能
 shell: true
 
-# 文件编辑大小限制
-# 可接受的格式为nginx的client_max_body_size可接受的值
-# fileEditSize: "1m"
+# # 文件编辑功能
+# fileEdit:
+#   # 文件编辑大小限制
+#   # 可接受的格式为nginx的client_max_body_size可接受的值，默认为 1m
+#   limitSize: "1m"
 
 # 提交作业的默认工作目录。使用{{ name }}代替作业名称。相对于用户的家目录
 # submitJobDefaultPwd: scow/jobs/{{ name }}

--- a/apps/cli/assets/config/portal.yaml
+++ b/apps/cli/assets/config/portal.yaml
@@ -43,11 +43,18 @@ homeText:
 # 是否启用终端功能
 shell: true
 
-# # 文件编辑功能
-# fileEdit:
-#   # 文件编辑大小限制
-#   # 可接受的格式为nginx的client_max_body_size可接受的值，默认为 1m
-#   limitSize: "1m"
+# # 文件管理
+# file:
+#   # 文件预览功能
+#   preview:
+#     # 大小限制
+#     # 可接受的格式为nginx的client_max_body_size可接受的值，默认为 50m
+#     limitSize: "40m"
+#   # 文件编辑功能
+#   edit:
+#     # 文件编辑大小限制
+#     # 可接受的格式为nginx的client_max_body_size可接受的值，默认为 1m
+#     limitSize: "2m"
 
 # 提交作业的默认工作目录。使用{{ name }}代替作业名称。相对于用户的家目录
 # submitJobDefaultPwd: scow/jobs/{{ name }}

--- a/apps/cli/assets/config/portal.yaml
+++ b/apps/cli/assets/config/portal.yaml
@@ -43,6 +43,10 @@ homeText:
 # 是否启用终端功能
 shell: true
 
+# 文件编辑大小限制
+# 可接受的格式为nginx的client_max_body_size可接受的值
+# fileEditSize: "1m"
+
 # 提交作业的默认工作目录。使用{{ name }}代替作业名称。相对于用户的家目录
 # submitJobDefaultPwd: scow/jobs/{{ name }}
 

--- a/apps/portal-web/.eslintrc.json
+++ b/apps/portal-web/.eslintrc.json
@@ -2,5 +2,6 @@
   "extends": [
     "@ddadaal/eslint-config/react",
     "../../.eslintrc.js"
-  ]
+  ],
+  "ignorePatterns": ["public/monaco-assets/**"]
 }

--- a/apps/portal-web/.gitignore
+++ b/apps/portal-web/.gitignore
@@ -25,5 +25,6 @@ yarn-error.log*
 .next/
 
 public/novnc
+public/monaco-assets
 
 api-routes-schemas.json

--- a/apps/portal-web/config.js
+++ b/apps/portal-web/config.js
@@ -194,6 +194,8 @@ const buildRuntimeConfig = async (phase, basePath) => {
 
     CLIENT_MAX_BODY_SIZE: config.CLIENT_MAX_BODY_SIZE,
 
+    FILE_EDIT_SIZE: portalConfig.fileEditSize,
+
     CROSS_CLUSTER_FILE_TRANSFER_ENABLED:
       Object.values(clusters).filter(
         (cluster) => cluster.crossClusterFileTransfer?.enabled).length > 1,

--- a/apps/portal-web/config.js
+++ b/apps/portal-web/config.js
@@ -194,7 +194,9 @@ const buildRuntimeConfig = async (phase, basePath) => {
 
     CLIENT_MAX_BODY_SIZE: config.CLIENT_MAX_BODY_SIZE,
 
-    FILE_EDIT_SIZE: portalConfig.fileEdit.limitSize,
+    FILE_EDIT_SIZE: portalConfig.file?.edit.limitSize,
+
+    FILE_PREVIEW_SIZE: portalConfig.file?.preview.limitSize,
 
     CROSS_CLUSTER_FILE_TRANSFER_ENABLED:
       Object.values(clusters).filter(

--- a/apps/portal-web/config.js
+++ b/apps/portal-web/config.js
@@ -194,7 +194,7 @@ const buildRuntimeConfig = async (phase, basePath) => {
 
     CLIENT_MAX_BODY_SIZE: config.CLIENT_MAX_BODY_SIZE,
 
-    FILE_EDIT_SIZE: portalConfig.fileEditSize,
+    FILE_EDIT_SIZE: portalConfig.fileEdit.limitSize,
 
     CROSS_CLUSTER_FILE_TRANSFER_ENABLED:
       Object.values(clusters).filter(

--- a/apps/portal-web/package.json
+++ b/apps/portal-web/package.json
@@ -6,11 +6,12 @@
     "dev": "cross-env NEXT_PUBLIC_USE_MOCK=1 TS_NODE_PROJECT=tsconfig.server.json node --watch -r ts-node/register -r tsconfig-paths/register server/index.ts",
     "dev:server": "cross-env NEXT_PUBLIC_USE_MOCK=0 TS_NODE_PROJECT=tsconfig.server.json node --watch -r ts-node/register -r tsconfig-paths/register server/index.ts",
     "serve": "node build/server/index.js",
-    "build": "npm run build:next && npm run build:ts",
+    "build": "node scripts/copyMonacoToPublic.js && npm run build:next && npm run build:ts",
     "build:next": "next build",
     "build:ts": "rimraf build && tsc -p tsconfig.server.json && tsc-alias -p tsconfig.server.json",
     "test": "jest --passWithNoTests",
-    "client": "ntar client"
+    "client": "ntar client",
+    "prepareDev": "node scripts/copyMonacoToPublic.js"
   },
   "files": [
     ".next",
@@ -26,6 +27,7 @@
   "license": "Mulan PSL v2",
   "repository": "https://glithub.com/PKUHPC/SCOW",
   "dependencies": {
+    "@ant-design/cssinjs": "1.16.2",
     "@ant-design/icons": "5.2.5",
     "@codemirror/language": "6.9.0",
     "@codemirror/legacy-modes": "6.3.3",
@@ -34,18 +36,18 @@
     "@ddadaal/tsgrpc-client": "0.17.6",
     "@ddadaal/tsgrpc-common": "0.2.4",
     "@grpc/grpc-js": "1.9.5",
+    "@monaco-editor/react": "^4.6.0",
     "@scow/config": "workspace:*",
     "@scow/lib-auth": "workspace:*",
     "@scow/lib-config": "workspace:*",
     "@scow/lib-decimal": "workspace:*",
+    "@scow/lib-operation-log": "workspace:*",
     "@scow/lib-ssh": "workspace:*",
     "@scow/lib-web": "workspace:*",
     "@scow/protos": "workspace:*",
-    "@scow/utils": "workspace:*",
-    "@scow/lib-operation-log": "workspace:*",
     "@scow/rich-error-model": "workspace:*",
+    "@scow/utils": "workspace:*",
     "@sinclair/typebox": "0.31.1",
-    "@ant-design/cssinjs": "1.16.2",
     "@uiw/codemirror-theme-github": "4.21.9",
     "@uiw/react-codemirror": "4.21.9",
     "antd": "5.8.4",
@@ -64,14 +66,14 @@
     "react-async": "10.0.1",
     "react-dom": "18.2.0",
     "react-is": "18.2.0",
+    "react-typed-i18n": "2.3.0",
     "simstate": "3.0.1",
     "styled-components": "6.0.7",
     "tslib": "2.6.2",
     "typescript": "5.1.6",
     "ws": "8.13.0",
     "xterm": "5.2.1",
-    "xterm-addon-fit": "0.7.0",
-    "react-typed-i18n": "2.3.0"
+    "xterm-addon-fit": "0.7.0"
   },
   "devDependencies": {
     "@ddadaal/next-typed-api-routes-cli": "0.9.1",
@@ -93,6 +95,9 @@
     "postcss": "8.4.28",
     "ts-log": "2.2.5",
     "webpack": "5.88.2"
+  },
+  "peerDependencies": {
+    "monaco-editor": "0.44.0"
   },
   "browserslist": {
     "production": [

--- a/apps/portal-web/scripts/copyMonacoToPublic.js
+++ b/apps/portal-web/scripts/copyMonacoToPublic.js
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2022 Peking University and Peking University Institute for Computing and Digital Economy
+ * SCOW is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *          http://license.coscl.org.cn/MulanPSL2
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PSL v2 for more details.
+ */
+
+const fs = require("fs-extra");
+const path = require("path");
+
+const sourcePath = path.join(__dirname, "../node_modules/monaco-editor/min/vs");
+const targetPath = path.join(__dirname, "../public/monaco-assets/vs");
+
+// Check if the source directory exists
+if (!fs.existsSync(sourcePath)) {
+  console.error(
+    `Error: Source directory ${sourcePath} does not exist. Ensure the target package is correctly installed.`);
+  process.exit(1);
+}
+
+// Ensure the target path exists, if not, create it
+fs.ensureDirSync(targetPath);
+
+// Attempt to copy
+try {
+  fs.copySync(sourcePath, targetPath, {
+    overwrite: true,
+    errorOnExist: false,
+  });
+  console.log(`Success: Copied from ${sourcePath} to ${targetPath}.`);
+} catch (error) {
+  console.error(`Error: An issue occurred during the copy process. Details: ${error.message}`);
+  process.exit(1);
+}
+
+console.log(`Copied files from ${sourcePath} to ${targetPath}`);

--- a/apps/portal-web/src/i18n/en.ts
+++ b/apps/portal-web/src/i18n/en.ts
@@ -201,7 +201,7 @@ export default {
         cantReadFile: "Cannot read file: {}",
         saveFileFail: "File save failed: {}",
         saveFileSuccess: "File saved successfully",
-        fileSizeExceeded: "Exceeds editable file size: {}",
+        fileSizeExceeded: "The file is too large, please download and edit it.",
       },
       createFileModal: {
         createErrorMessage: "File or directory with the same name already exists!",

--- a/apps/portal-web/src/i18n/en.ts
+++ b/apps/portal-web/src/i18n/en.ts
@@ -187,16 +187,21 @@ export default {
     },
     fileManagerComp: {
       fileEditModal: {
+        edit: "Edit",
         prompt: "Prompt",
         save: "Save",
         doNotSave: "Do Not Save",
         notSaved: "Not Saved",
         notSavePrompt: "The file has not been saved, do you want to save this file?",
         fileEdit: "File Edit",
+        filePreview: "File Preview",
+        fileLoading: "File is loading...",
+        exitEdit: "Exit Edit Mode",
         failedGetFile: "Failed to get file: {}",
         cantReadFile: "Cannot read file: {}",
         saveFileFail: "File save failed: {}",
         saveFileSuccess: "File saved successfully",
+        fileSizeExceeded: "Exceeds editable file size: {}",
       },
       createFileModal: {
         createErrorMessage: "File or directory with the same name already exists!",
@@ -206,9 +211,8 @@ export default {
         fileName: "File Name",
       },
       fileManager: {
-        edit: {
-          edit: "Edit",
-          fileSizeExceeded: "Exceeds editable file size: {}",
+        preview: {
+          cantPreview: "文件过大或者格式不支持，请下载后查看",
         },
         moveCopy: {
           copy: "Copy",

--- a/apps/portal-web/src/i18n/en.ts
+++ b/apps/portal-web/src/i18n/en.ts
@@ -201,7 +201,7 @@ export default {
         cantReadFile: "Cannot read file: {}",
         saveFileFail: "File save failed: {}",
         saveFileSuccess: "File saved successfully",
-        fileSizeExceeded: "The file is too large, please download and edit it.",
+        fileSizeExceeded: "File too large (maximum {}), please download and edit",
       },
       createFileModal: {
         createErrorMessage: "File or directory with the same name already exists!",
@@ -212,7 +212,7 @@ export default {
       },
       fileManager: {
         preview: {
-          cantPreview: "文件过大或者格式不支持，请下载后查看",
+          cantPreview: "File too large (maximum {}) or format not supported, please download to view",
         },
         moveCopy: {
           copy: "Copy",

--- a/apps/portal-web/src/i18n/en.ts
+++ b/apps/portal-web/src/i18n/en.ts
@@ -186,6 +186,18 @@ export default {
       },
     },
     fileManagerComp: {
+      fileEditModal: {
+        prompt: "Prompt",
+        save: "Save",
+        doNotSave: "Do Not Save",
+        notSaved: "Not Saved",
+        notSavePrompt: "The file has not been saved, do you want to save this file?",
+        fileEdit: "File Edit",
+        failedGetFile: "Failed to get file: {}",
+        cantReadFile: "Cannot read file: {}",
+        saveFileFail: "File save failed: {}",
+        saveFileSuccess: "File saved successfully",
+      },
       createFileModal: {
         createErrorMessage: "File or directory with the same name already exists!",
         createSuccessMessage: "Created successfully",
@@ -194,6 +206,10 @@ export default {
         fileName: "File Name",
       },
       fileManager: {
+        edit: {
+          edit: "Edit",
+          fileSizeExceeded: "Exceeds editable file size: {}",
+        },
         moveCopy: {
           copy: "Copy",
           move: "Move",

--- a/apps/portal-web/src/i18n/zh_cn.ts
+++ b/apps/portal-web/src/i18n/zh_cn.ts
@@ -201,7 +201,7 @@ export default {
         cantReadFile: "无法读取文件: {}",
         saveFileFail: "文件保存失败: {}",
         saveFileSuccess: "文件保存成功",
-        fileSizeExceeded: "文件过大，请下载后编辑",
+        fileSizeExceeded: "文件过大（最大{}），请下载后编辑",
       },
       createFileModal: {
         createErrorMessage: "同名文件或者目录已经存在！",
@@ -212,7 +212,7 @@ export default {
       },
       fileManager: {
         preview: {
-          cantPreview: "文件过大或者格式不支持，请下载后查看",
+          cantPreview: "文件过大（最大{}）或者格式不支持，请下载后查看",
         },
         moveCopy: {
           copy: "复制",

--- a/apps/portal-web/src/i18n/zh_cn.ts
+++ b/apps/portal-web/src/i18n/zh_cn.ts
@@ -187,16 +187,21 @@ export default {
     },
     fileManagerComp: {
       fileEditModal: {
+        edit: "编辑",
         prompt: "提示",
         save: "保存",
         doNotSave: "不保存",
         notSaved: "未保存",
         notSavePrompt: "文件未保存，是否保存该文件？",
         fileEdit: "文件编辑",
+        filePreview: "文件预览",
+        fileLoading: "文件正在加载...",
+        exitEdit: "退出编辑",
         failedGetFile: "获取文件: {} 失败",
         cantReadFile: "无法读取文件: {}",
         saveFileFail: "文件保存失败: {}",
         saveFileSuccess: "文件保存成功",
+        fileSizeExceeded: "超出可编辑文件大小: {}",
       },
       createFileModal: {
         createErrorMessage: "同名文件或者目录已经存在！",
@@ -206,9 +211,8 @@ export default {
         fileName: "文件名",
       },
       fileManager: {
-        edit: {
-          edit: "编辑",
-          fileSizeExceeded: "超出可编辑文件大小: {}",
+        preview: {
+          cantPreview: "文件过大或者格式不支持，请下载后查看",
         },
         moveCopy: {
           copy: "复制",

--- a/apps/portal-web/src/i18n/zh_cn.ts
+++ b/apps/portal-web/src/i18n/zh_cn.ts
@@ -186,6 +186,18 @@ export default {
       },
     },
     fileManagerComp: {
+      fileEditModal: {
+        prompt: "提示",
+        save: "保存",
+        doNotSave: "不保存",
+        notSaved: "未保存",
+        notSavePrompt: "文件未保存，是否保存该文件？",
+        fileEdit: "文件编辑",
+        failedGetFile: "获取文件: {} 失败",
+        cantReadFile: "无法读取文件: {}",
+        saveFileFail: "文件保存失败: {}",
+        saveFileSuccess: "文件保存成功",
+      },
       createFileModal: {
         createErrorMessage: "同名文件或者目录已经存在！",
         createSuccessMessage: "创建成功",
@@ -194,6 +206,10 @@ export default {
         fileName: "文件名",
       },
       fileManager: {
+        edit: {
+          edit: "编辑",
+          fileSizeExceeded: "超出可编辑文件大小: {}",
+        },
         moveCopy: {
           copy: "复制",
           move: "移动",

--- a/apps/portal-web/src/i18n/zh_cn.ts
+++ b/apps/portal-web/src/i18n/zh_cn.ts
@@ -201,7 +201,7 @@ export default {
         cantReadFile: "无法读取文件: {}",
         saveFileFail: "文件保存失败: {}",
         saveFileSuccess: "文件保存成功",
-        fileSizeExceeded: "超出可编辑文件大小: {}",
+        fileSizeExceeded: "文件过大，请下载后编辑",
       },
       createFileModal: {
         createErrorMessage: "同名文件或者目录已经存在！",

--- a/apps/portal-web/src/pageComponents/filemanager/FileEditModal.tsx
+++ b/apps/portal-web/src/pageComponents/filemanager/FileEditModal.tsx
@@ -209,7 +209,6 @@ export const FileEditModal: React.FC<Props> = ({ previewFile, setPreviewFile }) 
     downloadFile();
     setConfirm(false);
     setIsEdit(false);
-    setIsFullScreen(false);
     setMode(Mode.PREVIEW);
     setOptions({
       ...options,

--- a/apps/portal-web/src/pageComponents/filemanager/FileEditModal.tsx
+++ b/apps/portal-web/src/pageComponents/filemanager/FileEditModal.tsx
@@ -1,0 +1,230 @@
+/**
+ * Copyright (c) 2022 Peking University and Peking University Institute for Computing and Digital Economy
+ * SCOW is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *          http://license.coscl.org.cn/MulanPSL2
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PSL v2 for more details.
+ */
+
+import Editor, { loader } from "@monaco-editor/react";
+import { App, Badge, Modal, Space, Spin, Tabs, Tooltip } from "antd";
+import { useState } from "react";
+import { api } from "src/apis";
+import { prefix, useI18nTranslateToString } from "src/i18n";
+import { publicConfig } from "src/utils/config";
+import { getLanguage } from "src/utils/staticFiles";
+
+import { urlToUpload } from "./api";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  clusterId: string
+  filename: string;
+  filePath: string;
+}
+
+interface ConfirmModalProps {
+  open: boolean;
+  saving: boolean;
+  onSave: () => Promise<void>;
+  onClose: () => void;
+}
+
+interface FilenameProps {
+  isEdit: boolean;
+  filename: string;
+}
+
+const p = prefix("pageComp.fileManagerComp.fileEditModal.");
+
+loader.config({
+  paths: {
+    vs: publicConfig.BASE_PATH + "monaco-assets/vs",
+  },
+});
+
+function ConfirmModal({ open, saving, onSave, onClose }: ConfirmModalProps) {
+
+  const t = useI18nTranslateToString();
+
+  return (
+    <Modal
+      title={t(p("prompt"))}
+      open={open}
+      okText={t(p("save"))}
+      closeIcon={null}
+      cancelText={t(p("doNotSave"))}
+      cancelButtonProps={{ disabled: saving }}
+      onOk={onSave}
+      confirmLoading={saving}
+      onCancel={onClose}
+    >
+      {t(p("notSavePrompt"))}
+    </Modal>
+  );
+}
+
+const FilenameComponent: React.FC<FilenameProps> = ({ isEdit, filename }) => {
+
+  const t = useI18nTranslateToString();
+
+  return (
+    <Tooltip title={isEdit ? t(p("notSaved")) : null}>
+      <div>
+        <Space size="small">
+          <div>{filename}</div>
+          { isEdit && <Badge status="processing" /> }
+        </Space>
+      </div>
+    </Tooltip>
+  );
+};
+
+export const FileEditModal: React.FC<Props> = ({ open, onClose, clusterId, filename, filePath }) => {
+
+  const t = useI18nTranslateToString();
+
+  const [fileContent, setFileContent] = useState("");
+  const [isEdit, setIsEdit] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [confirm, setConfirm] = useState(false);
+
+  const { message } = App.useApp();
+
+  const handleEdit = (content) => {
+    setIsEdit(true);
+    setFileContent(content);
+  };
+
+  const closeProcess = () => {
+    setConfirm(false);
+    setIsEdit(false);
+    setFileContent("");
+    onClose();
+  };
+
+  const handleCancel = () => {
+    if (!isEdit) {
+      closeProcess();
+      return;
+    }
+
+    setConfirm(true);
+  };
+
+  const handleSave = async () => {
+    if (!isEdit) {
+      closeProcess();
+      return;
+    }
+
+    setSaving(true);
+    const blob = new Blob([fileContent], { type: "text/plain" });
+
+    const formData = new FormData();
+    formData.append("file", blob);
+
+    await fetch(urlToUpload(clusterId, filePath), {
+      method: "POST",
+      body: formData,
+    }).then((response) => {
+      if (!response.ok) {
+        return Promise.reject(response.statusText);
+      }
+      message.success(t(p("saveFileSuccess")));
+      closeProcess();
+    }).catch((error) => {
+      message.error(t(p("saveFileFail"), [error]));
+    }).finally(() => setSaving(false));
+  };
+
+  const downloadFile = () => {
+
+    if (!open) {
+      return;
+    }
+
+    setLoading(true);
+    api.downloadFile({
+      query: { download: false, path: filePath, cluster: clusterId },
+    }).then((json) => {
+      setFileContent(JSON.stringify(json, null, 2));
+    }).catch(async (res: Response) => {
+
+      if (!res.ok) {
+        message.error(t(p("failedGetFile"), [filename]));
+        return;
+      }
+
+      setLoading(false);
+      const reader = res.body?.getReader();
+      if (reader) {
+
+        let fileContent = "";
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) {
+            break;
+          }
+          fileContent += new TextDecoder().decode(value);
+          setFileContent(fileContent);
+        }
+
+      } else {
+        message.error(t(p("cantReadFile"), [filename]));
+      }
+
+    }).finally(() => {
+      setLoading(false);
+    });
+
+  };
+
+  return (
+    <div>
+      <Modal
+        open={open}
+        afterOpenChange={downloadFile}
+        title={t(p("fileEdit"))}
+        okText={t(p("save"))}
+        closeIcon={null}
+        onOk={handleSave}
+        confirmLoading={saving}
+        onCancel={handleCancel}
+        cancelButtonProps={{ disabled: saving }}
+        width={1000}
+        maskClosable={false}
+      >
+        <Tabs
+          type="card"
+          items={[{
+            label: <FilenameComponent isEdit={isEdit} filename={filename} />,
+            key: `${filename}`,
+            children: (
+              <Spin spinning={loading}>
+                <Editor
+                  height="60vh"
+                  defaultLanguage={getLanguage(filename)}
+                  value={fileContent}
+                  onChange={handleEdit}
+                />
+              </Spin>
+            ),
+          }]}
+        />
+      </Modal>
+      <ConfirmModal
+        open={confirm}
+        saving={saving}
+        onSave={handleSave}
+        onClose={closeProcess}
+      />
+    </div>
+  );
+};

--- a/apps/portal-web/src/pageComponents/filemanager/FileEditModal.tsx
+++ b/apps/portal-web/src/pageComponents/filemanager/FileEditModal.tsx
@@ -46,7 +46,7 @@ const FullScreenModalStyle = styled.div`
 
   &.fullscreen {
     .ant-modal {
-      width: 99vw !important;
+      width: 98vw !important;
       height: 100vh !important;
       top: 0 !important;
       padding: 0 !important;
@@ -349,7 +349,7 @@ export const FileEditModal: React.FC<Props> = ({ previewFile, setPreviewFile }) 
           )
           : (
             <Tooltip
-              title={downloading ? t(p("fileLoading")) : t(p("fileSizeExceeded"), [publicConfig.FILE_EDIT_SIZE])}
+              title={downloading ? t(p("fileLoading")) : t(p("fileSizeExceeded"))}
             >
               <Button disabled={true}>{t(p("edit"))}</Button>
             </Tooltip>

--- a/apps/portal-web/src/pageComponents/filemanager/FileEditModal.tsx
+++ b/apps/portal-web/src/pageComponents/filemanager/FileEditModal.tsx
@@ -184,7 +184,6 @@ export const FileEditModal: React.FC<Props> = ({ previewFile, setPreviewFile }) 
     setIsEdit(false);
     setMode(Mode.PREVIEW);
     setFileContent("");
-    setIsFullScreen(false);
     setOptions({
       ...options,
       readOnly: true,
@@ -193,6 +192,7 @@ export const FileEditModal: React.FC<Props> = ({ previewFile, setPreviewFile }) 
       ...previewFile,
       open: false,
     });
+    setIsFullScreen(false);
   };
 
   const handleClose = () => {
@@ -329,9 +329,10 @@ export const FileEditModal: React.FC<Props> = ({ previewFile, setPreviewFile }) 
   );
 
   const modalFooterRender = () => {
+    const fileEditLimitSize = publicConfig.FILE_EDIT_SIZE || DEFAULT_FILE_EDIT_LIMIT_SIZE;
     return (
       mode === Mode.PREVIEW ? (
-        fileSize <= convertToBytes(publicConfig.FILE_EDIT_SIZE || DEFAULT_FILE_EDIT_LIMIT_SIZE)
+        fileSize <= convertToBytes(fileEditLimitSize)
           ? (
             <Button
               type="primary"
@@ -348,7 +349,7 @@ export const FileEditModal: React.FC<Props> = ({ previewFile, setPreviewFile }) 
           )
           : (
             <Tooltip
-              title={downloading ? t(p("fileLoading")) : t(p("fileSizeExceeded"))}
+              title={downloading ? t(p("fileLoading")) : t(p("fileSizeExceeded"), [fileEditLimitSize])}
             >
               <Button disabled={true}>{t(p("edit"))}</Button>
             </Tooltip>

--- a/apps/portal-web/src/pageComponents/filemanager/FileManager.tsx
+++ b/apps/portal-web/src/pageComponents/filemanager/FileManager.tsx
@@ -334,7 +334,7 @@ export const FileManager: React.FC<Props> = ({ cluster, path, urlPrefix }) => {
         clusterId: cluster.id,
       });
     } else {
-      message.error(t(p("preview.cantPreview")));
+      message.info(t(p("preview.cantPreview")));
     }
   };
 

--- a/apps/portal-web/src/pageComponents/filemanager/FileManager.tsx
+++ b/apps/portal-web/src/pageComponents/filemanager/FileManager.tsx
@@ -318,14 +318,20 @@ export const FileManager: React.FC<Props> = ({ cluster, path, urlPrefix }) => {
 
   const handlePreview = (filename: string, fileSize: number) => {
 
+    const filePreviewLimitSize = publicConfig.FILE_PREVIEW_SIZE || DEFAULT_FILE_PREVIEW_LIMIT_SIZE;
+    if (fileSize > convertToBytes(filePreviewLimitSize)) {
+      message.info(t(p("preview.cantPreview"), [filePreviewLimitSize]));
+      return;
+    }
+
     if (isImage(filename)) {
       setPreviewImage({
         ...previewImage,
         visible: true,
         src: urlToDownload(cluster.id, join(path, filename), false),
       });
-    } else if (canPreviewWithEditor(filename)
-      && fileSize <= convertToBytes(publicConfig.FILE_PREVIEW_SIZE || DEFAULT_FILE_PREVIEW_LIMIT_SIZE)) {
+      return;
+    } else if (canPreviewWithEditor(filename)) {
       setPreviewFile({
         open: true,
         filename,
@@ -333,8 +339,10 @@ export const FileManager: React.FC<Props> = ({ cluster, path, urlPrefix }) => {
         filePath: join(path, filename),
         clusterId: cluster.id,
       });
+      return;
     } else {
-      message.info(t(p("preview.cantPreview")));
+      message.info(t(p("preview.cantPreview"), [filePreviewLimitSize]));
+      return;
     }
   };
 

--- a/apps/portal-web/src/pageComponents/filemanager/ImagePreviewer.tsx
+++ b/apps/portal-web/src/pageComponents/filemanager/ImagePreviewer.tsx
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2022 Peking University and Peking University Institute for Computing and Digital Economy
+ * SCOW is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *          http://license.coscl.org.cn/MulanPSL2
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PSL v2 for more details.
+ */
+
+import { Image, Spin } from "antd";
+import { Dispatch, SetStateAction, useEffect, useState } from "react";
+import { styled } from "styled-components";
+
+const FullScreenCentered = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  height: 100vh;
+  width: 100vw;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: rgba(255, 255, 255, 0.3);
+  z-index: 1000;
+`;
+
+interface PreviewImageProps {
+  visible: boolean;
+  src: string;
+  scaleStep: number;
+}
+
+interface Props {
+  previewImage: PreviewImageProps;
+  setPreviewImage: Dispatch<SetStateAction<PreviewImageProps>>
+}
+
+export const ImagePreviewer: React.FC<Props> = ({ previewImage, setPreviewImage }) => {
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (previewImage.visible) {
+      setLoading(true);
+    }
+  }, [previewImage.visible]);
+
+  const handleImageLoad = () => {
+    setLoading(false);
+  };
+
+  return (
+    <>
+      {loading && previewImage.visible && (
+        <FullScreenCentered>
+          <Spin size="large" />
+        </FullScreenCentered>
+      )}
+      <Image
+        style={{ display: "none" }}
+        src={previewImage.src}
+        preview={{
+          visible: previewImage.visible,
+          scaleStep: previewImage.scaleStep,
+          onVisibleChange: (vis) => {
+            setPreviewImage({
+              ...previewImage,
+              visible: false,
+            });
+
+            if (!vis) {
+              setLoading(false);
+            }
+          },
+        }}
+        onLoad={handleImageLoad}
+        onError={() => setLoading(false) }
+      />
+    </>
+  );
+};

--- a/apps/portal-web/src/utils/config.ts
+++ b/apps/portal-web/src/utils/config.ts
@@ -81,7 +81,9 @@ export interface PublicRuntimeConfig {
   // 上传（请求）文件的大小限制
   CLIENT_MAX_BODY_SIZE: string;
 
-  FILE_EDIT_SIZE: string;
+  FILE_EDIT_SIZE: string | undefined;
+
+  FILE_PREVIEW_SIZE: string | undefined;
 
   PUBLIC_PATH: string;
 

--- a/apps/portal-web/src/utils/config.ts
+++ b/apps/portal-web/src/utils/config.ts
@@ -81,6 +81,8 @@ export interface PublicRuntimeConfig {
   // 上传（请求）文件的大小限制
   CLIENT_MAX_BODY_SIZE: string;
 
+  FILE_EDIT_SIZE: string;
+
   PUBLIC_PATH: string;
 
   NAV_LINKS?: NavLink[];

--- a/apps/portal-web/src/utils/languageMap.ts
+++ b/apps/portal-web/src/utils/languageMap.ts
@@ -10,7 +10,7 @@
  * See the Mulan PSL v2 for more details.
  */
 
-const languageMap = {
+export const languageMap = {
   js: "javascript",
   jsx: "javascript",
   ts: "typescript",
@@ -42,5 +42,3 @@ const languageMap = {
   swift: "swift",
   m: "objective-c",
 };
-
-export default languageMap;

--- a/apps/portal-web/src/utils/languageMap.ts
+++ b/apps/portal-web/src/utils/languageMap.ts
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2022 Peking University and Peking University Institute for Computing and Digital Economy
+ * SCOW is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *          http://license.coscl.org.cn/MulanPSL2
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PSL v2 for more details.
+ */
+
+const languageMap = {
+  js: "javascript",
+  jsx: "javascript",
+  ts: "typescript",
+  tsx: "typescript",
+  html: "html",
+  css: "css",
+  json: "json",
+  md: "markdown",
+  py: "python",
+  java: "java",
+  c: "c",
+  cpp: "cpp",
+  cxx: "cpp",
+  cc: "cpp",
+  h: "cpp",
+  hpp: "cpp",
+  hxx: "cpp",
+  rs: "rust",
+  go: "go",
+  sh: "shell",
+  bash: "shell",
+  php: "php",
+  xml: "xml",
+  yml: "yaml",
+  yaml: "yaml",
+  sql: "sql",
+  pl: "perl",
+  rb: "ruby",
+  swift: "swift",
+  m: "objective-c",
+};
+
+export default languageMap;

--- a/apps/portal-web/src/utils/nonEditableExtensions.ts
+++ b/apps/portal-web/src/utils/nonEditableExtensions.ts
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2022 Peking University and Peking University Institute for Computing and Digital Economy
+ * SCOW is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *          http://license.coscl.org.cn/MulanPSL2
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PSL v2 for more details.
+ */
+
+export const nonEditableExtensions = new Set([
+  ".7z",
+  ".aiff",
+  ".apk",
+  ".app",
+  ".avi",
+  ".bat",
+  ".bin",
+  ".bmp",
+  ".bz2",
+  ".cmd",
+  ".com",
+  ".dat",
+  ".dll",
+  ".dmg",
+  ".doc",
+  ".docx",
+  ".exe",
+  ".flac",
+  ".flv",
+  ".gif",
+  ".gz",
+  ".img",
+  ".iso",
+  ".jpeg",
+  ".jpg",
+  ".mkv",
+  ".mov",
+  ".mp3",
+  ".mp4",
+  ".msi",
+  ".odt",
+  ".ott",
+  ".pdf",
+  ".png",
+  ".ppt",
+  ".pptx",
+  ".psd",
+  ".rar",
+  ".tar",
+  ".tgz",
+  ".tiff",
+  ".vcd",
+  ".wav",
+  ".wmv",
+  ".xcf",
+  ".xls",
+  ".xlsx",
+  ".zip",
+]);

--- a/apps/portal-web/src/utils/staticFiles.ts
+++ b/apps/portal-web/src/utils/staticFiles.ts
@@ -11,6 +11,7 @@
  */
 
 import { languageMap } from "src/utils/languageMap";
+import { nonEditableExtensions } from "src/utils/nonEditableExtensions";
 
 
 export function basename(path: string) {
@@ -34,4 +35,10 @@ export function getLanguage(filename) {
   const ext = filename.split(".").pop().toLowerCase();
   return languageMap[ext] || "plaintext";
 }
+
+export function canPreviewWithEditor(filename: string): boolean {
+  const extension = `.${filename.split(".").pop()}`;
+  return !nonEditableExtensions.has(extension.toLowerCase());
+}
+
 

--- a/apps/portal-web/src/utils/staticFiles.ts
+++ b/apps/portal-web/src/utils/staticFiles.ts
@@ -10,7 +10,28 @@
  * See the Mulan PSL v2 for more details.
  */
 
+import languageMap from "src/utils/languageMap";
+
+
 export function basename(path: string) {
   const parts = path.split(/[\/\\]/);
   return parts[parts.length - 1];
 }
+
+export function getExtension(filename: string) {
+  const parts = filename.split(".");
+  const extension = parts.pop();
+  return extension ? extension.toLowerCase() : "";
+}
+
+export function isNotImage(filename: string): boolean {
+  const imageExtensions = ["jpg", "jpeg", "png", "gif", "bmp", "tiff", "svg", "webp"];
+  const extension = getExtension(filename);
+  return !imageExtensions.includes(extension);
+}
+
+export function getLanguage(filename) {
+  const ext = filename.split(".").pop().toLowerCase();
+  return languageMap[ext] || "plaintext";
+}
+

--- a/apps/portal-web/src/utils/staticFiles.ts
+++ b/apps/portal-web/src/utils/staticFiles.ts
@@ -10,7 +10,7 @@
  * See the Mulan PSL v2 for more details.
  */
 
-import languageMap from "src/utils/languageMap";
+import { languageMap } from "src/utils/languageMap";
 
 
 export function basename(path: string) {
@@ -24,10 +24,10 @@ export function getExtension(filename: string) {
   return extension ? extension.toLowerCase() : "";
 }
 
-export function isNotImage(filename: string): boolean {
+export function isImage(filename: string): boolean {
   const imageExtensions = ["jpg", "jpeg", "png", "gif", "bmp", "tiff", "svg", "webp"];
   const extension = getExtension(filename);
-  return !imageExtensions.includes(extension);
+  return imageExtensions.includes(extension);
 }
 
 export function getLanguage(filename) {

--- a/dev/vagrant/config/portal.yaml
+++ b/dev/vagrant/config/portal.yaml
@@ -66,12 +66,12 @@ shell: true
 #   preview:
 #     # 大小限制
 #     # 可接受的格式为nginx的client_max_body_size可接受的值，默认为 50m
-#     limitSize: "40m"
+#     limitSize: "50m"
 #   # 文件编辑功能
 #   edit:
 #     # 文件编辑大小限制
 #     # 可接受的格式为nginx的client_max_body_size可接受的值，默认为 1m
-#     limitSize: "2m"
+#     limitSize: "1m"
 
 # 提交作业的默认工作目录。使用{{ name }}代替作业名称。相对于用户的家目录
 # submitJobDefaultPwd: scow/jobs/{{ name }}

--- a/dev/vagrant/config/portal.yaml
+++ b/dev/vagrant/config/portal.yaml
@@ -60,9 +60,11 @@ homeText:
 # 是否启用终端功能
 shell: true
 
-# 文件编辑大小限制
-# 可接受的格式为nginx的client_max_body_size可接受的值
-# fileEditSize: "1m"
+# # 文件编辑功能
+# fileEdit:
+#   # 文件编辑大小限制
+#   # 可接受的格式为nginx的client_max_body_size可接受的值，默认为 1m
+#   limitSize: "1m"
 
 # 提交作业的默认工作目录。使用{{ name }}代替作业名称。相对于用户的家目录
 # submitJobDefaultPwd: scow/jobs/{{ name }}

--- a/dev/vagrant/config/portal.yaml
+++ b/dev/vagrant/config/portal.yaml
@@ -60,6 +60,10 @@ homeText:
 # 是否启用终端功能
 shell: true
 
+# 文件编辑大小限制
+# 可接受的格式为nginx的client_max_body_size可接受的值
+# fileEditSize: "1m"
+
 # 提交作业的默认工作目录。使用{{ name }}代替作业名称。相对于用户的家目录
 # submitJobDefaultPwd: scow/jobs/{{ name }}
 

--- a/dev/vagrant/config/portal.yaml
+++ b/dev/vagrant/config/portal.yaml
@@ -60,11 +60,18 @@ homeText:
 # 是否启用终端功能
 shell: true
 
-# # 文件编辑功能
-# fileEdit:
-#   # 文件编辑大小限制
-#   # 可接受的格式为nginx的client_max_body_size可接受的值，默认为 1m
-#   limitSize: "1m"
+# # 文件管理
+# file:
+#   # 文件预览功能
+#   preview:
+#     # 大小限制
+#     # 可接受的格式为nginx的client_max_body_size可接受的值，默认为 50m
+#     limitSize: "40m"
+#   # 文件编辑功能
+#   edit:
+#     # 文件编辑大小限制
+#     # 可接受的格式为nginx的client_max_body_size可接受的值，默认为 1m
+#     limitSize: "2m"
 
 # 提交作业的默认工作目录。使用{{ name }}代替作业名称。相对于用户的家目录
 # submitJobDefaultPwd: scow/jobs/{{ name }}

--- a/docs/docs/deploy/config/portal/intro.md
+++ b/docs/docs/deploy/config/portal/intro.md
@@ -76,6 +76,20 @@ submitJobPromptText: "#此处参数设置的优先级高于页面其它地方，
 # 是否启用终端功能
 shell: true
 
+# # 文件管理
+# file:
+#   # 文件预览功能
+#   preview:
+#     # 大小限制
+#     # 可接受的格式为nginx的client_max_body_size可接受的值，默认为 50m
+#     limitSize: "50m"
+#   # 文件编辑功能
+#   edit:
+#     # 文件编辑大小限制
+#     # 可接受的格式为nginx的client_max_body_size可接受的值，默认为 1m
+#     # 建议设置为较大值
+#     limitSize: "1m"
+
 # 提交作业的默认工作目录。使用{{ name }}代替作业名称。相对于用户的家目录
 # submitJobDefaultPwd: scow/jobs/{{ name }}
 

--- a/libs/config/src/portal.ts
+++ b/libs/config/src/portal.ts
@@ -56,7 +56,9 @@ export const PortalConfigSchema = Type.Object({
 
   shell: Type.Boolean({ description: "是否启用终端功能", default: true }),
 
-  fileEditSize: Type.String({ description: "文件编辑大小限制", default: "1m" }),
+  fileEdit: Type.Object({
+    limitSize: Type.String({ description: "文件编辑大小限制", default: "1m" }),
+  }, { description: "文件编辑功能", default: { limitSize: "1m" } }),
 
   submitJobDefaultPwd: Type.String({
     description: "提交作业的默认工作目录。使用{{ name }}代替作业名称。相对于用户的家目录", default: "scow/jobs/{{ name }}" }),

--- a/libs/config/src/portal.ts
+++ b/libs/config/src/portal.ts
@@ -56,9 +56,15 @@ export const PortalConfigSchema = Type.Object({
 
   shell: Type.Boolean({ description: "是否启用终端功能", default: true }),
 
-  fileEdit: Type.Object({
-    limitSize: Type.String({ description: "文件编辑大小限制", default: "1m" }),
-  }, { description: "文件编辑功能", default: { limitSize: "1m" } }),
+  file: Type.Optional(Type.Object({
+    preview: Type.Object({
+      limitSize: Type.String({ description: "文件预览大小限制", default: "50m" }),
+    }, { description: "文件预览功能" }),
+    edit: Type.Object({
+      limitSize: Type.String({ description: "文件编辑大小限制", default: "1m" }),
+    }, { description: "文件编辑功能" }),
+  }, { description: "文件管理" })),
+
 
   submitJobDefaultPwd: Type.String({
     description: "提交作业的默认工作目录。使用{{ name }}代替作业名称。相对于用户的家目录", default: "scow/jobs/{{ name }}" }),

--- a/libs/config/src/portal.ts
+++ b/libs/config/src/portal.ts
@@ -56,6 +56,8 @@ export const PortalConfigSchema = Type.Object({
 
   shell: Type.Boolean({ description: "是否启用终端功能", default: true }),
 
+  fileEditSize: Type.String({ description: "文件编辑大小限制", default: "1m" }),
+
   submitJobDefaultPwd: Type.String({
     description: "提交作业的默认工作目录。使用{{ name }}代替作业名称。相对于用户的家目录", default: "scow/jobs/{{ name }}" }),
 

--- a/libs/config/src/portal.ts
+++ b/libs/config/src/portal.ts
@@ -59,10 +59,10 @@ export const PortalConfigSchema = Type.Object({
   file: Type.Optional(Type.Object({
     preview: Type.Object({
       limitSize: Type.String({ description: "文件预览大小限制", default: "50m" }),
-    }, { description: "文件预览功能" }),
+    }, { description: "文件预览功能", default: {} }),
     edit: Type.Object({
       limitSize: Type.String({ description: "文件编辑大小限制", default: "1m" }),
-    }, { description: "文件编辑功能" }),
+    }, { description: "文件编辑功能", default: {} }),
   }, { description: "文件管理" })),
 
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -703,6 +703,9 @@ importers:
       '@grpc/grpc-js':
         specifier: 1.9.5
         version: 1.9.5
+      '@monaco-editor/react':
+        specifier: ^4.6.0
+        version: 4.6.0(monaco-editor@0.44.0)(react-dom@18.2.0)(react@18.2.0)
       '@scow/config':
         specifier: workspace:*
         version: link:../../libs/config
@@ -763,6 +766,9 @@ importers:
       mime-types:
         specifier: 2.1.35
         version: 2.1.35
+      monaco-editor:
+        specifier: 0.44.0
+        version: 0.44.0
       next:
         specifier: 13.4.10
         version: 13.4.10(@babel/core@7.22.5)(react-dom@18.2.0)(react@18.2.0)
@@ -6021,6 +6027,28 @@ packages:
       '@mikro-orm/core': 5.7.14(@mikro-orm/mariadb@5.7.14)(@mikro-orm/migrations@5.7.14)(@mikro-orm/mysql@5.7.14)(@mikro-orm/seeder@5.7.14)
       fs-extra: 11.1.1
       globby: 11.1.0
+    dev: false
+
+  /@monaco-editor/loader@1.4.0(monaco-editor@0.44.0):
+    resolution: {integrity: sha512-00ioBig0x642hytVspPl7DbQyaSWRaolYie/UFNjoTdvoKPzo6xrXLhTk9ixgIKcLH5b5vDOjVNiGyY+uDCUlg==}
+    peerDependencies:
+      monaco-editor: '>= 0.21.0 < 1'
+    dependencies:
+      monaco-editor: 0.44.0
+      state-local: 1.0.7
+    dev: false
+
+  /@monaco-editor/react@4.6.0(monaco-editor@0.44.0)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-RFkU9/i7cN2bsq/iTkurMWOEErmYcY6JiQI3Jn+WeR/FGISH8JbHERjpS9oRuSOPvDMJI0Z8nJeKkbOs9sBYQw==}
+    peerDependencies:
+      monaco-editor: '>= 0.25.0 < 1'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@monaco-editor/loader': 1.4.0(monaco-editor@0.44.0)
+      monaco-editor: 0.44.0
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
   /@next/bundle-analyzer@13.4.13:
@@ -14661,6 +14689,10 @@ packages:
     resolution: {integrity: sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==}
     dev: false
 
+  /monaco-editor@0.44.0:
+    resolution: {integrity: sha512-5SmjNStN6bSuSE5WPT2ZV+iYn1/yI9sd4Igtk23ChvqB7kDk9lZbB9F5frsuvpB+2njdIeGGFf2G4gbE6rCC9Q==}
+    dev: false
+
   /moo@0.5.2:
     resolution: {integrity: sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==}
     dev: false
@@ -18412,6 +18444,10 @@ packages:
 
   /standard-as-callback@2.1.0:
     resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
+    dev: false
+
+  /state-local@1.0.7:
+    resolution: {integrity: sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==}
     dev: false
 
   /state-toggle@1.0.3:

--- a/renovate.json
+++ b/renovate.json
@@ -25,9 +25,7 @@
     },
     {
       "matchPackagePatterns": [
-        "next",
-        "@monaco-editor/react",
-        "monaco-editor"
+        "next"
       ],
       "enabled": false
     },

--- a/renovate.json
+++ b/renovate.json
@@ -25,7 +25,9 @@
     },
     {
       "matchPackagePatterns": [
-        "next"
+        "next",
+        "@monaco-editor/react",
+        "monaco-editor"
       ],
       "enabled": false
     },


### PR DESCRIPTION
# 文件编辑功能
## 1. 查看页面采取预览模态框，取消现有的网页形式，同时还能解决现在文件较大时查看可能会崩溃的情况；
![image](https://github.com/PKUHPC/SCOW/assets/140392039/30bb6918-d125-4523-aa80-a01d2fb0191c)
![image](https://github.com/PKUHPC/SCOW/assets/140392039/ff18fdd0-0f07-496e-b5b9-09bfbb5819e8)

## 2. 点击文件为查看操作，此时需判断该文件是否支持在线查看，判断标准：文件格式，ppt、doc、exe等确定无法查看的文件 不允许查看，文件大小超标的（管理员配置，默认50M）的不允许查看。点击后弹出提示“文件过大或者格式不支持，请下载后查看”，不再自动下载文件。其余文件允许查看（仍然可能是乱码，但是没关系，除了明确无法查看的应该尽量允许用户查看）。
![image](https://github.com/PKUHPC/SCOW/assets/140392039/469507b3-7b99-488c-a6b2-12b4f074e1ca)
![image](https://github.com/PKUHPC/SCOW/assets/140392039/113ba9bd-9ec8-47e8-a879-06873ae09977)

## 3. 在查看文件页面，右下角增加编辑按钮，右上角增加全屏/取消全屏和关闭按钮，点击编辑后进入编辑模式，右下角变为退出编辑和保存按钮；
![image](https://github.com/PKUHPC/SCOW/assets/140392039/752919f3-9848-4c0b-a1e1-afab6a96bf2d)
![image](https://github.com/PKUHPC/SCOW/assets/140392039/689d9732-6a28-4e6b-9184-c67cb1b12cbc)

## 4. 点击编辑时判断该文件是否支持在线编辑，判断标准：文件大小，文件大小超标的（管理员配置，默认10M）不允许编辑，点击后弹出提示“文件过大，请下载后编辑”。
![image](https://github.com/PKUHPC/SCOW/assets/140392039/69ab36f0-6e1c-4ea7-8b49-eb3843bbe1ce)

## 5. 编辑页面，关闭按钮关闭页面，取消按钮退出编辑模式返回查看页面，点击关闭或取消时如果有编辑过内容，则弹出提示“文件未保存，是否保存该文件”;
![image](https://github.com/PKUHPC/SCOW/assets/140392039/31cf6866-f088-4d5a-8cde-cc079f4d7fcb)

## 6. 可编辑文件大小可配置
在 `portal.yaml` 中新增配置项：
```yaml
# 文件管理
file:
  # 文件预览功能
  preview:
    # 大小限制
    # 可接受的格式为nginx的client_max_body_size可接受的值，默认为 50m
    limitSize: "40m"
  # 文件编辑功能
  edit:
    # 文件编辑大小限制
    # 可接受的格式为nginx的client_max_body_size可接受的值，默认为 1m
    limitSize: "2m"
```
默认可预览文件大小为 50m
默认可编辑文件大小为 1m

目前只有 js、ts、json 等有代码提示，其余语言暂时只有语法高亮

### 文件修改后显示已编辑状态
![image](https://github.com/PKUHPC/SCOW/assets/140392039/962fc661-1d01-40fe-beed-7cc1492b9c21)
