### PR TITLE
fix(lib-server):  lib-server @scow/protos 从 devDependencies 移动到 dependencies

### DIFF
--- a/.changeset/serious-starfishes-dance.md
+++ b/.changeset/serious-starfishes-dance.md
@@ -1,0 +1,5 @@
+---
+"@scow/lib-server": patch
+---
+
+lib-server @scow/protos 从 devDependencies 移动到 dependencies

--- a/libs/server/package.json
+++ b/libs/server/package.json
@@ -22,6 +22,7 @@
     "@grpc/grpc-js": "1.9.14",
     "nookies": "2.5.2",
     "@scow/config": "workspace:*",
+    "@scow/protos": "workspace:*",
     "dayjs": "1.11.10",
     "@scow/lib-scheduler-adapter": "workspace:*",
     "@scow/utils": "workspace:*",
@@ -32,7 +33,6 @@
   },
   "devDependencies": {
     "@ddadaal/tsgrpc-server": "0.19.5",
-    "@scow/protos": "workspace:*",
     "@types/shell-quote": "1.7.4"
   },
   "volta": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1432,12 +1432,12 @@ importers:
       '@scow/config':
         specifier: workspace:*
         version: link:../config
-      dayjs:
-        specifier: 1.11.10
-        version: 1.11.10
       '@scow/lib-scheduler-adapter':
         specifier: workspace:*
         version: link:../scheduler-adapter
+      '@scow/protos':
+        specifier: workspace:*
+        version: link:../protos/scow
       '@scow/rich-error-model':
         specifier: workspace:*
         version: link:../rich-error-model
@@ -1447,6 +1447,9 @@ importers:
       '@scow/utils':
         specifier: workspace:*
         version: link:../utils
+      dayjs:
+        specifier: 1.11.10
+        version: 1.11.10
       nookies:
         specifier: 2.5.2
         version: 2.5.2
@@ -1460,9 +1463,6 @@ importers:
       '@ddadaal/tsgrpc-server':
         specifier: 0.19.5
         version: 0.19.5(@grpc/grpc-js@1.9.14)
-      '@scow/protos':
-        specifier: workspace:*
-        version: link:../protos/scow
       '@types/shell-quote':
         specifier: 1.7.4
         version: 1.7.4


### PR DESCRIPTION
如题，目前该包@scow/protos只在dev dependencies引用，无法启动，需要移入dependencies