### PR TITLE
feat(portal-web): 优化文件编辑功能

### DIFF
--- a/.changeset/empty-dancers-film.md
+++ b/.changeset/empty-dancers-film.md
@@ -2,4 +2,4 @@
 "@scow/portal-web": patch
 ---
 
-修改 monaco-editor 默认换行符为 LF
+优化文件编辑功能

--- a/.changeset/empty-dancers-film.md
+++ b/.changeset/empty-dancers-film.md
@@ -1,0 +1,5 @@
+---
+"@scow/portal-web": patch
+---
+
+修改 monaco-editor 默认换行符为 LF

--- a/apps/portal-web/src/i18n/en.ts
+++ b/apps/portal-web/src/i18n/en.ts
@@ -233,6 +233,7 @@ export default {
         saveFileFail: "File save failed: {}",
         saveFileSuccess: "File saved successfully",
         fileSizeExceeded: "File too large (maximum {}), please download and edit",
+        fileFetchAbortPrompt: "Fetch {} operation was aborted",
       },
       createFileModal: {
         createErrorMessage: "File or directory with the same name already exists!",

--- a/apps/portal-web/src/i18n/zh_cn.ts
+++ b/apps/portal-web/src/i18n/zh_cn.ts
@@ -233,6 +233,7 @@ export default {
         saveFileFail: "文件保存失败: {}",
         saveFileSuccess: "文件保存成功",
         fileSizeExceeded: "文件过大（最大{}），请下载后编辑",
+        fileFetchAbortPrompt: "获取文件 {} 操作被终止",
       },
       createFileModal: {
         createErrorMessage: "同名文件或者目录已经存在！",

--- a/apps/portal-web/src/pageComponents/filemanager/FileEditModal.tsx
+++ b/apps/portal-web/src/pageComponents/filemanager/FileEditModal.tsx
@@ -13,8 +13,9 @@
 import { CloseOutlined, FullscreenExitOutlined, FullscreenOutlined } from "@ant-design/icons";
 import Editor, { loader } from "@monaco-editor/react";
 import { App, Badge, Button, Modal, Space, Spin, Tabs, Tooltip } from "antd";
+import { editor } from "monaco-editor";
 import { join } from "path";
-import { Dispatch, SetStateAction, useEffect, useState } from "react";
+import { Dispatch, SetStateAction, useEffect, useRef, useState } from "react";
 import { api } from "src/apis";
 import { prefix, useI18nTranslateToString } from "src/i18n";
 import { publicConfig } from "src/utils/config";
@@ -158,6 +159,7 @@ export const FileEditModal: React.FC<Props> = ({ previewFile, setPreviewFile }) 
   const [confirm, setConfirm] = useState(false);
   const [exitType, setExitType] = useState<ExitType>(ExitType.CLOSE);
   const [isFullScreen, setIsFullScreen] = useState(false);
+  const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null);
 
   const [options, setOptions] = useState({
     readOnly: true,
@@ -169,6 +171,15 @@ export const FileEditModal: React.FC<Props> = ({ previewFile, setPreviewFile }) 
       downloadFile();
     }
   }, [open]);
+
+  useEffect(() => {
+    if (editorRef.current) {
+      const editorInstance = editorRef.current.getModel();
+
+      // 设置换行符为 LF (\n)
+      editorInstance?.setEOL(0); // 0 代表 LF，1 代表 CRLF
+    }
+  }, [editorRef.current]);
 
   const { message } = App.useApp();
 
@@ -393,6 +404,7 @@ export const FileEditModal: React.FC<Props> = ({ previewFile, setPreviewFile }) 
                   defaultLanguage={getLanguage(filename)}
                   options={options}
                   value={fileContent}
+                  onMount={(editor) => { editorRef.current = editor; }}
                   onChange={handleEdit}
                 />
               </Spin>

--- a/apps/portal-web/src/pageComponents/filemanager/FileEditModal.tsx
+++ b/apps/portal-web/src/pageComponents/filemanager/FileEditModal.tsx
@@ -151,7 +151,7 @@ export const FileEditModal: React.FC<Props> = ({ previewFile, setPreviewFile }) 
   const { open, filename, fileSize, filePath, clusterId } = previewFile;
 
   const [mode, setMode] = useState<Mode>(Mode.PREVIEW);
-  const [fileContent, setFileContent] = useState("");
+  const [fileContent, setFileContent] = useState<string | undefined>(undefined);
   const [isEdit, setIsEdit] = useState(false);
   const [loading, setLoading] = useState(false);
   const [downloading, setDownloading] = useState(false);
@@ -196,7 +196,7 @@ export const FileEditModal: React.FC<Props> = ({ previewFile, setPreviewFile }) 
     setConfirm(false);
     setIsEdit(false);
     setMode(Mode.PREVIEW);
-    setFileContent("");
+    setFileContent(undefined);
     setOptions({
       ...options,
       readOnly: true,
@@ -240,6 +240,9 @@ export const FileEditModal: React.FC<Props> = ({ previewFile, setPreviewFile }) 
   };
 
   const handleSave = async () => {
+    if (fileContent === undefined) {
+      return;
+    }
 
     setSaving(true);
     const blob = new Blob([fileContent], { type: "text/plain" });

--- a/apps/portal-web/src/pageComponents/filemanager/FileEditModal.tsx
+++ b/apps/portal-web/src/pageComponents/filemanager/FileEditModal.tsx
@@ -184,8 +184,10 @@ export const FileEditModal: React.FC<Props> = ({ previewFile, setPreviewFile }) 
   const { message } = App.useApp();
 
   const handleEdit = (content) => {
-    if (content && !downloading) {
-      setIsEdit(true);
+    if (!downloading) {
+      if (content !== fileContent) {
+        setIsEdit(true);
+      }
       setFileContent(content);
     }
   };


### PR DESCRIPTION
# 优化文件编辑功能
## 修改 monaco-editor 默认换行符
monaco 编辑器会自动判断文件的换行符类型。
1. 如果是新建的空文件，则会根据当前运行环境（例如 windows）来决定换行符。
2. 如果不是空文件会根据当前文件的换行符自动判断后续的换行符，如果是 \r\n 后续也是 \r\n 如果原本就是 \n 那后续也是 \n

提交文件运行的模式下，如果文件换行符为 \r\n 时无法提交成功。
用户在 scow 上编写的时 monaco-editor 可能处于 windows 环境，如果在编辑一个新文件就会导致换行符为 \r\n
所以直接将 monaco-editor 的默认换行符设置为 \n，来避免上述情况的发生。但这样对于原本就是 \r\n 的文件，后续编辑会存在两种换行符。

如果要完全避免文件提交运行报错这个问题，还是应该在提交该文件时将换行符进行切换，这种情况仍然会导致该问题：
1. 用户直接上传的文件的换行符为 \r\n
2. 原本的文件就是 \r\n

## 增加流式文件下载中断逻辑
如果流式下载文件未结束时直接关闭模态框打开其他文件模态框会有内容覆盖问题，所需要增加中断流式加载

## 新增文件加载时禁止点击编辑按钮