### PR TITLE
fix(web): 修复 token 失效后切换系统不跳转回登录页面的问题

### DIFF
--- a/.changeset/blue-ears-provide.md
+++ b/.changeset/blue-ears-provide.md
@@ -1,0 +1,6 @@
+---
+"@scow/portal-web": patch
+"@scow/mis-web": patch
+---
+
+修复 token 失效后切换系统不跳转回登录页面的问题

--- a/apps/mis-web/src/pages/api/auth/callback.ts
+++ b/apps/mis-web/src/pages/api/auth/callback.ts
@@ -11,11 +11,12 @@
  */
 
 import { Type, typeboxRoute, typeboxRouteSchema } from "@ddadaal/next-typed-api-routes-runtime";
+import { redirectToAuthLogin } from "@scow/lib-web/build/routes/auth/redirectToLogin";
 import { setTokenCookie } from "src/auth/cookie";
 import { validateToken } from "src/auth/token";
 import { OperationResult, OperationType } from "src/models/operationLog";
 import { callLog } from "src/server/operationLog";
-import { publicConfig } from "src/utils/config";
+import { publicConfig, runtimeConfig } from "src/utils/config";
 import { parseIp } from "src/utils/server";
 
 export const AuthCallbackSchema = typeboxRouteSchema({
@@ -53,7 +54,7 @@ export default typeboxRoute(AuthCallbackSchema, async (req, res) => {
     }
     res.redirect(publicConfig.BASE_PATH);
   } else {
-    return { 403: null };
+    redirectToAuthLogin(req, res, runtimeConfig.PROTOCOL, publicConfig.BASE_PATH, runtimeConfig.AUTH_EXTERNAL_URL);
   }
 
 });

--- a/apps/mis-web/src/stores/UserStore.ts
+++ b/apps/mis-web/src/stores/UserStore.ts
@@ -33,9 +33,11 @@ export function UserStore(initialUser: User | undefined = undefined) {
   const loggedIn = !!user;
 
   const logout = useCallback(() => {
-    api.logout({}).catch((e) => { console.log("Error when logout", e); });
-    setUser(undefined);
-    destroyUserInfoCookie(null);
+    api.logout({}).catch((e) => { console.log("Error when logout", e); })
+      .finally(() => {
+        setUser(undefined);
+        destroyUserInfoCookie(null);
+      });
   }, []);
 
   return { loggedIn, user, logout };

--- a/apps/portal-web/src/pages/api/auth/callback.ts
+++ b/apps/portal-web/src/pages/api/auth/callback.ts
@@ -11,12 +11,13 @@
  */
 
 import { typeboxRouteSchema } from "@ddadaal/next-typed-api-routes-runtime";
+import { redirectToAuthLogin } from "@scow/lib-web/build/routes/auth/redirectToLogin";
 import { Type } from "@sinclair/typebox";
 import { setTokenCookie } from "src/auth/cookie";
 import { validateToken } from "src/auth/token";
 import { OperationResult, OperationType } from "src/models/operationLog";
 import { callLog } from "src/server/operationLog";
-import { publicConfig } from "src/utils/config";
+import { publicConfig, runtimeConfig } from "src/utils/config";
 import { route } from "src/utils/route";
 import { parseIp } from "src/utils/server";
 
@@ -57,8 +58,7 @@ export default route(AuthCallbackSchema, async (req, res) => {
     }
     res.redirect(publicConfig.BASE_PATH);
   } else {
-    return { 403: null };
-
+    redirectToAuthLogin(req, res, runtimeConfig.PROTOCOL, publicConfig.BASE_PATH, runtimeConfig.AUTH_EXTERNAL_URL);
   }
 
 });

--- a/apps/portal-web/src/stores/UserStore.ts
+++ b/apps/portal-web/src/stores/UserStore.ts
@@ -26,9 +26,11 @@ export function UserStore(initialUser: User | undefined = undefined) {
   const loggedIn = !!user;
 
   const logout = useCallback(() => {
-    api.logout({}).catch((e) => { console.log("Error when logout", e); });
-    setUser(undefined);
-    destroyUserInfoCookie(null);
+    api.logout({}).catch((e) => { console.log("Error when logout", e); })
+      .finally(() => {
+        setUser(undefined);
+        destroyUserInfoCookie(null);
+      });
   }, []);
 
   return { loggedIn, user, logout };


### PR DESCRIPTION
本 PR 修复两个问题
1. 退出登录时未在 redis 中删除 token 的问题
[#493](https://github.com/PKUHPC/SCOW/pull/493) 中已经提及的 bug，但是修复是无效的，原因是 api 调用是异步的，仍然先执行的后续删除 cookie 操作

2. 修复 token 失效后切换系统时不会返回到登陆系统而是会显示 403 界面的问题