### PR TITLE
fix(portal-web): 快捷方式的icon显示大小问题

### DIFF
--- a/.changeset/tasty-beers-grow.md
+++ b/.changeset/tasty-beers-grow.md
@@ -1,0 +1,5 @@
+---
+"@scow/portal-web": patch
+---
+
+修复快捷方式的 icon 显示大小问题

--- a/apps/portal-web/src/pageComponents/dashboard/EntryItem.tsx
+++ b/apps/portal-web/src/pageComponents/dashboard/EntryItem.tsx
@@ -30,7 +30,6 @@ const AvatarContainer = styled.div`
   display: flex;
   justify-content: center;
   flex: 1;
-
 `;
 
 const NameContainer = styled.div`
@@ -71,6 +70,7 @@ export const EntryItem: React.FC<Props> = ({ style,
             <img
               src={join(publicConfig.PUBLIC_PATH, logoPath)}
               onError={() => handleImageError(entryBaseName)}
+              style={{ maxWidth:"100px", objectFit:"contain" }}
             />
           ) : (
             icon && isSupportedIconName(icon) ?


### PR DESCRIPTION
## 测试用的图片（右边留白多一些）
![image](https://github.com/PKUHPC/SCOW/assets/74037789/628ee89d-b57b-4423-914f-17e3a4fa4c69)

## 修改之前的显示效果
![tem1](https://github.com/PKUHPC/SCOW/assets/74037789/f8ac232d-571d-4ba4-a211-ebfb6caa03a9)

## 修改之后的显示效果
![image](https://github.com/PKUHPC/SCOW/assets/74037789/d070d7f9-1ae9-4da2-97a3-da767e8c4e1f)
