### PR TITLE
feat(cli): install.yaml 文件增加 misc.nodeOptions参数，可设置node服务参数

### DIFF
--- a/.changeset/famous-seals-hunt.md
+++ b/.changeset/famous-seals-hunt.md
@@ -2,4 +2,4 @@
 "@scow/cli": minor
 ---
 
-install.yaml 文件增加 mis.nodeArguments 参数，可传递 string 数组给所有 node 服务
+install.yaml 文件增加 mis.nodeOptions 参数，可传递给所有node 服务参数，如“--max-old-space-size=8192” 

--- a/.changeset/famous-seals-hunt.md
+++ b/.changeset/famous-seals-hunt.md
@@ -1,0 +1,5 @@
+---
+"@scow/cli": minor
+---
+
+install.yaml 文件增加 mis.nodeArguments 参数，可传递 string 数组给所有 node 服务

--- a/apps/cli/src/compose/index.ts
+++ b/apps/cli/src/compose/index.ts
@@ -196,7 +196,7 @@ export const createComposeSpec = (config: InstallConfigSchema) => {
       environment: {
         SCOW_LAUNCH_APP: "portal-server",
         PORTAL_BASE_PATH: portalBasePath,
-        NODE_ARGS: nodeArguments ? JSON.stringify(nodeArguments) : "",
+        NODE_ARGS: nodeArguments?.join(" ") ?? "",
         ...serviceLogEnv,
       },
       ports: config.portal.portMappings?.portalServer ? { [config.portal.portMappings.portalServer]: 5000 } : {},

--- a/apps/cli/src/compose/index.ts
+++ b/apps/cli/src/compose/index.ts
@@ -49,13 +49,13 @@ export const createComposeSpec = (config: InstallConfigSchema) => {
     LOG_PRETTY: String(config.log.pretty),
   };
 
-  const nodeArguments = config.misc?.nodeArguments;
-
   const composeSpec = {
     version: "3",
     services: {} as Record<string, ServiceSpec>,
     volumes: {} as Record<string, object>,
   };
+
+  const nodeOptions = config.misc?.nodeOptions;
 
   // service creation function
   const addService = (
@@ -66,7 +66,6 @@ export const createComposeSpec = (config: InstallConfigSchema) => {
       ports: string[] | Record<string, number>,
       volumes: string [] | Record<string, string>,
       depends_on?: string[],
-      command?: string,
     },
   ) => {
 
@@ -135,6 +134,7 @@ export const createComposeSpec = (config: InstallConfigSchema) => {
       "EXTRA": config.gateway.extra,
       "ALLOWED_SERVER_NAME": config.gateway.allowedServerName,
       "DEFAULT_SERVER_BLOCK": config.gateway.allowedServerName === "_" ? "" : defaultServerBlock,
+      ...nodeOptions ? { NODE_OPTIONS: nodeOptions } : {},
     },
     ports: { [config.port]: 80 },
     volumes: {
@@ -179,10 +179,10 @@ export const createComposeSpec = (config: InstallConfigSchema) => {
         "BASE_PATH": BASE_PATH,
         "PORTAL_BASE_PATH": portalBasePath,
         ...serviceLogEnv,
+        ...nodeOptions ? { NODE_OPTIONS: nodeOptions } : {},
       },
       ports: config.auth.portMappings?.auth ? { [config.auth.portMappings?.auth]: 5000 } : {},
       volumes: authVolumes,
-      ...nodeArguments ? { command: `node ${nodeArguments.join(" ")} index.js'` } : {},
     });
   }
 
