### PR TITLE
fix(ci): 修改pnpm最新版升级到9.0造成的构建问题

### DIFF
--- a/dev/test-adapter/Dockerfile
+++ b/dev/test-adapter/Dockerfile
@@ -17,6 +17,7 @@ RUN corepack enable
 
 WORKDIR /app
 
+COPY package.json .
 COPY pnpm-lock.yaml .
 
 COPY patches ./patches

--- a/docker/Dockerfile.docs
+++ b/docker/Dockerfile.docs
@@ -16,6 +16,8 @@ RUN apk update && apk add libc6-compat python3 make gcc g++ git
 RUN corepack enable
 
 WORKDIR /app
+
+COPY package.json .
 COPY pnpm-lock.yaml .
 COPY patches ./patches
 

--- a/docker/Dockerfile.scow
+++ b/docker/Dockerfile.scow
@@ -20,6 +20,8 @@ RUN apk add libc6-compat python3 make gcc g++ curl git
 RUN corepack enable
 
 WORKDIR /app
+
+COPY package.json .
 COPY pnpm-lock.yaml .
 COPY patches ./patches
 


### PR DESCRIPTION
pnpm的最新版升级到了9.0，Lockfile版本从6.x更新到了9.x，存在不兼容问题。而现在在容器构建时，执行`pnpm fetch`时下载的pnpm为最新版，而不是package.json中执行的版本，使得在执行pnpm fetch时lockfile被更新到最新的9.x版本，但是后面在执行后续的pnpm指令时使用的pnpm版本为老版本，不兼容最新的lockfile。

由于 https://github.com/vercel/turbo/issues/7993 问题，现在不能升级pnpm到最新的9.0版本。

此PR把package.json在执行`pnpm fetch`执行复制进了容器，使得执行`pnpm fetch`时所使用的pnpm版本为指定的版本而非最新版，保证lockfile不会意外改变。