### PR TITLE
fix: 修复 codemirror 导致的崩溃问题

### DIFF
--- a/.changeset/eighty-melons-dance.md
+++ b/.changeset/eighty-melons-dance.md
@@ -1,0 +1,5 @@
+---
+"@scow/portal-web": patch
+---
+
+回退 codemirror 版本，解决提交作业界面崩溃问题

--- a/apps/portal-web/package.json
+++ b/apps/portal-web/package.json
@@ -50,7 +50,7 @@
     "@scow/utils": "workspace:*",
     "@sinclair/typebox": "0.32.12",
     "@uiw/codemirror-theme-github": "4.21.21",
-    "@uiw/react-codemirror": "4.21.21",
+    "@uiw/react-codemirror": "4.21.20",
     "antd": "5.13.2",
     "busboy": "1.6.0",
     "dayjs": "1.11.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -774,8 +774,8 @@ importers:
         specifier: 4.21.21
         version: 4.21.21(@codemirror/language@6.10.0)(@codemirror/state@6.4.0)(@codemirror/view@6.23.0)
       '@uiw/react-codemirror':
-        specifier: 4.21.21
-        version: 4.21.21(@babel/runtime@7.23.8)(@codemirror/autocomplete@6.6.0)(@codemirror/language@6.10.0)(@codemirror/lint@6.0.0)(@codemirror/search@6.2.3)(@codemirror/state@6.4.0)(@codemirror/theme-one-dark@6.1.0)(@codemirror/view@6.23.0)(codemirror@6.0.1)(react-dom@18.2.0)(react@18.2.0)
+        specifier: 4.21.20
+        version: 4.21.20(@babel/runtime@7.23.8)(@codemirror/autocomplete@6.6.0)(@codemirror/language@6.10.0)(@codemirror/lint@6.0.0)(@codemirror/search@6.2.3)(@codemirror/state@6.4.0)(@codemirror/theme-one-dark@6.1.0)(@codemirror/view@6.23.0)(codemirror@6.0.1)(react-dom@18.2.0)(react@18.2.0)
       antd:
         specifier: 5.13.2
         version: 5.13.2(react-dom@18.2.0)(react@18.2.0)
@@ -3338,7 +3338,7 @@ packages:
     resolution: {integrity: sha512-9uf0g9m2wZyrIim1SavcxMdwsu8wc/y5uSw6JRUBYIGWrN+RY4vSru/BqB+MyNWqx4C2uRhQ/Kh7Pw8lAyT3qQ==}
     dependencies:
       '@codemirror/language': 6.10.0
-      '@codemirror/state': 6.2.0
+      '@codemirror/state': 6.4.0
       '@codemirror/view': 6.23.0
       '@lezer/common': 1.1.1
     dev: false
@@ -3346,7 +3346,7 @@ packages:
   /@codemirror/language@6.10.0:
     resolution: {integrity: sha512-2vaNn9aPGCRFKWcHPFksctzJ8yS5p7YoaT+jHpc0UGKzNuAIx4qy6R5wiqbP+heEEdyaABA582mNqSHzSoYdmg==}
     dependencies:
-      '@codemirror/state': 6.2.0
+      '@codemirror/state': 6.4.0
       '@codemirror/view': 6.23.0
       '@lezer/common': 1.1.1
       '@lezer/highlight': 1.1.4
@@ -3374,10 +3374,6 @@ packages:
       '@codemirror/state': 6.4.0
       '@codemirror/view': 6.23.0
       crelt: 1.0.5
-    dev: false
-
-  /@codemirror/state@6.2.0:
-    resolution: {integrity: sha512-69QXtcrsc3RYtOtd+GsvczJ319udtBf1PTrr2KbLWM/e2CXUPnh0Nz9AUo8WfhSQ7GeL8dPVNUmhQVgpmuaNGA==}
     dev: false
 
   /@codemirror/state@6.4.0:
@@ -7252,8 +7248,8 @@ packages:
       eslint-visitor-keys: 3.4.3
     dev: true
 