@@ -196,8 +196,8 @@ export const createComposeSpec = (config: InstallConfigSchema) => {
       environment: {
         SCOW_LAUNCH_APP: "portal-server",
         PORTAL_BASE_PATH: portalBasePath,
-        NODE_ARGS: nodeArguments?.join(" ") ?? "",
         ...serviceLogEnv,
+        ...nodeOptions ? { NODE_OPTIONS: nodeOptions } : {},
       },
       ports: config.portal.portMappings?.portalServer ? { [config.portal.portMappings.portalServer]: 5000 } : {},
       volumes: {
@@ -205,7 +205,6 @@ export const createComposeSpec = (config: InstallConfigSchema) => {
         "./config": "/etc/scow",
         "~/.ssh": "/root/.ssh",
       },
-      ...nodeArguments ? { command: "sh -c 'node $$NODE_ARGS index.js'" } : {},
     });
 
     addService("portal-web", {
@@ -221,13 +220,13 @@ export const createComposeSpec = (config: InstallConfigSchema) => {
         "PUBLIC_PATH": join(BASE_PATH, publicPath),
         "AUDIT_DEPLOYED": config.audit ? "true" : "false",
         "PROTOCOL": config.gateway.protocol,
+        ...nodeOptions ? { NODE_OPTIONS: nodeOptions } : {},
       },
       ports: {},
       volumes: {
         "/etc/hosts": "/etc/hosts",
         "./config": "/etc/scow",
       },
-      ...nodeArguments ? { command: `node ${nodeArguments.join(" ")} index.js'` } : {},
     });
 
     addService("novnc", {
@@ -247,13 +246,13 @@ export const createComposeSpec = (config: InstallConfigSchema) => {
         "SCOW_LAUNCH_APP": "mis-server",
         "DB_PASSWORD": config.mis.dbPassword,
         ...serviceLogEnv,
+        ...nodeOptions ? { NODE_OPTIONS: nodeOptions } : {},
       },
       volumes: {
         "/etc/hosts": "/etc/hosts",
         "./config": "/etc/scow",
         "~/.ssh": "/root/.ssh",
       },
-      ...nodeArguments ? { command: `node ${nodeArguments.join(" ")} index.js'` } : {},
     });
 
     addService("mis-web", {
@@ -267,12 +266,12 @@ export const createComposeSpec = (config: InstallConfigSchema) => {
         "PUBLIC_PATH": join(BASE_PATH, publicPath),
         "AUDIT_DEPLOYED": config.audit ? "true" : "false",
         "PROTOCOL": config.gateway.protocol,
+        ...nodeOptions ? { NODE_OPTIONS: nodeOptions } : {},
       },
       ports: {},
       volumes: {
         "./config": "/etc/scow",
       },
-      ...nodeArguments ? { command: `node ${nodeArguments.join(" ")} index.js'` } : {},
     });
 
     composeSpec.volumes["db_data"] = {};
@@ -300,11 +299,11 @@ export const createComposeSpec = (config: InstallConfigSchema) => {
         "SCOW_LAUNCH_APP": "audit-server",
         "DB_PASSWORD": config.audit.dbPassword,
         ...serviceLogEnv,
+        ...nodeOptions ? { NODE_OPTIONS: nodeOptions } : {},
       },
       volumes: {
         "./config": "/etc/scow",
       },
-      ...nodeArguments ? { command: `node ${nodeArguments.join(" ")} index.js'` } : {},
     });
 
     composeSpec.volumes["audit_db_data"] = {};

--- a/apps/cli/src/compose/index.ts
+++ b/apps/cli/src/compose/index.ts
@@ -49,6 +49,8 @@ export const createComposeSpec = (config: InstallConfigSchema) => {
     LOG_PRETTY: String(config.log.pretty),
   };
 
+  const nodeArguments = config.misc?.nodeArguments;
+
   const composeSpec = {
     version: "3",
     services: {} as Record<string, ServiceSpec>,
@@ -64,6 +66,7 @@ export const createComposeSpec = (config: InstallConfigSchema) => {
       ports: string[] | Record<string, number>,
       volumes: string [] | Record<string, string>,
       depends_on?: string[],
+      command?: string,
     },
   ) => {
 
@@ -179,6 +182,7 @@ export const createComposeSpec = (config: InstallConfigSchema) => {
       },
       ports: config.auth.portMappings?.auth ? { [config.auth.portMappings?.auth]: 5000 } : {},
       volumes: authVolumes,
+      ...nodeArguments ? { command: `sh -c 'node ${nodeArguments} index.js'` } : {},
     });
   }
 
