### PR TITLE
chore: 更新CI配置

### DIFF
--- a/.github/workflows/docs-preview.yaml
+++ b/.github/workflows/docs-preview.yaml
@@ -30,7 +30,7 @@ jobs:
         run: pnpm run --filter docs... build
         env:
           GIT_PLATFORM: github
-          CR_URL: ghcr.io/pkuhpc/scow
+          CR_URL: ghcr.io/${{ github.event.repository.name }}
           BASE_PATH: /${{ github.event.repository.name }}/pr-preview/pr-${{ github.event.number }}/
 
       - name: Deploy preview

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -30,7 +30,7 @@ jobs:
         run: pnpm run --filter docs... build
         env:
           GIT_PLATFORM: github
-          CR_URL: ghcr.io/pkuhpc/scow
+          CR_URL: ghcr.io/${{ github.event.repository.name }}
           BASE_PATH: /${{ github.event.repository.name }}/
 
       - name: Deploy to GitHub Pages

--- a/.github/workflows/pr-cleanup.yaml
+++ b/.github/workflows/pr-cleanup.yaml
@@ -13,7 +13,7 @@ jobs:
         uses: dawidd6/action-delete-branch@v3
         with:
           github_token: ${{ secrets.SCOW_DEPLOYMENT_PAT }}
-          owner: PKUHPC
-          repository: scow-vagrant
+          owner: ${{ secrets.VAGRANT_REPO_OWNER }}
+          repository: ${{ secrets.VAGRANT_REPO_NAME }}
           branches: ${{ github.event.number }}/merge
           soft_fail: true

--- a/.github/workflows/side-projects.yaml
+++ b/.github/workflows/side-projects.yaml
@@ -15,6 +15,7 @@ jobs:
   scow-vagrant:
     name: Update scow-vagrant
     runs-on: ubuntu-latest
+    if: github.event.repository.name == 'PKUHPC/SCOW'
     steps:
       - uses: actions/checkout@v4
 
@@ -30,5 +31,5 @@ jobs:
         with:
           token: ${{ secrets.SCOW_DEPLOYMENT_PAT }}
           folder: ./deploy/vagrant
-          repository-name: PKUHPC/scow-vagrant
+          repository-name: ${{ secrets.VAGRANT_REPO_OWNER }}/${{ secrets.VAGRANT_REPO_NAME }}
           branch: ${{ github.ref_type == 'branch' && github.ref_name || 'master' }}

--- a/.github/workflows/side-projects.yaml
+++ b/.github/workflows/side-projects.yaml
@@ -15,7 +15,6 @@ jobs:
   scow-vagrant:
     name: Update scow-vagrant
     runs-on: ubuntu-latest
-    if: github.event.repository.name == 'PKUHPC/SCOW'
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/test-build-publish.yaml
+++ b/.github/workflows/test-build-publish.yaml
@@ -171,8 +171,8 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           file: docker/Dockerfile.${{ matrix.file }}
           labels: ${{ steps.meta.outputs.labels }}
-          # only build arm64 in master commits
-          platforms: linux/amd64${{ github.ref_type == 'tag' && ',linux/arm64' || '' }}
+          # only build arm64 in tag commits or branches with name starting with `arm-`
+          platforms: linux/amd64${{ (github.ref_type == 'tag' || startsWith(github.ref_name, 'arm-')) && ',linux/arm64' || '' }}
 
 
   release:


### PR DESCRIPTION
1. 文档中SCOW镜像地址以实际仓库为准
2. scow-vagrant发布仓库可通过仓库的secret配置
3. 将会在所有arm-开头的仓库中构建arm镜像