-  /@uiw/codemirror-extensions-basic-setup@4.21.21(@codemirror/autocomplete@6.6.0)(@codemirror/commands@6.2.3)(@codemirror/language@6.10.0)(@codemirror/lint@6.0.0)(@codemirror/search@6.2.3)(@codemirror/state@6.4.0)(@codemirror/view@6.23.0):
-    resolution: {integrity: sha512-+0i9dPrRSa8Mf0CvyrMvnAhajnqwsP3IMRRlaHDRgsSGL8igc4z7MhvUPn+7cWFAAqWzQRhMdMSWzo6/TEa3EA==}
+  /@uiw/codemirror-extensions-basic-setup@4.21.20(@codemirror/autocomplete@6.6.0)(@codemirror/commands@6.2.3)(@codemirror/language@6.10.0)(@codemirror/lint@6.0.0)(@codemirror/search@6.2.3)(@codemirror/state@6.4.0)(@codemirror/view@6.23.0):
+    resolution: {integrity: sha512-Wyi9q4uw0xGYd/tJ6bULG7tkCLqcUsQT0AQBfCDtnkV3LdiLU0LceTrzJoHJyIKSHsKDJxFQxa1qg3QLt4gIUA==}
     peerDependencies:
       '@codemirror/autocomplete': '>=6.0.0'
       '@codemirror/commands': '>=6.0.0'
@@ -7294,8 +7290,8 @@ packages:
       '@codemirror/view': 6.23.0
     dev: false
 
-  /@uiw/react-codemirror@4.21.21(@babel/runtime@7.23.8)(@codemirror/autocomplete@6.6.0)(@codemirror/language@6.10.0)(@codemirror/lint@6.0.0)(@codemirror/search@6.2.3)(@codemirror/state@6.4.0)(@codemirror/theme-one-dark@6.1.0)(@codemirror/view@6.23.0)(codemirror@6.0.1)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-PaxBMarufMWoR0qc5zuvBSt76rJ9POm9qoOaJbqRmnNL2viaF+d+Paf2blPSlm1JSnqn7hlRjio+40nZJ9TKzw==}
+  /@uiw/react-codemirror@4.21.20(@babel/runtime@7.23.8)(@codemirror/autocomplete@6.6.0)(@codemirror/language@6.10.0)(@codemirror/lint@6.0.0)(@codemirror/search@6.2.3)(@codemirror/state@6.4.0)(@codemirror/theme-one-dark@6.1.0)(@codemirror/view@6.23.0)(codemirror@6.0.1)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-PdyewPvNXnvT3JHj888yjpbWsAGw5qlxW6w1sMdsqJ0R6vPV++ob1iZXCGrM1FVpbqPK0DNfpXvjzp2gIr3lYw==}
     peerDependencies:
       '@babel/runtime': '>=7.11.0'
       '@codemirror/state': '>=6.0.0'
@@ -7310,7 +7306,7 @@ packages:
       '@codemirror/state': 6.4.0
       '@codemirror/theme-one-dark': 6.1.0
       '@codemirror/view': 6.23.0
-      '@uiw/codemirror-extensions-basic-setup': 4.21.21(@codemirror/autocomplete@6.6.0)(@codemirror/commands@6.2.3)(@codemirror/language@6.10.0)(@codemirror/lint@6.0.0)(@codemirror/search@6.2.3)(@codemirror/state@6.4.0)(@codemirror/view@6.23.0)
+      '@uiw/codemirror-extensions-basic-setup': 4.21.20(@codemirror/autocomplete@6.6.0)(@codemirror/commands@6.2.3)(@codemirror/language@6.10.0)(@codemirror/lint@6.0.0)(@codemirror/search@6.2.3)(@codemirror/state@6.4.0)(@codemirror/view@6.23.0)
       codemirror: 6.0.1(@lezer/common@1.1.1)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)

--- a/renovate.json
+++ b/renovate.json
@@ -33,7 +33,8 @@
         "react-dom",
         "@types/react",
         "pino",
-        "turbo"
+        "turbo",
+        "@uiw/react-codemirror"
       ],
       "enabled": false
     }


### PR DESCRIPTION
@uiw/react-codemirror v4.21.20->v4.21.21 后提交作业页面报错无法打开。暂时未从其更新日志中找到可能导致对应错误的原因，先回退版本