@@ -200,6 +204,7 @@ export const createComposeSpec = (config: InstallConfigSchema) => {
         "./config": "/etc/scow",
         "~/.ssh": "/root/.ssh",
       },
+      ...nodeArguments ? { command: `sh -c 'node ${nodeArguments} index.js'` } : {},
     });
 
     addService("portal-web", {
@@ -221,6 +226,7 @@ export const createComposeSpec = (config: InstallConfigSchema) => {
         "/etc/hosts": "/etc/hosts",
         "./config": "/etc/scow",
       },
+      ...nodeArguments ? { command: `sh -c 'node ${nodeArguments} index.js'` } : {},
     });
 
     addService("novnc", {
@@ -246,6 +252,7 @@ export const createComposeSpec = (config: InstallConfigSchema) => {
         "./config": "/etc/scow",
         "~/.ssh": "/root/.ssh",
       },
+      ...nodeArguments ? { command: `sh -c 'node ${nodeArguments} index.js'` } : {},
     });
 
     addService("mis-web", {
@@ -264,6 +271,7 @@ export const createComposeSpec = (config: InstallConfigSchema) => {
       volumes: {
         "./config": "/etc/scow",
       },
+      ...nodeArguments ? { command: `sh -c 'node ${nodeArguments} index.js'` } : {},
     });
 
     composeSpec.volumes["db_data"] = {};
@@ -295,6 +303,7 @@ export const createComposeSpec = (config: InstallConfigSchema) => {
       volumes: {
         "./config": "/etc/scow",
       },
+      ...nodeArguments ? { command: `sh -c 'node ${nodeArguments} index.js'` } : {},
     });
 
     composeSpec.volumes["audit_db_data"] = {};

--- a/apps/cli/src/compose/index.ts
+++ b/apps/cli/src/compose/index.ts
@@ -182,7 +182,7 @@ export const createComposeSpec = (config: InstallConfigSchema) => {
       },
       ports: config.auth.portMappings?.auth ? { [config.auth.portMappings?.auth]: 5000 } : {},
       volumes: authVolumes,
-      ...nodeArguments ? { command: `sh -c 'node ${nodeArguments} index.js'` } : {},
+      ...nodeArguments ? { command: `node ${nodeArguments.join(" ")} index.js'` } : {},
     });
   }
 

