### PR TITLE
feat(audit): 操作日志内容增加模糊搜索功能

### DIFF
--- a/.changeset/purple-cars-worry.md
+++ b/.changeset/purple-cars-worry.md
@@ -1,0 +1,6 @@
+---
+"@scow/audit-server": minor
+"@scow/mis-web": minor
+---
+
+操作日志新增操作内容模糊搜索功能

--- a/.changeset/tender-lamps-shout.md
+++ b/.changeset/tender-lamps-shout.md
@@ -1,0 +1,5 @@
+---
+"@scow/grpc-api": minor
+---
+
+GetOperationLogs 新增 operation_detail 传参用于模糊搜索

--- a/apps/audit-server/src/utils/operationLogs.ts
+++ b/apps/audit-server/src/utils/operationLogs.ts
@@ -26,6 +26,7 @@ export async function filterOperationLogs(
     endTime,
     operationType,
     operationTargetAccountName,
+    operationDetail,
   }: OperationLogFilter,
 ) {
 
@@ -35,11 +36,13 @@ export async function filterOperationLogs(
       ...(startTime ? [{ operationTime: { $gte: startTime } }] : []),
       ...(endTime ? [{ operationTime: { $lte: endTime } }] : []),
     ],
-    ...(operationType || operationTargetAccountName ? {
+    ...(operationType || operationTargetAccountName || operationDetail ? {
       metaData: {
         ...((operationType) ? { $case: operationType } : {}),
         ...((operationTargetAccountName) ? { targetAccountName: operationTargetAccountName } : {}),
+        ...operationDetail ? { $like: `%${operationDetail}%` } : {},
       },
+
     } : {}),
     ...(operationResult ? { operation_result: operationResultToJSON(operationResult) } : {}),
   };

--- a/apps/audit-server/tests/log/operationLogs.test.ts
+++ b/apps/audit-server/tests/log/operationLogs.test.ts
@@ -90,7 +90,7 @@ it("get operation logs", async () => {
 
   const resp = await asyncClientCall(client, "getOperationLogs", {
     page: 1,
-    filter: { operatorUserIds: ["testUserId"]},
+    filter: { operatorUserIds: ["testUserId"], operationDetail: "123" },
   });
 
   expect(resp.totalCount).toBe(2);

--- a/apps/mis-web/src/components/OperationLogTable.tsx
+++ b/apps/mis-web/src/components/OperationLogTable.tsx
@@ -32,6 +32,7 @@ interface FilterForm {
   operationType?: OperationType;
   operationTime?: [dayjs.Dayjs, dayjs.Dayjs],
   operationResult?: OperationResult;
+  operationDetail?: string;
 }
 
 interface PageInfo {
@@ -66,6 +67,7 @@ export const OperationLogTable: React.FC<Props> = ({ user, queryType, accountNam
       operationType: undefined,
       operationTime: [today.clone().subtract(30, "day"), today],
       operationResult: undefined,
+      operationDetail: undefined,
     };
   });
 
@@ -90,6 +92,7 @@ export const OperationLogTable: React.FC<Props> = ({ user, queryType, accountNam
       startTime: query.operationTime?.[0].toISOString(),
       endTime: query.operationTime?.[1].toISOString(),
       operationTargetAccountName: accountName,
+      operationDetail: query.operationDetail,
       page: pageInfo.page,
       pageSize: pageInfo.pageSize,
     } });
@@ -120,8 +123,8 @@ export const OperationLogTable: React.FC<Props> = ({ user, queryType, accountNam
           initialValues={query}
           onFinish={async () => {
             const { operationType, operatorUserId,
-              operationResult, operationTime } = await form.validateFields();
-            setQuery({ operationType, operatorUserId, operationResult, operationTime });
+              operationResult, operationTime, operationDetail } = await form.validateFields();
+            setQuery({ operationType, operatorUserId, operationResult, operationTime, operationDetail });
             setPageInfo({ page: 1, pageSize: pageInfo.pageSize });
           }}
         >
@@ -153,6 +156,9 @@ export const OperationLogTable: React.FC<Props> = ({ user, queryType, accountNam
               <Input style={{ width: 150 }} />
             </Form.Item>
           )}
+          <Form.Item label="操作内容" name="operationDetail">
+            <Input style={{ width: 150 }} />
+          </Form.Item>
           <Form.Item label={t(p("operationTime"))} name="operationTime">
             <DatePicker.RangePicker showTime allowClear={false} presets={getDefaultPresets(languageId)} />
           </Form.Item>

--- a/apps/mis-web/src/pages/api/log/getOperationLog.ts
+++ b/apps/mis-web/src/pages/api/log/getOperationLog.ts
@@ -28,19 +28,13 @@ export const GetOperationLogFilter = Type.Object({
 
   operatorUserIds: Type.String(),
 
-  /**
-   * @format date-time
-   */
   startTime: Type.Optional(Type.String({ format: "date-time" })),
 
-  /**
-   * @format date-time
-   */
   endTime: Type.Optional(Type.String({ format: "date-time" })),
 
   operationType: Type.Optional(Type.Enum(OperationType)),
   operationResult: Type.Optional(Type.Enum(OperationResult)),
-
+  operationDetail: Type.Optional(Type.String()),
   operationTargetAccountName: Type.Optional(Type.String()),
 });
 
@@ -56,15 +50,10 @@ export const GetOperationLogsSchema = typeboxRouteSchema({
     type: Type.Enum(OperationLogQueryType),
 
     ...GetOperationLogFilter.properties,
-    /**
-     * @minimum 1
-     * @type integer
-     */
+
     page: Type.Integer({ minimum: 1 }),
 
-    /**
-     * @type integer
-     */
+
     pageSize: Type.Optional(Type.Integer()),
   }),
 
@@ -88,12 +77,13 @@ export default typeboxRoute(GetOperationLogsSchema, async (req, res) => {
 
   const {
     type, operatorUserIds, startTime, endTime,
-    operationType, operationResult, operationTargetAccountName, page, pageSize } = req.query;
+    operationType, operationResult, operationDetail, operationTargetAccountName, page, pageSize } = req.query;
 
   const filter = {
     operatorUserIds: operatorUserIds ? operatorUserIds.split(",") : [],
     startTime, endTime, operationType,
     operationResult, operationTargetAccountName,
+    operationDetail,
   };
   // 用户请求
   if (type === OperationLogQueryType.USER) {

--- a/protos/audit/operation_log.proto
+++ b/protos/audit/operation_log.proto
@@ -415,6 +415,9 @@ message OperationLogFilter {
   optional google.protobuf.Timestamp start_time = 4;
   optional google.protobuf.Timestamp end_time = 5;
   optional OperationResult operation_result = 6;
+
+  // 对operation_event里的信息进行搜索
+  optional string operation_detail = 7;
 }
 
 message GetOperationLogsRequest {


### PR DESCRIPTION
### 背景：
目前操作日志可以根据操作人，操作时间，操作结果以及操作类型进行筛选，但使用过程中，会遇到如下情况， 移除账户操作，需要查看移除a用户的操作，但是存在大量移除账户的操作，根据筛选条件无法快速定位到该条操作记录。

### 改动：

操作日志增加一个筛选框，用户可以输入用户id  账户名等信息对 操作内容中的数据进行模糊搜素

![image](https://github.com/PKUHPC/SCOW/assets/130351655/971cd527-bc83-4d6e-8c0a-a1de6ed82133)
