### PR TITLE
chore(mis-web): 优化充值列表以及获取充值记录接口传参

### DIFF
--- a/.changeset/silly-spiders-end.md
+++ b/.changeset/silly-spiders-end.md
@@ -1,0 +1,5 @@
+---
+"@scow/mis-web": patch
+---
+
+管理系统充值列表传参优化，删除多余参数，统一为 searchType 控制

--- a/apps/mis-web/src/pages/accounts/[accountName]/payments.tsx
+++ b/apps/mis-web/src/pages/accounts/[accountName]/payments.tsx
@@ -18,7 +18,7 @@ import { UserRole } from "src/models/User";
 import {
   checkQueryAccountNameIsAdmin,
   useAccountPagesAccountName } from "src/pageComponents/accounts/checkQueryAccountNameIsAdmin";
-import { PaymentTable } from "src/pageComponents/common/PaymentTable";
+import { PaymentTable, SearchType } from "src/pageComponents/common/PaymentTable";
 import { Head } from "src/utils/head";
 
 const p = prefix("page.accounts.accountName.payments.");
@@ -37,6 +37,7 @@ export const PaymentsPage: NextPage = requireAuth(
       <Head title={title} />
       <PageTitle titleText={title} />
       <PaymentTable
+        searchType={SearchType.selfAccount}
         accountName={accountName}
       />
     </div>

--- a/apps/mis-web/src/pages/admin/finance/payments.tsx
+++ b/apps/mis-web/src/pages/admin/finance/payments.tsx
@@ -32,8 +32,6 @@ export const TenantPaymentsPage: NextPage = requireAuth((i) =>
       <PageTitle titleText={t(p("chargeRecord"))} />
       <PaymentTable
         searchType={SearchType.tenant}
-        showTenantName={true}
-        showAuditInfo={true}
       />
     </div>
   );

--- a/apps/mis-web/src/pages/tenant/finance/accountPayments.tsx
+++ b/apps/mis-web/src/pages/tenant/finance/accountPayments.tsx
@@ -32,8 +32,6 @@ export const PaymentsPage: NextPage = requireAuth((i) =>
       <PageTitle titleText={t(p("title"))} />
       <PaymentTable
         searchType={SearchType.account}
-        showAccountName={true}
-        showAuditInfo={true}
       />
     </div>
   );

--- a/apps/mis-web/src/pages/tenant/finance/payments.tsx
+++ b/apps/mis-web/src/pages/tenant/finance/payments.tsx
@@ -15,7 +15,7 @@ import { requireAuth } from "src/auth/requireAuth";
 import { PageTitle } from "src/components/PageTitle";
 import { prefix, useI18nTranslateToString } from "src/i18n";
 import { TenantRole } from "src/models/User";
-import { PaymentTable } from "src/pageComponents/common/PaymentTable";
+import { PaymentTable, SearchType } from "src/pageComponents/common/PaymentTable";
 import { Head } from "src/utils/head";
 
 const p = prefix("page.tenant.finance.payments.");
@@ -31,7 +31,7 @@ export const PaymentsPage: NextPage = requireAuth((i) =>
       <Head title={t(p("title"))} />
       <PageTitle titleText={t(p("title"))} />
       <PaymentTable
-        showAuditInfo={true}
+        searchType={SearchType.selfTenant}
       />
     </div>
   );


### PR DESCRIPTION
### 现状
目前充值table为公共组件，一共四个页面使用，分别为

1. 账户管理下的充值记录(仅查用户自己账户的充值信息)
2. 租户管理下的账户充值记录(可查询自己租户下所有的账户充值记录，且可以对账户进行筛选)
3. 租户管理下的租户充值记录(仅查用户自己租户的充值信息)
4. 平台管理下的充值记录(可查询平台所有的租户充值记录，且可以对租户进行筛选)

且查询充值记录共有两个web api： getTenantPayments和 getPayments
getTenantPayments负责4的情况， getPayments负责1，2，3页面

对于getPayments，同时还会传参accountName，searchTenant，再根据这两个参数决定如何调用grpc，前后端一共有多个参数以及if判断来区分这四种情况，逻辑比较乱。

### 改动
将多余参数删去，仅用searchType 表示四种情况，并且将searchType传至getPayments来判断如何调用grpc服务