### PR TITLE
feat(mis): 增加配置项控制普通用户是否可以修改作业时限

### DIFF
--- a/.changeset/forty-ducks-hide.md
+++ b/.changeset/forty-ducks-hide.md
@@ -1,0 +1,6 @@
+---
+"@scow/mis-web": patch
+"@scow/cli": patch
+---
+
+增加配置项控制普通用户是否可以修改作业时限

--- a/.changeset/plenty-tools-flash.md
+++ b/.changeset/plenty-tools-flash.md
@@ -1,0 +1,5 @@
+---
+"@scow/config": patch
+---
+
+mis 增加 CHANGE_JOB_LIMIT 参数控制普通用户是否可以修改作业时限

--- a/.changeset/plenty-tools-flash.md
+++ b/.changeset/plenty-tools-flash.md
@@ -2,4 +2,4 @@
 "@scow/config": patch
 ---
 
-mis 增加 userChangeJobLimitEnabled 参数控制普通用户是否可以修改作业时限
+mis 增加 allowUserChangeJobTimeLimit 参数控制普通用户是否可以修改作业时限

--- a/.changeset/plenty-tools-flash.md
+++ b/.changeset/plenty-tools-flash.md
@@ -2,4 +2,4 @@
 "@scow/config": patch
 ---
 
-mis 增加 CHANGE_JOB_LIMIT 参数控制普通用户是否可以修改作业时限
+mis 增加 userChangeJobLimitEnabled 参数控制普通用户是否可以修改作业时限

--- a/apps/cli/assets/init-full/config/mis.yaml
+++ b/apps/cli/assets/init-full/config/mis.yaml
@@ -107,4 +107,4 @@ createUser:
 
 
 # 用户是否可以修改作业时限配置
-# userChangeJobLimitEnabled: true
+# allowUserChangeJobTimeLimit: true

--- a/apps/cli/assets/init-full/config/mis.yaml
+++ b/apps/cli/assets/init-full/config/mis.yaml
@@ -104,3 +104,7 @@ createUser:
 #         allowedRoles: [tenantAdmin, platformAdmin]
 #   - text: "一级导航2"
 #     url: "https://hahahaha2.com"
+
+
+# 用户是否可以修改作业时限配置
+# userChangeJobLimitEnabled: true

