### PR TITLE
feat(mis-server): 适配 mikro-orm 更新导致的 Ref nullable 的默认值变化

### DIFF
--- a/.changeset/five-dragons-deliver.md
+++ b/.changeset/five-dragons-deliver.md
@@ -1,0 +1,5 @@
+---
+"@scow/mis-server": patch
+---
+
+适配 mikro-orm 更新会修改 ref 字段默认为 null

--- a/apps/mis-server/src/entities/StorageQuota.ts
+++ b/apps/mis-server/src/entities/StorageQuota.ts
@@ -20,7 +20,7 @@ export class StorageQuota {
   @PrimaryKey()
     id!: number;
 
-  @ManyToOne(() => User, { cascade: [Cascade.ALL], ref: true })
+  @ManyToOne(() => User, { cascade: [Cascade.ALL], ref: true, nullable: false })
     user: Ref<User>;
 
   @Property()

--- a/apps/mis-server/src/entities/UserAccount.ts
+++ b/apps/mis-server/src/entities/UserAccount.ts
@@ -33,10 +33,10 @@ export class UserAccount {
   @PrimaryKey()
     id!: number;
 
-  @ManyToOne(() => User, { cascade: [Cascade.ALL], ref: true })
+  @ManyToOne(() => User, { cascade: [Cascade.ALL], ref: true, nullable: false })
     user: Ref<User>;
 
-  @ManyToOne(() => Account, { cascade: [Cascade.ALL], ref: true })
+  @ManyToOne(() => Account, { cascade: [Cascade.ALL], ref: true, nullable: false })
     account: Ref<Account>;
 
   @Property({ columnType: "varchar(10)", comment: Object.values(UserStatus).join(", ") })

--- a/apps/mis-server/src/migrations/.snapshot-scow_server.json
+++ b/apps/mis-server/src/migrations/.snapshot-scow_server.json
@@ -49,12 +49,14 @@
             "id"
           ],
           "composite": false,
+          "constraint": true,
           "primary": true,
           "unique": true
         }
       ],
       "checks": [],
-      "foreignKeys": {}
+      "foreignKeys": {},
+      "nativeEnums": {}
     },
     {
       "columns": {
@@ -135,6 +137,7 @@
             "amount"
           ],
           "composite": true,
+          "constraint": false,
           "primary": false,
           "unique": false
         },
@@ -147,6 +150,7 @@
             "type"
           ],
           "composite": true,
+          "constraint": false,
           "primary": false,
           "unique": false
         },
@@ -156,12 +160,14 @@
             "id"
           ],
           "composite": false,
+          "constraint": true,
           "primary": true,
           "unique": true
         }
       ],
       "checks": [],
-      "foreignKeys": {}
+      "foreignKeys": {},
+      "nativeEnums": {}
     },
     {
       "columns": {
@@ -466,6 +472,7 @@
           ],
           "composite": false,
           "keyName": "idJob",
+          "constraint": false,
           "primary": false,
           "unique": false
         },
@@ -475,6 +482,7 @@
           ],
           "composite": false,
           "keyName": "account",
+          "constraint": false,
           "primary": false,
           "unique": false
         },
@@ -484,6 +492,7 @@
           ],
           "composite": false,
           "keyName": "user",
+          "constraint": false,
           "primary": false,
           "unique": false
         },
@@ -493,6 +502,7 @@
           ],
           "composite": false,
           "keyName": "time_submit",
+          "constraint": false,
           "primary": false,
           "unique": false
         },
@@ -502,6 +512,7 @@
           ],
           "composite": false,
           "keyName": "time_start",
+          "constraint": false,
           "primary": false,
           "unique": false
         },
@@ -511,6 +522,7 @@
           ],
           "composite": false,
           "keyName": "time_end",
+          "constraint": false,
           "primary": false,
           "unique": false
         },
@@ -520,6 +532,7 @@
           ],
           "composite": false,
           "keyName": "time_used",
+          "constraint": false,
           "primary": false,
           "unique": false
         },
@@ -529,6 +542,7 @@
           ],
           "composite": false,
           "keyName": "time_wait",
+          "constraint": false,
           "primary": false,
           "unique": false
         },
@@ -538,6 +552,7 @@
           ],
           "composite": false,
           "keyName": "record_time",
+          "constraint": false,
           "primary": false,
           "unique": false
         },
