### PR TITLE
fix(mis): 修复平台管理页面用户列表的用户统计错误

### DIFF
--- a/.changeset/fast-trees-draw.md
+++ b/.changeset/fast-trees-draw.md
@@ -1,0 +1,6 @@
+---
+"@scow/mis-server": minor
+"@scow/mis-web": minor
+---
+
+管理系统 AllUserTable 恢复计数接口并且新增筛选参数

--- a/.changeset/itchy-trains-play.md
+++ b/.changeset/itchy-trains-play.md
@@ -1,0 +1,5 @@
+---
+"@scow/grpc-api": minor
+---
+
+GetPlatformUsersCounts 新增 id_or_name 参数

--- a/apps/mis-server/src/services/user.ts
+++ b/apps/mis-server/src/services/user.ts
@@ -595,13 +595,23 @@ export const userServiceServer = plugin((server) => {
       }];
     },
 
-    getPlatformUsersCounts: async ({ em }) => {
-
-      const totalCount = await em.count(User);
+    getPlatformUsersCounts: async ({ request, em }) => {
+      const { idOrName } = request;
+      const idOrNameQuery = idOrName ? {
+        $and: [
+          {
+            $or: [
+              { userId: { $like: `%${idOrName}%` } },
+              { name: { $like: `%${idOrName}%` } },
+            ],
+          },
+        ],
+      } : {};
+      const totalCount = await em.count(User, idOrNameQuery);
       const totalAdminCount = await em.count(User,
-        { platformRoles: { $like: `%${PlatformRole.PLATFORM_ADMIN}%` } });
+        { platformRoles: { $like: `%${PlatformRole.PLATFORM_ADMIN}%` }, ...idOrNameQuery });
       const totalFinanceCount = await em.count(User,
-        { platformRoles: { $like: `%${PlatformRole.PLATFORM_FINANCE}%` } });
+        { platformRoles: { $like: `%${PlatformRole.PLATFORM_FINANCE}%` }, ...idOrNameQuery });
 
       return [{
         totalCount: totalCount,

--- a/apps/mis-web/src/pages/api/admin/getPlatformUsersCounts.ts
+++ b/apps/mis-web/src/pages/api/admin/getPlatformUsersCounts.ts
@@ -28,6 +28,10 @@ export type GetPlatformUsersCountsResponse = Static<typeof GetPlatformUsersCount
 export const GetPlatformUsersCountsSchema = typeboxRouteSchema({
   method: "GET",
 
+  query: Type.Object({
+    idOrName: Type.Optional(Type.String()),
+  }),
+
   responses: {
     200: GetPlatformUsersCountsResponse,
   },
@@ -42,10 +46,12 @@ export default typeboxRoute(GetPlatformUsersCountsSchema,
     if (!info) {
       return;
     }
-
+    const { idOrName } = req.query;
     const client = getClient(UserServiceClient);
 
-    const result = await asyncClientCall(client, "getPlatformUsersCounts", {});
+    const result = await asyncClientCall(client, "getPlatformUsersCounts", {
+      idOrName,
+    });
 
     return {
       200: result,

--- a/protos/server/user.proto
+++ b/protos/server/user.proto
@@ -302,6 +302,7 @@ message GetUsersByIdsResponse {
 }
 
 message GetPlatformUsersCountsRequest {
+  optional string id_or_name = 1;
 }
 
 message GetPlatformUsersCountsResponse {


### PR DESCRIPTION
### 现状：
1. 平台管理页面下的AllUserTable里的数据接口是后端分页，但是前端对三个tab的数据统计是根据该分页接口的该页数据过滤得到的，是不准确的。
2. 之前的GetPlatformUsersCounts是用来适配GetAllUsers后端分页接口，但在此处#905 被删去，原因在于当用户填入了筛选项时，数据统计的接口并不是筛选后的情况。


### 改动
1. 恢复AllUserTable里的GetPlatformUsersCounts接口，确保统计数据准确，
2. 同时给该接口增加过滤参数，确保用户输入过滤项时的数据实时更新。


