### PR TITLE
fix(portal-web): 修复/api/proxy无法建立websocket连接

### DIFF
--- a/.changeset/pretty-pumpkins-enjoy.md
+++ b/.changeset/pretty-pumpkins-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@scow/portal-web": patch
+---
+
+修复/api/proxy路径websocket无法建立连接问题

--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
   "packageManager": "pnpm@8.10.5",
   "pnpm": {
     "patchedDependencies": {
-      "react-typed-i18n@2.3.0": "patches/react-typed-i18n@2.3.0.patch"
+      "react-typed-i18n@2.3.0": "patches/react-typed-i18n@2.3.0.patch",
+      "next@14.0.3": "patches/next@14.0.3.patch"
     }
   }
 }

--- a/patches/next@14.0.3.patch
+++ b/patches/next@14.0.3.patch
@@ -1,0 +1,17 @@
+diff --git a/dist/server/lib/router-server.js b/dist/server/lib/router-server.js
+index caf4e897450f93c80cea20301bccf9d68880500d..b5cbbca59b5c87a55a2b104d65b1396fcfef9349 100644
+--- a/dist/server/lib/router-server.js
++++ b/dist/server/lib/router-server.js
+@@ -411,9 +411,9 @@ async function initialize(opts) {
+             });
+             // TODO: allow upgrade requests to pages/app paths?
+             // this was not previously supported
+-            if (matchedOutput) {
+-                return socket.end();
+-            }
++            // if (matchedOutput) {
++            //     return socket.end();
++            // }
+             if (parsedUrl.protocol) {
+                 return await (0, _proxyrequest.proxyRequest)(req, socket, parsedUrl, head);
+             }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
+  next@14.0.3:
+    hash: u3guk2b2qg64nbffn3mmconeve
+    path: patches/next@14.0.3.patch
   react-typed-i18n@2.3.0:
     hash: eybujl4up7xenffji6zpg43f3u
     path: patches/react-typed-i18n@2.3.0.patch
@@ -509,7 +512,7 @@ importers:
         version: 2.1.35
       next:
         specifier: 14.0.3
-        version: 14.0.3(@babel/core@7.23.3)(react-dom@18.2.0)(react@18.2.0)
+        version: 14.0.3(patch_hash=u3guk2b2qg64nbffn3mmconeve)(@babel/core@7.23.3)(react-dom@18.2.0)(react@18.2.0)
       next-compose-plugins:
         specifier: 2.2.1
         version: 2.2.1
@@ -772,7 +775,7 @@ importers:
         version: 0.44.0
       next:
         specifier: 14.0.3
-        version: 14.0.3(@babel/core@7.23.3)(react-dom@18.2.0)(react@18.2.0)
+        version: 14.0.3(patch_hash=u3guk2b2qg64nbffn3mmconeve)(@babel/core@7.23.3)(react-dom@18.2.0)(react@18.2.0)
       next-compose-plugins:
         specifier: 2.2.1
         version: 2.2.1
@@ -1216,7 +1219,7 @@ importers:
         version: 1.11.10
       next:
         specifier: 14.0.3
-        version: 14.0.3(@babel/core@7.23.3)(react-dom@18.2.0)(react@18.2.0)
+        version: 14.0.3(patch_hash=u3guk2b2qg64nbffn3mmconeve)(@babel/core@7.23.3)(react-dom@18.2.0)(react@18.2.0)
       react:
         specifier: 18.2.0
         version: 18.2.0
@@ -3527,7 +3530,7 @@ packages:
       ajv-formats: 2.1.1(ajv@8.12.0)
       ajv-formats-draft2019: 1.6.1(ajv@8.12.0)
       fast-json-stringify: 5.8.0
-      next: 14.0.3(@babel/core@7.23.3)(react-dom@18.2.0)(react@18.2.0)
+      next: 14.0.3(patch_hash=u3guk2b2qg64nbffn3mmconeve)(@babel/core@7.23.3)(react-dom@18.2.0)(react@18.2.0)
       tslib: 2.6.1
       zod: 3.22.4
     dev: false
@@ -14862,7 +14865,7 @@ packages:
     resolution: {integrity: sha512-OjJ+fV15FXO2uQXQagLD4C0abYErBjyjE0I0FHpOEIB8upw0hg1ldFP6cqHTJBH1cZqy96OeR3u1dJ+Ez2D4Bg==}
     dev: false
 
-  /next@14.0.3(@babel/core@7.23.3)(react-dom@18.2.0)(react@18.2.0):
+  /next@14.0.3(patch_hash=u3guk2b2qg64nbffn3mmconeve)(@babel/core@7.23.3)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-AbYdRNfImBr3XGtvnwOxq8ekVCwbFTv/UJoLwmaX89nk9i051AEY4/HAWzU0YpaTDw8IofUpmuIlvzWF13jxIw==}
     engines: {node: '>=18.17.0'}
     hasBin: true
@@ -14899,6 +14902,7 @@ packages:
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
+    patched: true
 
   /no-case@3.0.4:
     resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}


### PR DESCRIPTION
#985 后继。

从next.js 14开始，对已经注册为route的path（包括pages下的页面，pages/api下的api route）发送websocket请求会直接1006断开。代理http/ws请求的path都是一致的/api/proxy，之前/api/proxy是作为api route出现的，所以对/api/proxy的ws请求会直接断开。

此PR删除了next中关于此部分的逻辑，允许了往已经注册为route的path upgrade的逻辑。

此方案在dev可行，在构建后不可行：删除了/api/proxy的api route，在系统启动的时候，为http server增加request事件的handler，在此handler中处理/api/proxy的代理HTTP请求的逻辑。原因推测为构建后会直接404掉没有注册为route的path。