@@ -547,12 +562,14 @@
             "bi_job_index"
           ],
           "composite": false,
+          "constraint": true,
           "primary": true,
           "unique": true
         }
       ],
       "checks": [],
-      "foreignKeys": {}
+      "foreignKeys": {},
+      "nativeEnums": {}
     },
     {
       "columns": {
@@ -631,7 +648,7 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
-          "length": 0,
+          "length": 6,
           "mappedType": "datetime"
         }
       },
@@ -643,12 +660,14 @@
             "id"
           ],
           "composite": false,
+          "constraint": true,
           "primary": true,
           "unique": true
         }
       ],
       "checks": [],
-      "foreignKeys": {}
+      "foreignKeys": {},
+      "nativeEnums": {}
     },
     {
       "columns": {
@@ -668,7 +687,7 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
-          "length": 0,
+          "length": 6,
           "mappedType": "datetime"
         },
         "tenant_name": {
@@ -747,6 +766,7 @@
             "amount"
           ],
           "composite": true,
+          "constraint": false,
           "primary": false,
           "unique": false
         },
@@ -756,12 +776,14 @@
             "id"
           ],
           "composite": false,
+          "constraint": true,
           "primary": true,
           "unique": true
         }
       ],
       "checks": [],
-      "foreignKeys": {}
+      "foreignKeys": {},
+      "nativeEnums": {}
     },
     {
       "columns": {
@@ -799,7 +821,7 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
-          "length": 0,
+          "length": 6,
           "mappedType": "datetime"
         }
       },
@@ -811,12 +833,14 @@
             "id"
           ],
           "composite": false,
+          "constraint": true,
           "primary": true,
           "unique": true
         }
       ],
       "checks": [],
-      "foreignKeys": {}
+      "foreignKeys": {},
+      "nativeEnums": {}
     },
     {
       "columns": {
@@ -847,12 +871,14 @@
             "key"
           ],
           "composite": false,
+          "constraint": true,
           "primary": true,
           "unique": true
         }
       ],
       "checks": [],
-      "foreignKeys": {}
+      "foreignKeys": {},
+      "nativeEnums": {}
     },
     {
       "columns": {
@@ -893,8 +919,8 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
-          "length": 0,
-          "default": "current_timestamp(0)",
+          "length": 6,
+          "default": "current_timestamp(6)",
           "mappedType": "datetime"
         }
       },
@@ -906,6 +932,7 @@
           ],
           "composite": false,
           "keyName": "tenant_name_unique",
+          "constraint": true,
           "primary": false,
           "unique": true
         },
@@ -915,12 +942,14 @@
             "id"
           ],
           "composite": false,
+          "constraint": true,
           "primary": true,
           "unique": true
         }
       ],
       "checks": [],
-      "foreignKeys": {}
+      "foreignKeys": {},
+      "nativeEnums": {}
     },
     {
       "columns": {
@@ -998,7 +1027,7 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
-          "length": 0,
+          "length": 6,
           "mappedType": "datetime"
         }
       },
@@ -1010,6 +1039,7 @@
           ],
           "composite": false,
           "keyName": "job_price_item_item_id_unique",
+          "constraint": true,
           "primary": false,
           "unique": true
         },
@@ -1019,6 +1049,7 @@
           ],
           "composite": false,
           "keyName": "job_price_item_tenant_id_index",
+          "constraint": false,
           "primary": false,
           "unique": false
         },
@@ -1028,6 +1059,7 @@
             "id"
           ],
           "composite": false,
+          "constraint": true,
           "primary": true,
           "unique": true
         }
@@ -1047,7 +1079,8 @@
           "deleteRule": "set null",
           "updateRule": "cascade"
         }
-      }
+      },
+      "nativeEnums": {}
     },
     {
       "columns": {
@@ -1125,7 +1158,7 @@
           "autoincrement": false,
           "primary": false,
           "nullable": true,
-          "length": 0,
+          "length": 6,
           "mappedType": "datetime"
         }
       },
@@ -1137,6 +1170,7 @@
           ],
           "composite": false,
           "keyName": "account_account_name_unique",
+          "constraint": true,
           "primary": false,
           "unique": true
         },
@@ -1146,6 +1180,7 @@
           ],
           "composite": false,
           "keyName": "account_tenant_id_index",
+          "constraint": false,
           "primary": false,
           "unique": false
         },
