### PR TITLE
fix(mis): 移出用户前增加用户是否有运行中作业的判断

### DIFF
--- a/.changeset/angry-coats-wait.md
+++ b/.changeset/angry-coats-wait.md
@@ -1,0 +1,6 @@
+---
+"@scow/mis-server": patch
+"@scow/mis-web": patch
+---
+
+移出用户前增加用户是否有运行中作业的判断

--- a/apps/mis-server/src/services/user.ts
+++ b/apps/mis-server/src/services/user.ts
@@ -214,6 +214,7 @@ export const userServiceServer = plugin((server) => {
       // 如果要从账户中移出用户，先封锁，先将用户封锁，保证用户无法提交作业
       if (userAccount.status === UserStatus.UNBLOCKED) {
         await blockUserInAccount(userAccount, server.ext, logger);
+        await em.flush();
       }
 
       // 查询用户是否有RUNNING、PENDING的作业，如果有，抛出异常

--- a/apps/mis-server/src/services/user.ts
+++ b/apps/mis-server/src/services/user.ts
@@ -196,7 +196,7 @@ export const userServiceServer = plugin((server) => {
       const userAccount = await em.findOne(UserAccount, {
         user: { userId, tenant: { name: tenantName } },
         account: { accountName, tenant: { name: tenantName } },
-      });
+      }, { populate: ["user", "account"]});
 
       if (!userAccount) {
         throw <ServiceError>{
@@ -208,6 +208,33 @@ export const userServiceServer = plugin((server) => {
         throw <ServiceError>{
           code: Status.OUT_OF_RANGE,
           message: `User ${userId} is the owner of the account ${accountName}。`,
+        };
+      }
+
+      // 如果要从账户中移出用户，先封锁，先将用户封锁，保证用户无法提交作业
+      if (userAccount.status === UserStatus.UNBLOCKED) {
+        await blockUserInAccount(userAccount, server.ext, logger);
+      }
+
+      // 查询用户是否有RUNNING、PENDING的作业，如果有，抛出异常
+      const jobs = await server.ext.clusters.callOnAll(
+        logger,
+        async (client) => {
+          const fields = [
+            "job_id", "user", "state", "account",
+          ];
+
+          return await asyncClientCall(client.job, "getJobs", {
+            fields,
+            filter: { users: [userId], accounts: [accountName], states: ["RUNNING", "PENDING"]},
+          });
+        },
+      );
+
+      if (jobs.filter((i) => i.result.jobs.length > 0).length > 0) {
+        throw <ServiceError>{
+          code: Status.FAILED_PRECONDITION,
+          message: `User ${userId}  has jobs running or pending and cannot remove. `,
         };
       }
 

--- a/apps/mis-server/src/services/user.ts
+++ b/apps/mis-server/src/services/user.ts
@@ -221,9 +221,7 @@ export const userServiceServer = plugin((server) => {
       const jobs = await server.ext.clusters.callOnAll(
         logger,
         async (client) => {
-          const fields = [
-            "job_id", "user", "state", "account",
-          ];
+          const fields = ["job_id", "user", "state", "account"];
 
           return await asyncClientCall(client.job, "getJobs", {
             fields,
@@ -235,7 +233,8 @@ export const userServiceServer = plugin((server) => {
       if (jobs.filter((i) => i.result.jobs.length > 0).length > 0) {
         throw <ServiceError>{
           code: Status.FAILED_PRECONDITION,
-          message: `User ${userId}  has jobs running or pending and cannot remove. `,
+          message: `User ${userId}  has jobs running or pending and cannot remove.
+          Please wait for the job to end or end the job manually before moving out.`,
         };
       }
 

--- a/apps/mis-server/src/services/user.ts
+++ b/apps/mis-server/src/services/user.ts
@@ -233,7 +233,7 @@ export const userServiceServer = plugin((server) => {
       if (jobs.filter((i) => i.result.jobs.length > 0).length > 0) {
         throw <ServiceError>{
           code: Status.FAILED_PRECONDITION,
-          message: `User ${userId}  has jobs running or pending and cannot remove.
+          message: `User ${userId} has jobs running or pending and cannot remove.
           Please wait for the job to end or end the job manually before moving out.`,
         };
       }

--- a/apps/mis-web/src/i18n/en.ts
+++ b/apps/mis-web/src/i18n/en.ts
@@ -642,6 +642,8 @@ export default {
         confirmRemoveText: "Confirm removing user from account",
         removeSuccess: "User removed successfully!",
         removerUser: "Remove User",
+        cannotRemoverUserWhoHaveRunningJobFromAccount: "The user still has a job running, "
+          + " and the user has been blocked. Please wait for the job to end or end the job manually before moving out.",
       },
     },
   },

--- a/apps/mis-web/src/i18n/zh_cn.ts
+++ b/apps/mis-web/src/i18n/zh_cn.ts
@@ -642,6 +642,7 @@ export default {
         confirmRemoveText:"确认要从账户",
         removeSuccess:"移出用户成功！",
         removerUser:"移出用户",
+        cannotRemoverUserWhoHaveRunningJobFromAccount:"用户还有作业在运行，已封锁该用户，请等待作业结束或手动结束作业后再移出",
       },
     },
   },

--- a/apps/mis-web/src/pageComponents/users/UserTable.tsx
+++ b/apps/mis-web/src/pageComponents/users/UserTable.tsx
@@ -214,7 +214,14 @@ export const UserTable: React.FC<Props> = ({
                       identityId: r.userId,
                       accountName: accountName,
                     } })
-                      .httpError(409, () => { message.error(t(p("cannotRemoverUserWhoHaveRunningJobFromAccount"))); })
+                      .httpError(409, () => {
+                        message.destroy("removeUser");
+                        message.error({
+                          content: t(p("cannotRemoverUserWhoHaveRunningJobFromAccount")),
+                          duration: 4,
+                        });
+                        reload();
+                      })
                       .then(() => {
                         message.destroy("removeUser");
                         message.success(t(p("removeSuccess")));

--- a/apps/mis-web/src/pageComponents/users/UserTable.tsx
+++ b/apps/mis-web/src/pageComponents/users/UserTable.tsx
@@ -214,6 +214,7 @@ export const UserTable: React.FC<Props> = ({
                       identityId: r.userId,
                       accountName: accountName,
                     } })
+                      .httpError(409, () => { message.error(t(p("cannotRemoverUserWhoHaveRunningJobFromAccount"))); })
                       .then(() => {
                         message.destroy("removeUser");
                         message.success(t(p("removeSuccess")));

--- a/apps/mis-web/src/pages/api/users/removeFromAccount.ts
+++ b/apps/mis-web/src/pages/api/users/removeFromAccount.ts
@@ -39,6 +39,8 @@ export const RemoveUserFromAccountSchema = typeboxRouteSchema({
     // 不能移出账户拥有者
     406: Type.Null(),
 
+    // 不能移出有正在运行作业的用户，只能先封锁
+    409: Type.Null(),
   },
 });
 
@@ -81,6 +83,7 @@ export default /* #__PURE__*/route(RemoveUserFromAccountSchema, async (req, res)
     .catch(handlegRPCError({
       [Status.NOT_FOUND]: () => ({ 404: null }),
       [Status.OUT_OF_RANGE]: () => ({ 406: null }),
+      [Status.FAILED_PRECONDITION]: () => ({ 409: null }),
     },
     async () => await callLog(logInfo, OperationResult.FAIL),
     ));


### PR DESCRIPTION
在移出用户的时候，先将用户封锁，保证用户无法提交作业，再查看用户是否有还在运行的作业。如果有的话，提示：用户还有作业在运行，请等待作业结束或手动结束作业后再移出

![image](https://github.com/PKUHPC/SCOW/assets/25954437/7e728455-eb18-4858-804a-323ebb90662f)
