### PR TITLE
fix(cli): 去掉 node-cron 表达式前秒的限制

### DIFF
--- a/.changeset/wild-paws-drop.md
+++ b/.changeset/wild-paws-drop.md
@@ -1,0 +1,7 @@
+---
+"@scow/demo-vagrant": patch
+"@scow/cli": patch
+"@scow/docs": patch
+---
+
+去掉 node-cron 表达式前秒的限制

--- a/apps/cli/assets/init-full/config/mis.yaml
+++ b/apps/cli/assets/init-full/config/mis.yaml
@@ -13,7 +13,7 @@ fetchJobs:
     # 是否开启
     enabled: true
     # 周期的cron表达式
-    cron: "10 */10 * * * *"
+    cron: "*/10 * * * *"
 
 # 周期性同步scow与调度器(如slurm)账户用户封锁状态的配置
 periodicSyncUserAccountBlockStatus:

--- a/apps/cli/assets/init/config/mis.yaml
+++ b/apps/cli/assets/init/config/mis.yaml
@@ -12,7 +12,7 @@ fetchJobs:
     # 是否开启
     enabled: true
     # 周期的cron表达式
-    cron: "10 */10 * * * *"
+    cron: "*/10 * * * *"
 
 # 预定义的充值类型
 predefinedChargingTypes:

--- a/deploy/vagrant/scow/scow-deployment/config/mis.yaml
+++ b/deploy/vagrant/scow/scow-deployment/config/mis.yaml
@@ -12,7 +12,7 @@ fetchJobs:
     # 是否开启
     enabled: true
     # 周期的cron表达式
-    cron: "10 */10 * * * *"
+    cron: "*/10 * * * *"
 
 # 预定义的充值类型
 predefinedChargingTypes:

--- a/docs/blog/2023-10-20-scow-update1.0.md
+++ b/docs/blog/2023-10-20-scow-update1.0.md
@@ -92,7 +92,7 @@ db:
 fetchJobs:
   periodicFetch:
     enabled: true
-    cron: "10 */10 * * * *"
+    cron: "*/10 * * * *"
 
 predefinedChargingTypes:
   - 测试

--- a/docs/docs/deploy/config/mis/intro.md
+++ b/docs/docs/deploy/config/mis/intro.md
@@ -74,7 +74,7 @@ fetchJobs:
     # 是否开启
     enabled: true
     # 周期的cron表达式
-    cron: "10 */10 * * * *"
+    cron: "*/10 * * * *"
 
 # 周期性同步scow与调度器(如slurm)账户用户封锁状态的配置
 periodicSyncUserAccountBlockStatus:


### PR DESCRIPTION
mis.yaml 原本获取作业的cron表达式：    
```mis.yaml
cron: "10 */10 * * * *"
```
前面多了一个10，默认应该是10分钟一次：*/10 * * * *，前面多加一个10会将定时任务设置在每10分的第10秒精确执行，其实也是不影响我们想要的效果。但为了让部分熟悉linux的用户理解更准确，我们去掉最前面的10，修改后如下：
```mis.yaml
cron: "*/10 * * * *"
```