### PR TITLE
fix(portal): 修复用户删除无权限目录时导致的崩溃问题

### DIFF
--- a/.changeset/calm-ducks-rest.md
+++ b/.changeset/calm-ducks-rest.md
@@ -1,0 +1,6 @@
+---
+"@scow/portal-server": patch
+"@scow/portal-web": patch
+---
+
+修复用户删除无权限目录时导致的崩溃问题

--- a/apps/portal-server/src/utils/ssh.ts
+++ b/apps/portal-server/src/utils/ssh.ts
@@ -88,7 +88,11 @@ export async function sshConnect<T>(
         code: status.INTERNAL,
         details: e.message,
         message: e.message,
-        metadata: scowErrorMetadata(SSH_ERROR_CODE, typeof e.cause === "string" ? { cause:e.cause } : undefined),
+        metadata: scowErrorMetadata(SSH_ERROR_CODE, typeof e.cause === "string"
+          ? e.cause.length > 150
+            ? { cause: encodeURIComponent(e.cause.substring(0, 150) + "...") }
+            : { cause: encodeURIComponent(e.cause) }
+          : undefined),
       });
     }
 

--- a/apps/portal-web/src/pages/api/file/deleteDir.ts
+++ b/apps/portal-web/src/pages/api/file/deleteDir.ts
@@ -33,6 +33,7 @@ export const DeleteDirSchema = typeboxRouteSchema({
   responses: {
     204: Type.Null(),
     400: Type.Object({ code: Type.Literal("INVALID_CLUSTER") }),
+    500: Type.Object({ code: Type.Literal("CANT_DELETE") }),
   },
 });
 
@@ -52,7 +53,7 @@ export default route(DeleteDirSchema, async (req, res) => {
     operatorUserId: info.identityId,
     operatorIp: parseIp(req) ?? "",
     operationTypeName: OperationType.deleteDirectory,
-    operationTypePayload:{
+    operationTypePayload: {
       clusterId: cluster, path,
     },
   };
@@ -64,8 +65,10 @@ export default route(DeleteDirSchema, async (req, res) => {
     return { 204: null };
   }, handlegRPCError({
     [status.NOT_FOUND]: () => ({ 400: { code: "INVALID_CLUSTER" as const } }),
+    [status.INTERNAL]: () => ({ 500: { code: "CANT_DELETE" as const } }),
   },
   async () => await callLog(logInfo, OperationResult.FAIL),
   ));
+
 
 });


### PR DESCRIPTION
1. 修复 ssh 抛错时 metadata 格式有问题报错 illegal characters
原因是 ssh 操作出问题之后直接将控制台报错当作 metadata 返回，但是控制台报错包含特殊字符与 metadata 要求不符导致了 unknown 的错误。
2. deleteDir 没有 catch 住 internal 错误
3. 限制 ssh 抛错长度
初步判断是问题 3 导致的 portal-web 的 api 部分直接崩溃，限制长度后不会崩溃