### PR TITLE
chore: 修复修改proto文件后 scow/protos build时cache会错误命中的问题

### DIFF
--- a/apps/portal-web/src/utils/dashboard.ts
+++ b/apps/portal-web/src/utils/dashboard.ts
@@ -16,7 +16,7 @@ import { SortOrder } from "antd/lib/table/interface";
 import { useI18nTranslateToString } from "src/i18n";
 import { AppWithCluster } from "src/pageComponents/dashboard/QuickEntry";
 
-import { getI18nText, publicConfig } from "./config";
+import { publicConfig } from "./config";
 
 
 export const formatEntryId = (item: Entry) => {

--- a/turbo.json
+++ b/turbo.json
@@ -52,7 +52,7 @@
     },
     "@scow/protos#generate": {
       "inputs": [
-        "node_modules/@scow/grpc-api/**/*.proto",
+        "../../../protos/**/*.proto",
         "buf.gen.yaml"
       ],
       "outputs": [


### PR DESCRIPTION
turbo.json里 @scow/protos#generate  中input  为“node_modules/@scow/grpc-api/**/*.proto”，修改proto文件无法触发缓存更新，改为”../../../protos/**/*.proto“后可实现