### PR TITLE
fix(portal-web): 修复连续双击文件名时 path 变化 loading 未变导致进入错误目录

### DIFF
--- a/apps/portal-web/src/pageComponents/filemanager/FileManager.tsx
+++ b/apps/portal-web/src/pageComponents/filemanager/FileManager.tsx
@@ -496,7 +496,8 @@ export const FileManager: React.FC<Props> = ({ cluster, path, urlPrefix }) => {
             setSelectedKeys([fileInfoKey(r, path)]);
           },
           onDoubleClick: () => {
-            if (r.type === "DIR") {
+            if (!loading && r.type === "DIR") {
+              setLoading(true);
               router.push(fullUrl(join(path, r.name)));
             } else if (r.type === "FILE") {
               handlePreview(r.name, r.size);
@@ -506,8 +507,8 @@ export const FileManager: React.FC<Props> = ({ cluster, path, urlPrefix }) => {
         fileNameRender={(_, r) => (
           r.type === "DIR" ? (
             <a onClick={() => {
-              console.log(loading, path);
               if (!loading) {
+                setLoading(true);
                 router.push(fullUrl(join(path, r.name)));
               }
             }}

--- a/apps/portal-web/src/pageComponents/filemanager/FileManager.tsx
+++ b/apps/portal-web/src/pageComponents/filemanager/FileManager.tsx
@@ -506,6 +506,7 @@ export const FileManager: React.FC<Props> = ({ cluster, path, urlPrefix }) => {
         fileNameRender={(_, r) => (
           r.type === "DIR" ? (
             <a onClick={() => {
+              console.log(loading, path);
               if (!loading) {
                 router.push(fullUrl(join(path, r.name)));
               }


### PR DESCRIPTION
文件管理列表中，path 和 loading 并非同时更新，path 变化后，会有一段时间 loading 仍为 false，即还未触发请求。
故而需要提前设置 loading 状态保证改变 path 马上会触发 loading

待优化: path 变化但数据未更新时，列表的 rowKey 也会发生变化，会触发 react 的 diff，但实际上此时数据未发生变化。