--- a/apps/mis-web/config.js
+++ b/apps/mis-web/config.js
@@ -186,6 +186,10 @@ const buildRuntimeConfig = async (phase, basePath) => {
 
     UI_EXTENSION: misConfig.uiExtension,
 
+    CHANGE_JOB_LIMIT: {
+      userEnabled: misConfig.userChangeJobLimitEnabled,
+    },
+
   };
 
   if (!building) {

--- a/apps/mis-web/config.js
+++ b/apps/mis-web/config.js
@@ -187,7 +187,7 @@ const buildRuntimeConfig = async (phase, basePath) => {
     UI_EXTENSION: misConfig.uiExtension,
 
     CHANGE_JOB_LIMIT: {
-      userEnabled: misConfig.userChangeJobLimitEnabled,
+      allowUser: misConfig.allowUserChangeJobTimeLimit,
     },
 
   };

--- a/apps/mis-web/src/pageComponents/job/RunningJobTable.tsx
+++ b/apps/mis-web/src/pageComponents/job/RunningJobTable.tsx
@@ -220,6 +220,9 @@ export const RunningJobInfoTable: React.FC<JobInfoTableProps> = ({
 
   const [previewItem, setPreviewItem] = useState<RunningJobInfo | undefined>(undefined);
 
+  // 非用户页面或者用户页面且用户允许修改作业时限
+  const changeJobLimitEnabled = showUser || (!showUser && publicConfig.CHANGE_JOB_LIMIT.userEnabled);
+
   const t = useI18nTranslateToString();
   const languageId = useI18n().currentLanguage.id;
 
@@ -228,11 +231,13 @@ export const RunningJobInfoTable: React.FC<JobInfoTableProps> = ({
       {selection ? (
         <TableTitle>
           <Space>
-            <BatchChangeJobTimeLimitButton
-              data={selection.selected}
-              disabled={isLoading || selection.selected.length === 0}
-              reload={reload}
-            />
+            {changeJobLimitEnabled && (
+              <BatchChangeJobTimeLimitButton
+                data={selection.selected}
+                disabled={isLoading || selection.selected.length === 0}
+                reload={reload}
+              />
+            )}
           </Space>
         </TableTitle>
       ) : undefined}
@@ -323,12 +328,14 @@ export const RunningJobInfoTable: React.FC<JobInfoTableProps> = ({
               >
                 <a>{t(p("finishJobButton"))}</a>
               </Popconfirm>
-              <ChangeJobTimeLimitModalLink
-                reload={reload}
-                data={[r]}
-              >
-                {t(p("changeLimit"))}
-              </ChangeJobTimeLimitModalLink>
+              {changeJobLimitEnabled && (
+                <ChangeJobTimeLimitModalLink
+                  reload={reload}
+                  data={[r]}
+                >
+                  {t(p("changeLimit"))}
+                </ChangeJobTimeLimitModalLink>
+              )}
             </Space>
           )}
         />

--- a/apps/mis-web/src/pageComponents/job/RunningJobTable.tsx
+++ b/apps/mis-web/src/pageComponents/job/RunningJobTable.tsx
@@ -221,7 +221,7 @@ export const RunningJobInfoTable: React.FC<JobInfoTableProps> = ({
   const [previewItem, setPreviewItem] = useState<RunningJobInfo | undefined>(undefined);
 
   // 非用户页面或者用户页面且用户允许修改作业时限
-  const changeJobLimitEnabled = showUser || (!showUser && publicConfig.CHANGE_JOB_LIMIT.userEnabled);
+  const changeJobLimitEnabled = showUser || (!showUser && publicConfig.CHANGE_JOB_LIMIT.allowUser);
 
   const t = useI18nTranslateToString();
   const languageId = useI18n().currentLanguage.id;

--- a/apps/mis-web/src/pages/api/job/cancelJob.ts
+++ b/apps/mis-web/src/pages/api/job/cancelJob.ts
@@ -50,7 +50,12 @@ export default /* #__PURE__*/route(CancelJobSchema, async (req, res) => {
 
   const { cluster, jobId } = req.query;
 
-  const { job, jobAccessible } = await checkJobAccessible(jobId, cluster, info);
+  const { job, jobAccessible } = await checkJobAccessible({
+    actionType: "cancelJob",
+    jobId,
+    cluster,
+    info,
+  });
 
   if (jobAccessible === "NotAllowed") {
     return { 403: null };

--- a/apps/mis-web/src/pages/api/job/changeJobTimeLimit.ts
+++ b/apps/mis-web/src/pages/api/job/changeJobTimeLimit.ts
@@ -20,6 +20,7 @@ import { OperationResult, OperationType } from "src/models/operationLog";
 import { checkJobAccessible } from "src/server/jobAccessible";
 import { callLog } from "src/server/operationLog";
 import { getClient } from "src/utils/client";
+import { publicConfig } from "src/utils/config";
 import { handlegRPCError, parseIp } from "src/utils/server";
 
 export type ChangeMode =
@@ -66,7 +67,14 @@ export default typeboxRoute(ChangeJobTimeLimitSchema,
     const client = getClient(JobServiceClient);
 
     // check if the user can change the job time limit
-    const { job, jobAccessible } = await checkJobAccessible(jobId, cluster, info, limitMinutes);
+    const { job, jobAccessible } = await checkJobAccessible({
+      actionType: "changeJobLimit",
+      jobId,
+      cluster,
+      info,
+      limitMinutes,
+      userEnabled: publicConfig.CHANGE_JOB_LIMIT.userEnabled,
+    });
 
     if (jobAccessible === "NotAllowed") {
       return { 403: null };

--- a/apps/mis-web/src/pages/api/job/changeJobTimeLimit.ts
+++ b/apps/mis-web/src/pages/api/job/changeJobTimeLimit.ts
@@ -73,7 +73,7 @@ export default typeboxRoute(ChangeJobTimeLimitSchema,
       cluster,
       info,
       limitMinutes,
-      userEnabled: publicConfig.CHANGE_JOB_LIMIT.userEnabled,
+      allowUser: publicConfig.CHANGE_JOB_LIMIT.allowUser,
     });
 
     if (jobAccessible === "NotAllowed") {

--- a/apps/mis-web/src/pages/api/job/queryJobTimeLimit.ts
+++ b/apps/mis-web/src/pages/api/job/queryJobTimeLimit.ts
@@ -54,7 +54,7 @@ export default typeboxRoute(QueryJobTimeLimitSchema,
 
     const { cluster, jobId } = req.query;
 
-    const { jobAccessible } = await checkJobAccessible(jobId, cluster, info);
+    const { jobAccessible } = await checkJobAccessible({ actionType: "queryJobLimit", jobId, cluster, info });
 
     if (jobAccessible === "NotAllowed") {
       return { 403: null };

--- a/apps/mis-web/src/server/jobAccessible.ts
+++ b/apps/mis-web/src/server/jobAccessible.ts
@@ -24,8 +24,20 @@ type Result = {
   job: RunningJob, jobAccessible: JobAccessible
 }
 
-export async function checkJobAccessible(
-  jobId: string, cluster: string, info: UserInfo, limitMinutes?: number,
+type ActionType = "cancelJob" | "changeJobLimit" | "queryJobLimit"
+
+interface Props {
+  actionType: ActionType
+  jobId: string
+  cluster: string
+  info: UserInfo
+  limitMinutes?: number
+  userEnabled?: boolean
+}
+
+export async function checkJobAccessible({
+  actionType, jobId, cluster, info, limitMinutes, userEnabled = true,
+}: Props,
 ): Promise<Result> {
 
   const client = getClient(JobServiceClient);
@@ -58,7 +70,9 @@ export async function checkJobAccessible(
     return result;
   }
   // 用户发起了这个作业
-  if (job.user === info.identityId) {
+  // 如果是取消作业和查询作业时限，返回"OK"
+  // 如果是修改作业时限，需要userEnabled 为true时返回"OK"
+  if (job.user === info.identityId && (actionType !== "changeJobLimit" || userEnabled)) {
     result.jobAccessible = "OK";
     return result;
   }

--- a/apps/mis-web/src/server/jobAccessible.ts
+++ b/apps/mis-web/src/server/jobAccessible.ts
@@ -32,11 +32,11 @@ interface Props {
   cluster: string
   info: UserInfo
   limitMinutes?: number
-  userEnabled?: boolean
+  allowUser?: boolean
 }
 
 export async function checkJobAccessible({
-  actionType, jobId, cluster, info, limitMinutes, userEnabled = true,
+  actionType, jobId, cluster, info, limitMinutes, allowUser = true,
 }: Props,
 ): Promise<Result> {
 
@@ -71,8 +71,8 @@ export async function checkJobAccessible({
   }
   // 用户发起了这个作业
   // 如果是取消作业和查询作业时限，返回"OK"
-  // 如果是修改作业时限，需要userEnabled 为true时返回"OK"
-  if (job.user === info.identityId && (actionType !== "changeJobLimit" || userEnabled)) {
+  // 如果是修改作业时限，需要allowUser 为true时返回"OK"
+  if (job.user === info.identityId && (actionType !== "changeJobLimit" || allowUser)) {
     result.jobAccessible = "OK";
     return result;
   }

--- a/apps/mis-web/src/utils/config.ts
+++ b/apps/mis-web/src/utils/config.ts
@@ -99,7 +99,7 @@ export interface PublicRuntimeConfig {
 
   UI_EXTENSION?: { url: string; }
 
-  CHANGE_JOB_LIMIT: { userEnabled: boolean}
+  CHANGE_JOB_LIMIT: { allowUser: boolean}
 }
 
 export const runtimeConfig: ServerRuntimeConfig = getConfig().serverRuntimeConfig;

--- a/apps/mis-web/src/utils/config.ts
+++ b/apps/mis-web/src/utils/config.ts
@@ -98,6 +98,8 @@ export interface PublicRuntimeConfig {
   },
 
   UI_EXTENSION?: { url: string; }
+
+  CHANGE_JOB_LIMIT: { userEnabled: boolean}
 }
 
 export const runtimeConfig: ServerRuntimeConfig = getConfig().serverRuntimeConfig;

--- a/dev/vagrant/config/mis.yaml
+++ b/dev/vagrant/config/mis.yaml
@@ -130,3 +130,6 @@ createUser:
 # 自定义可查询消费类型
 # customChargeTypes: ["月租", "存储费"]
 
+
+# 用户是否可以修改作业时限配置
+# userChangeJobLimitEnabled: true

--- a/dev/vagrant/config/mis.yaml
+++ b/dev/vagrant/config/mis.yaml
@@ -132,4 +132,4 @@ createUser:
 
 
 # 用户是否可以修改作业时限配置
-# userChangeJobLimitEnabled: true
+# allowUserChangeJobTimeLimit: true

--- a/libs/config/src/mis.ts
+++ b/libs/config/src/mis.ts
@@ -138,6 +138,11 @@ export const MisConfigSchema = Type.Object({
     url: Type.String({ description: "UI扩展站完整URL" }),
   })),
 
+  userChangeJobLimitEnabled: Type.Boolean({
+    description: "普通用户是否可以修改作业时限",
+    default: true,
+  }),
+
 });
 
 const MIS_CONFIG_NAME = "mis";

--- a/libs/config/src/mis.ts
+++ b/libs/config/src/mis.ts
@@ -138,7 +138,7 @@ export const MisConfigSchema = Type.Object({
     url: Type.String({ description: "UI扩展站完整URL" }),
   })),
 
-  userChangeJobLimitEnabled: Type.Boolean({
+  allowUserChangeJobTimeLimit: Type.Boolean({
     description: "普通用户是否可以修改作业时限",
     default: true,
   }),


### PR DESCRIPTION
### 改动 
mis 增加配置参数 userChangeJobLimitEnabled 参数控制普通用户是否可以修改作业时限

该参数默认为true， 当改为false时， da'shboard和用户空间处的未结束作业 表里隐藏修改作业时限的按钮，并且api层面也会做该限制。

![image](https://github.com/PKUHPC/SCOW/assets/130351655/a0f02db6-f257-4552-84e6-e917a16c4e58)

![image](https://github.com/PKUHPC/SCOW/assets/130351655/bbbc3bdf-8db9-470c-bc97-4509e8ba6947)

