### PR TITLE
feat(portal-web): 交互式应用列表PENDING状态修改为不显示剩余时间

### DIFF
--- a/.changeset/lemon-garlics-sin.md
+++ b/.changeset/lemon-garlics-sin.md
@@ -1,0 +1,5 @@
+---
+"@scow/portal-web": patch
+---
+
+修改交互式应用列表作业在 PENDING 状态时不显示剩余时间

--- a/apps/portal-web/src/pageComponents/app/AppSessionsTable.tsx
+++ b/apps/portal-web/src/pageComponents/app/AppSessionsTable.tsx
@@ -61,7 +61,8 @@ export const AppSessionsTable: React.FC<Props> = ({ cluster }) => {
 
       return sessions.map((x) => ({
         ...x,
-        remainingTime: x.state === "RUNNING" ? calculateAppRemainingTime(x.runningTime, x.timeLimit) : x.timeLimit,
+        remainingTime: x.state === "RUNNING" ? calculateAppRemainingTime(x.runningTime, x.timeLimit) :
+          x.state === "PENDING" ? "" : x.timeLimit,
       }));
 
     }, [cluster]),


### PR DESCRIPTION
### 做了什么

修改交互式应用列表PENDING状态时不显示剩余时间
修改后👇（本地环境问题，作业id有重复）
![pending时不显示剩余时间](https://github.com/PKUHPC/SCOW/assets/43978285/6a6ccf2b-cbb7-4efb-a386-bf3604ff7967)
