### PR TITLE
fix(ai): Containerd运行时下大镜像推送失败

### DIFF
--- a/.changeset/cuddly-frogs-rest.md
+++ b/.changeset/cuddly-frogs-rest.md
@@ -1,0 +1,5 @@
+---
+"@scow/ai": patch
+---
+
+修复大镜像在 Containerd 运行时推送失败的问题

--- a/apps/ai/src/app/(auth)/image/CreateEditImageModal.tsx
+++ b/apps/ai/src/app/(auth)/image/CreateEditImageModal.tsx
@@ -86,7 +86,7 @@ export const CreateEditImageModal: React.FC<Props> = (
         ]);
         return;
       }
-      message.error("添加镜像失败");
+      message.error(`添加镜像失败, ${err.message}`);
     },
   });
 
@@ -101,7 +101,7 @@ export const CreateEditImageModal: React.FC<Props> = (
       if (data?.code === "NOT_FOUND") {
         message.error("镜像不存在");
       } else {
-        message.error("编辑镜像失败");
+        message.error(`编辑镜像失败,${e.message}`);
       }
     },
   });

--- a/apps/ai/src/server/trpc/route/image/image.ts
+++ b/apps/ai/src/server/trpc/route/image/image.ts
@@ -31,15 +31,6 @@ import { z } from "zod";
 import { clusters } from "../config";
 import { clusterExist } from "../utils";
 
-// class NotTarError extends TRPCError {
-//   constructor(name: string, tag: string) {
-//     super({
-//       code: "UNPROCESSABLE_CONTENT",
-//       message: `Image ${name}:${tag} create failed: image is not a tar file`,
-//     });
-//   }
-// };
-
 class NoClusterError extends TRPCError {
   constructor(name: string, tag: string) {
     super({
@@ -48,15 +39,6 @@ class NoClusterError extends TRPCError {
     });
   }
 };
-
-// class NoLocalImageError extends TRPCError {
-//   constructor(name: string, tag: string) {
-//     super({
-//       code: "NOT_FOUND",
-//       message: `Image ${name}:${tag} create failed: localImage not found`,
-//     });
-//   }
-// }
 
 class InternalServerError extends TRPCError {
   constructor(errMessage: string, process: "Create" | "Copy") {


### PR DESCRIPTION
**改动**
1.此pr在` containerd `运行时的 `nerdctl push `命令中追加 `--all-platforms`运行参数，避免可能由于基础镜像为多平台的大镜像在推送到镜像仓库中推送失败的问题
2.在创建镜像与编辑镜像时追加后台详细错误信息展示

**修改后**
1.不影响docker运行时的命令执行，本地创建和远程镜像创建均可成功
2.不影响containerd运行时普通镜像上传，本地创建和远程镜像创建均可成功
3.创建后本地拉取及制作的镜像正常删除
![image](https://github.com/PKUHPC/SCOW/assets/43978285/70ce73cf-244e-49ce-8dd7-eb7d52a460de)
![image](https://github.com/PKUHPC/SCOW/assets/43978285/ec808e35-a9a9-4a8f-99a6-66786d5a1178)
![image](https://github.com/PKUHPC/SCOW/assets/43978285/816fd767-581f-4908-ac8c-4744860329ef)

4.创建/编辑时错误信息补充完整
![image](https://github.com/PKUHPC/SCOW/assets/43978285/6a0cf21e-6ae2-4235-bd3f-ff8989ea9eca)
