### PR TITLE
fix(ai): 启用serverMinification，使用--no-mangling

### DIFF
--- a/.changeset/serious-fishes-bathe.md
+++ b/.changeset/serious-fishes-bathe.md
@@ -1,0 +1,5 @@
+---
+"@scow/ai": patch
+---
+
+启用 serverMinification，只关闭 name mangling

--- a/apps/ai/next.config.mjs
+++ b/apps/ai/next.config.mjs
@@ -42,10 +42,9 @@ export default async () => {
   const nextConfig = {
     compiler: {
       styledComponents: true,
+
     },
-    experimental: {
-      serverMinification: false,
-    },
+    swcMinify: false,
     basePath: BASE_PATH === "/" ? undefined : BASE_PATH,
     assetPrefix: BASE_PATH === "/" ? undefined : BASE_PATH,
     webpack: (config) => {

--- a/apps/ai/package.json
+++ b/apps/ai/package.json
@@ -18,7 +18,7 @@
     "serve": "node start.mjs",
     "serve:next": "next start",
     "build": "npm run build:next",
-    "build:next": "rimraf .next.backup && cross-env BUILDING=1 NEXT_PUBLIC_BASE_PATH=/@BASE_PATH@ next build",
+    "build:next": "rimraf .next.backup && cross-env BUILDING=1 NEXT_PUBLIC_BASE_PATH=/@BASE_PATH@ next build --no-mangling",
     "build:ts": "rimraf build && tsc -p tsconfig.server.json && tsc-alias -p tsconfig.server.json",
     "orm": "dotenv -e env/.env.dev -- npx mikro-orm",
     "ormCreate": "dotenv -e env/.env.dev -- npx mikro-orm migration:create",


### PR DESCRIPTION
启用AI项目的服务器端代码优化serverMinification，只使用`--no-mangling`和`swcMinify: false`来关闭name mangling以解决[这个问题](https://github.com/mikro-orm/mikro-orm/issues/5487)。理论上来说应该只要`--no-mangling`就行，但是应该还是next的bug （ https://github.com/vercel/next.js/issues/50208 ），必须还要同时设置`swcMinify: false`才可以。