@@ -1155,6 +1190,7 @@
           ],
           "composite": false,
           "keyName": "account_whitelist_id_unique",
+          "constraint": true,
           "primary": false,
           "unique": true
         },
@@ -1164,6 +1200,7 @@
             "id"
           ],
           "composite": false,
+          "constraint": true,
           "primary": true,
           "unique": true
         }
@@ -1195,7 +1232,8 @@
           "deleteRule": "set null",
           "updateRule": "cascade"
         }
-      }
+      },
+      "nativeEnums": {}
     },
     {
       "columns": {
@@ -1251,8 +1289,8 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
-          "length": 0,
-          "default": "current_timestamp(0)",
+          "length": 6,
+          "default": "current_timestamp(6)",
           "mappedType": "datetime"
         },
         "tenant_roles": {
@@ -1292,6 +1330,7 @@
           ],
           "composite": false,
           "keyName": "user_tenant_id_index",
+          "constraint": false,
           "primary": false,
           "unique": false
         },
@@ -1301,6 +1340,7 @@
           ],
           "composite": false,
           "keyName": "user_user_id_unique",
+          "constraint": true,
           "primary": false,
           "unique": true
         },
@@ -1310,6 +1350,7 @@
             "id"
           ],
           "composite": false,
+          "constraint": true,
           "primary": true,
           "unique": true
         }
@@ -1328,7 +1369,8 @@
           "referencedTableName": "tenant",
           "updateRule": "cascade"
         }
-      }
+      },
+      "nativeEnums": {}
     },
     {
       "columns": {
@@ -1377,6 +1419,7 @@
           ],
           "composite": false,
           "keyName": "storage_quota_user_id_index",
+          "constraint": false,
           "primary": false,
           "unique": false
         },
@@ -1386,6 +1429,7 @@
             "id"
           ],
           "composite": false,
+          "constraint": true,
           "primary": true,
           "unique": true
         }
@@ -1402,10 +1446,11 @@
             "id"
           ],
           "referencedTableName": "user",
-          "deleteRule": "CASCADE",
+          "deleteRule": "cascade",
           "updateRule": "cascade"
         }
-      }
+      },
+      "nativeEnums": {}
     },
     {
       "columns": {
@@ -1487,6 +1532,7 @@
           ],
           "composite": false,
           "keyName": "user_account_user_id_index",
+          "constraint": false,
           "primary": false,
           "unique": false
         },
@@ -1496,6 +1542,7 @@
           ],
           "composite": false,
           "keyName": "user_account_account_id_index",
+          "constraint": false,
           "primary": false,
           "unique": false
         },
@@ -1505,6 +1552,7 @@
             "id"
           ],
           "composite": false,
+          "constraint": true,
           "primary": true,
           "unique": true
         }
@@ -1521,7 +1569,7 @@
             "id"
           ],
           "referencedTableName": "user",
-          "deleteRule": "CASCADE",
+          "deleteRule": "cascade",
           "updateRule": "cascade"
         },
         "user_account_account_id_foreign": {
@@ -1534,10 +1582,12 @@
             "id"
           ],
           "referencedTableName": "account",
-          "deleteRule": "CASCADE",
+          "deleteRule": "cascade",
           "updateRule": "cascade"
         }
-      }
+      },
+      "nativeEnums": {}
     }
-  ]
+  ],
+  "nativeEnums": {}
 }

--- a/apps/mis-server/src/migrations/Migration20240129075557.ts
+++ b/apps/mis-server/src/migrations/Migration20240129075557.ts
@@ -1,0 +1,17 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20240129075557 extends Migration {
+
+  async up(): Promise<void> {
+    this.addSql('alter table `tenant` modify `create_time` DATETIME(6) not null default current_timestamp(6);');
+
+    this.addSql('alter table `user` modify `create_time` DATETIME(6) not null default current_timestamp(6);');
+  }
+
+  async down(): Promise<void> {
+    this.addSql('alter table `tenant` modify `create_time` DATETIME(6) not null default current_timestamp(0);');
+
+    this.addSql('alter table `user` modify `create_time` DATETIME(6) not null default current_timestamp(0);');
+  }
+
+}


### PR DESCRIPTION
mikro orm 更新到 v6 后运行 migration:create，对数据表有所修改
- 修复了 current_timestamp 对于精度的识别
- mikro orm 将 ManyToOne 的 nullable 默认值修改为了 true，手动改回 false