--- a/apps/cli/src/compose/index.ts
+++ b/apps/cli/src/compose/index.ts
@@ -196,6 +196,7 @@ export const createComposeSpec = (config: InstallConfigSchema) => {
       environment: {
         SCOW_LAUNCH_APP: "portal-server",
         PORTAL_BASE_PATH: portalBasePath,
+        NODE_ARGS: nodeArguments ? JSON.stringify(nodeArguments) : "",
         ...serviceLogEnv,
       },
       ports: config.portal.portMappings?.portalServer ? { [config.portal.portMappings.portalServer]: 5000 } : {},
@@ -204,7 +205,7 @@ export const createComposeSpec = (config: InstallConfigSchema) => {
         "./config": "/etc/scow",
         "~/.ssh": "/root/.ssh",
       },
-      ...nodeArguments ? { command: `node ${nodeArguments.join(" ")} index.js'` } : {},
+      ...nodeArguments ? { command: "sh -c 'node $$NODE_ARGS index.js'" } : {},
     });
 
     addService("portal-web", {

--- a/apps/cli/src/compose/index.ts
+++ b/apps/cli/src/compose/index.ts
@@ -204,7 +204,7 @@ export const createComposeSpec = (config: InstallConfigSchema) => {
         "./config": "/etc/scow",
         "~/.ssh": "/root/.ssh",
       },
-      ...nodeArguments ? { command: `sh -c 'node ${nodeArguments} index.js'` } : {},
+      ...nodeArguments ? { command: `node ${nodeArguments.join(" ")} index.js'` } : {},
     });
 
     addService("portal-web", {
@@ -226,7 +226,7 @@ export const createComposeSpec = (config: InstallConfigSchema) => {
         "/etc/hosts": "/etc/hosts",
         "./config": "/etc/scow",
       },
-      ...nodeArguments ? { command: `sh -c 'node ${nodeArguments} index.js'` } : {},
+      ...nodeArguments ? { command: `node ${nodeArguments.join(" ")} index.js'` } : {},
     });
 
     addService("novnc", {
@@ -252,7 +252,7 @@ export const createComposeSpec = (config: InstallConfigSchema) => {
         "./config": "/etc/scow",
         "~/.ssh": "/root/.ssh",
       },
-      ...nodeArguments ? { command: `sh -c 'node ${nodeArguments} index.js'` } : {},
+      ...nodeArguments ? { command: `node ${nodeArguments.join(" ")} index.js'` } : {},
     });
 
     addService("mis-web", {
@@ -271,7 +271,7 @@ export const createComposeSpec = (config: InstallConfigSchema) => {
       volumes: {
         "./config": "/etc/scow",
       },
-      ...nodeArguments ? { command: `sh -c 'node ${nodeArguments} index.js'` } : {},
+      ...nodeArguments ? { command: `node ${nodeArguments.join(" ")} index.js'` } : {},
     });
 
     composeSpec.volumes["db_data"] = {};
@@ -303,7 +303,7 @@ export const createComposeSpec = (config: InstallConfigSchema) => {
       volumes: {
         "./config": "/etc/scow",
       },
-      ...nodeArguments ? { command: `sh -c 'node ${nodeArguments} index.js'` } : {},
+      ...nodeArguments ? { command: `node ${nodeArguments.join(" ")} index.js'` } : {},
     });
 
     composeSpec.volumes["audit_db_data"] = {};

--- a/apps/cli/src/config/install.ts
+++ b/apps/cli/src/config/install.ts
@@ -122,6 +122,11 @@ export const InstallConfigSchema = Type.Object({
       })),
     })),
   })),
+
+  misc: Type.Optional(Type.Object({
+    nodeArguments:  Type.Optional(Type.Array(Type.String(), { description: "传递给node服务的string数组" })),
+  }, { description: "多个不好分类的配置参数参数" })),
+
 }, { description: "审计系统部署选项，如果不设置，则不部署审计系统" });
 
 export type InstallConfigSchema = Static<typeof InstallConfigSchema>;

--- a/apps/cli/src/config/install.ts
+++ b/apps/cli/src/config/install.ts
@@ -124,7 +124,7 @@ export const InstallConfigSchema = Type.Object({
   })),
 
   misc: Type.Optional(Type.Object({
-    nodeArguments:  Type.Optional(Type.Array(Type.String(), { description: "传递给node服务的string数组" })),
+    nodeOptions:  Type.Optional(Type.String({ description: "传递给node服务的参数" })),
   }, { description: "多个不好分类的配置参数参数" })),
 
 }, { description: "审计系统部署选项，如果不设置，则不部署审计系统" });


### PR DESCRIPTION
Node.js 默认的最大内存限制可能不足以处理高并发量。您可以通过设置 --max-old-space-size 来增加 Node.js 进程的内存限制。

如下图，原本在某环境中，max-old-space-size 默认为 4144，修改install.yaml文件后，成功修改其最大老生代堆内存大小

```yaml title="install.yaml"
misc:
#  nodeOptions: "--max-old-space-size=2048"
  nodeOptions: "--max-old-space-size=8192"

```

<img width="532" alt="image" src="https://github.com/PKUHPC/SCOW/assets/25954437/2e2ce9fb-65ad-44e9-abe7-833a197ab102">
