### PR TITLE
fix(portal): 修改 GetFileMetadataResponse 中文件大小 size 为 uint64

### DIFF
--- a/.changeset/kind-nails-hunt.md
+++ b/.changeset/kind-nails-hunt.md
@@ -1,0 +1,5 @@
+---
+"@scow/grpc-api": patch
+---
+
+修改 GetFileMetadataResponse 中文件大小 size 为 uint64

--- a/protos/portal/file.proto
+++ b/protos/portal/file.proto
@@ -155,7 +155,7 @@ message GetFileMetadataRequest {
 }
 
 message GetFileMetadataResponse {
-  uint32 size = 1;
+  uint64 size = 1;
   string type = 2;
 }
 


### PR DESCRIPTION
该 pr 为 [#937](https://github.com/PKUHPC/SCOW/pull/937/files) 遗漏部分的补充修改

uint32 能表示的文件大小约为 4GB，故改为 uint64。

需要注意，scow 目前 proto 对于 uint64 转译后生成的文件中被解释为 number。number 比 uint64 的数值表示范围要小很多，目前没出现问题是由于 number 可以表示约为 9 PB 的文件大小，一般不会出现不够的情况
