### PR TITLE
chore:  暂停react-query更新

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -45,7 +45,8 @@
     {
       "matchPackagePatterns": [
         "ldapjs",
-        "@types/ldapjs"
+        "@types/ldapjs",
+        "@tanstack/react-query"
       ],
       "enabled": false
     }


### PR DESCRIPTION
react-query有v5更新，但是trpc需要等到11版本发布后才能兼容react-query v5。暂时停止react-query更新直到trpc v11发布。