### PR TITLE
fix(portal-web): dashboard的监控数据的clusterId

### DIFF
--- a/.changeset/serious-llamas-approve.md
+++ b/.changeset/serious-llamas-approve.md
@@ -1,0 +1,5 @@
+---
+"@scow/portal-web": patch
+---
+
+仪表盘返回的监控数据替换 clusterId

--- a/apps/portal-web/src/pages/dashboard.tsx
+++ b/apps/portal-web/src/pages/dashboard.tsx
@@ -57,6 +57,20 @@ export const DashboardPage: NextPage<Props> = requireAuth(() => true)(() => {
 
       // 处理成功的结果
       const successfulResults = rawClusterInfoResults
+      // 替换clusterId，适配器返回的clusterName和SCOW配置文件中的clusterId没关系
+        .map((result, idx) => {
+          if (result.status === "fulfilled") {
+            return {
+              ...result,
+              value:{
+                clusterInfo:{ clusterName:clusters[idx].id,
+                  partitions:result.value.clusterInfo.partitions },
+              },
+            } as PromiseSettledResult<FulfilledResult>;
+          }
+
+          return result;
+        })
         .filter(
           (result): result is PromiseFulfilledResult<FulfilledResult> =>
             result.status === "fulfilled")


### PR DESCRIPTION
### 仪表盘的监控数据替换clusterId，适配器返回的clusterName和SCOW配置文件中的clusterId没关系