### PR TITLE
fix(cli): 添加 @sinclair/typebox 到 pkg

### DIFF
--- a/.changeset/unlucky-zebras-design.md
+++ b/.changeset/unlucky-zebras-design.md
@@ -1,0 +1,5 @@
+---
+"@scow/cli": patch
+---
+
+修复 cli 由于 @sinclair/typebox 更新导致的编译问题

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -44,7 +44,8 @@
     "scripts": "build/**/*.js",
     "assets": [
       "assets/**/*",
-      "package.json"
+      "package.json",
+      "node_modules/@sinclair/typebox/**/*"
     ],
     "targets": [
       "node18-linux-x64",


### PR DESCRIPTION
@sinclair/typebox 升级后 cli 报错：
```
'/**/SCOW/node_modules/.pnpm/@sinclair+typebox@0.32.12/node_modules/@sinclair/typebox/build/require/type/index.js' was not included into executable at compilation stage. Please recompile adding it as asset or script.
```
将 @sinclair/typebox 加入到 pkg 后解决
