### PR TITLE
fix(ai):  修复 trpc openapi 将 boolean params 全部转为 string 的问题

### DIFF
--- a/.changeset/healthy-cycles-sin.md
+++ b/.changeset/healthy-cycles-sin.md
@@ -1,0 +1,5 @@
+---
+"@scow/ai": patch
+---
+
+修复 trpc openapi 将 boolean params 全部转为 string 的问题

--- a/.github/workflows/test-build-publish.yaml
+++ b/.github/workflows/test-build-publish.yaml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Wait for ports
         if: vars.RUN_TESTS == 'true'
-        uses: ifaxity/wait-on-action@main
+        uses: ifaxity/wait-on-action@v1.1.0
         with:
           log: true
           verbose: true

--- a/apps/ai/src/app/(auth)/algorithm/AlgorithmTable.tsx
+++ b/apps/ai/src/app/(auth)/algorithm/AlgorithmTable.tsx
@@ -22,6 +22,7 @@ import { ModalButton } from "src/components/ModalLink";
 import { AlgorithmInterface, AlgorithmTypeText, Framework } from "src/models/Algorithm";
 import { Cluster } from "src/server/trpc/route/config";
 import { formatDateTime } from "src/utils/datetime";
+import { parseBooleanParam } from "src/utils/parse";
 import { trpc } from "src/utils/trpc";
 
 import { AlgorithmVersionList } from "./AlgorithmVersionList";
@@ -77,7 +78,7 @@ export const AlgorithmTable: React.FC<Props> = ({ isPublic, clusters }) => {
       framework:query.framework === "ALL" ? undefined : query.framework,
       nameOrDesc:query.nameOrDesc,
       clusterId:query.clusterId,
-      isPublic,
+      isPublic: parseBooleanParam(isPublic),
     });
   if (error) {
     message.error("找不到算法");

--- a/apps/ai/src/app/(auth)/algorithm/AlgorithmVersionList.tsx
+++ b/apps/ai/src/app/(auth)/algorithm/AlgorithmVersionList.tsx
@@ -21,6 +21,7 @@ import { Cluster } from "src/server/trpc/route/config";
 import { AppRouter } from "src/server/trpc/router";
 import { getSharedStatusText } from "src/utils/common";
 import { formatDateTime } from "src/utils/datetime";
+import { parseBooleanParam } from "src/utils/parse";
 import { trpc } from "src/utils/trpc";
 
 import { CopyPublicAlgorithmModal } from "./CopyPublicAlgorithmModal";
@@ -46,7 +47,10 @@ export const AlgorithmVersionList: React.FC<Props> = (
   const router = useRouter();
 
   const { data: versionData, isFetching, refetch, error: versionError } =
-    trpc.algorithm.getAlgorithmVersions.useQuery({ algorithmId:algorithmId, isPublic });
+    trpc.algorithm.getAlgorithmVersions.useQuery({
+      algorithmId:algorithmId,
+      isPublic: isPublic !== undefined ? parseBooleanParam(isPublic) : undefined,
+    });
   if (versionError) {
     message.error("找不到算法版本");
   }

--- a/apps/ai/src/app/(auth)/dataset/DatasetListTable.tsx
+++ b/apps/ai/src/app/(auth)/dataset/DatasetListTable.tsx
@@ -25,6 +25,7 @@ import { Cluster } from "src/server/trpc/route/config";
 import { DatasetInterface } from "src/server/trpc/route/dataset/dataset";
 import { AppRouter } from "src/server/trpc/router";
 import { formatDateTime } from "src/utils/datetime";
+import { parseBooleanParam } from "src/utils/parse";
 import { trpc } from "src/utils/trpc";
 
 import { defaultClusterContext } from "../defaultClusterContext";
@@ -79,7 +80,7 @@ export const DatasetListTable: React.FC<Props> = ({ isPublic, clusters }) => {
   const [pageInfo, setPageInfo] = useState<PageInfo>({ page: 1, pageSize: 10 });
 
   const { data, refetch, isFetching, error } = trpc.dataset.list.useQuery({
-    ...pageInfo, ...query, clusterId: query.cluster?.id, isPublic,
+    ...pageInfo, ...query, clusterId: query.cluster?.id, isPublic: parseBooleanParam(isPublic),
   });
   if (error) {
     message.error("找不到数据集");

--- a/apps/ai/src/app/(auth)/dataset/DatasetVersionList.tsx
+++ b/apps/ai/src/app/(auth)/dataset/DatasetVersionList.tsx
@@ -21,6 +21,7 @@ import { DatasetInterface } from "src/server/trpc/route/dataset/dataset";
 import { AppRouter } from "src/server/trpc/router";
 import { getSharedStatusText } from "src/utils/common";
 import { formatDateTime } from "src/utils/datetime";
+import { parseBooleanParam } from "src/utils/parse";
 import { trpc } from "src/utils/trpc";
 
 import { CopyPublicDatasetModal } from "./CopyPublicDatasetModal";
@@ -45,7 +46,10 @@ export const DatasetVersionList: React.FC<Props> = (
   const router = useRouter();
 
   const { data: versionData, isFetching, refetch, error: versionError }
-    = trpc.dataset.versionList.useQuery({ datasetId, isPublic });
+    = trpc.dataset.versionList.useQuery({
+      datasetId,
+      isPublic:  isPublic !== undefined ? parseBooleanParam(isPublic) : undefined,
+    });
   if (versionError) {
     message.error("找不到数据集版本");
   }

--- a/apps/ai/src/app/(auth)/image/ImageListTable.tsx
+++ b/apps/ai/src/app/(auth)/image/ImageListTable.tsx
@@ -25,6 +25,7 @@ import { SourceText, Status } from "src/models/Image";
 import { Cluster } from "src/server/trpc/route/config";
 import { AppRouter } from "src/server/trpc/router";
 import { formatDateTime } from "src/utils/datetime";
+import { parseBooleanParam } from "src/utils/parse";
 import { trpc } from "src/utils/trpc";
 
 import { CopyImageModal } from "./CopyImageModal";
@@ -67,7 +68,7 @@ export const ImageListTable: React.FC<Props> = ({ isPublic, clusters }) => {
   const cluster = Form.useWatch("cluster", form);
 
   const { data, refetch, isFetching, error } = trpc.image.list.useQuery({
-    ...pageInfo, ...query, clusterId: cluster?.id,
+    ...pageInfo, ...query, isPublic: parseBooleanParam(isPublic), clusterId: cluster?.id,
   });
 
   const { modal, message } = App.useApp();
@@ -239,7 +240,7 @@ export const ImageListTable: React.FC<Props> = ({ isPublic, clusters }) => {
                           onOk: async () => {
                             await deleteImageMutation.mutateAsync({
                               id: r.id,
-                              force: r.status === Status.CREATING,
+                              force: parseBooleanParam(r.status === Status.CREATING),
                             });
                           },
                         });

--- a/apps/ai/src/app/(auth)/jobs/[clusterId]/AppSessionsTable.tsx
+++ b/apps/ai/src/app/(auth)/jobs/[clusterId]/AppSessionsTable.tsx
@@ -25,6 +25,7 @@ import { Cluster } from "src/server/trpc/route/config";
 import { AppSession } from "src/server/trpc/route/jobs/apps";
 import { calculateAppRemainingTime, compareDateTime, formatDateTime } from "src/utils/datetime";
 import { compareNumber } from "src/utils/math";
+import { parseBooleanParam } from "src/utils/parse";
 import { trpc } from "src/utils/trpc";
 
 import { ConnectTopAppLink } from "./ConnectToAppLink";
@@ -69,7 +70,7 @@ export const AppSessionsTable: React.FC<Props> = ({ cluster, status }) => {
   const [connectivityRefreshToken, setConnectivityRefreshToken] = useState(false);
 
   const { data, refetch, isLoading, isFetching } = trpc.jobs.listAppSessions.useQuery({
-    clusterId: cluster.id, isRunning: unfinished,
+    clusterId: cluster.id, isRunning: parseBooleanParam(unfinished),
   });
 
   const cancelJobMutation = trpc.jobs.cancelJob.useMutation({

--- a/apps/ai/src/app/(auth)/jobs/[clusterId]/LaunchAppForm.tsx
+++ b/apps/ai/src/app/(auth)/jobs/[clusterId]/LaunchAppForm.tsx
@@ -30,6 +30,7 @@ import { DatasetInterface } from "src/server/trpc/route/dataset/dataset";
 import { DatasetVersionInterface } from "src/server/trpc/route/dataset/datasetVersion";
 import { AppCustomAttribute } from "src/server/trpc/route/jobs/apps";
 import { formatSize } from "src/utils/format";
+import { parseBooleanParam } from "src/utils/parse";
 import { trpc } from "src/utils/trpc";
 
 import { useDataOptions, useDataVersionOptions } from "./hooks";
@@ -51,7 +52,7 @@ interface Props {
 interface FixedFormFields {
   appJobName: string;
   algorithm: { name: number, version: number };
-  image: { name: number };
+  image: { type?: AccessibilityType, name?: number };
   remoteImageUrl: string | undefined;
   startCommand?: string;
   dataset: { name: number, version: number };
@@ -184,9 +185,9 @@ export const LaunchAppForm = (props: Props) => {
   const isImagePublic = imageType !== undefined ? imageType === AccessibilityType.PUBLIC : imageType;
 
   const { data: images, isLoading: isImagesLoading } = trpc.image.list.useQuery({
-    isPublic: isImagePublic,
+    isPublic: isImagePublic !== undefined ? parseBooleanParam(isImagePublic) : undefined,
     clusterId,
-    withExternal: true,
+    withExternal: "true",
   }, {
     enabled: isImagePublic !== undefined,
   });

--- a/apps/ai/src/app/(auth)/jobs/[clusterId]/hooks.ts
+++ b/apps/ai/src/app/(auth)/jobs/[clusterId]/hooks.ts
@@ -13,6 +13,7 @@
 import { UseQueryResult } from "@tanstack/react-query";
 import { Form, FormInstance } from "antd";
 import { useMemo } from "react";
+import { parseBooleanParam } from "src/utils/parse";
 
 import { AccessibilityType } from "./LaunchAppForm";
 
@@ -39,7 +40,8 @@ export function useDataOptions<T>(
   const isItemPublic = itemType !== undefined ? itemType === AccessibilityType.PUBLIC : itemType;
 
   const { data: items, isLoading: isDataLoading } = queryHook({
-    isPublic : isItemPublic, clusterId,
+    isPublic : isItemPublic !== undefined ? parseBooleanParam(isItemPublic) : undefined,
+    clusterId,
   }, { enabled: isItemPublic !== undefined });
 
   const dataOptions = useMemo(() => {
@@ -62,7 +64,8 @@ export function useDataVersionOptions<T>(
   const isItemPublic = itemType !== undefined ? itemType === AccessibilityType.PUBLIC : itemType;
 
   const { data: versions, isLoading: isDataVersionsLoading } = queryHook({
-    [`${dataType}Id`]: selectedItem, isPublic : isItemPublic,
+    [`${dataType}Id`]: selectedItem,
+    isPublic : isItemPublic !== undefined ? parseBooleanParam(isItemPublic) : undefined,
   }, { enabled: selectedItem !== undefined });
 
   const dataVersionOptions = useMemo(() => {

--- a/apps/ai/src/app/(auth)/model/ModelTable.tsx
+++ b/apps/ai/src/app/(auth)/model/ModelTable.tsx
@@ -22,6 +22,7 @@ import { ModalButton } from "src/components/ModalLink";
 import { ModelInterface } from "src/models/Model";
 import { Cluster } from "src/server/trpc/route/config";
 import { formatDateTime } from "src/utils/datetime";
+import { parseBooleanParam } from "src/utils/parse";
 import { trpc } from "src/utils/trpc";
 
 import { CreateAndEditModalModal } from "./CreateAndEditModelModal";
@@ -68,7 +69,7 @@ export const ModalTable: React.FC<Props> = ({ isPublic, clusters }) => {
     { ...pageInfo,
       nameOrDesc:query.nameOrDesc,
       clusterId:query.clusterId,
-      isPublic,
+      isPublic: parseBooleanParam(isPublic),
     });
   if (error) {
     message.error("找不到模型");

--- a/apps/ai/src/app/(auth)/model/ModelVersionList.tsx
+++ b/apps/ai/src/app/(auth)/model/ModelVersionList.tsx
@@ -21,6 +21,7 @@ import { Cluster } from "src/server/trpc/route/config";
 import { AppRouter } from "src/server/trpc/router";
 import { getSharedStatusText } from "src/utils/common";
 import { formatDateTime } from "src/utils/datetime";
+import { parseBooleanParam } from "src/utils/parse";
 import { trpc } from "src/utils/trpc";
 
 import { CopyPublicModelModal } from "./CopyPublicModelModal";
@@ -45,7 +46,10 @@ export const ModelVersionList: React.FC<Props> = (
   const router = useRouter();
 
   const { data: versionData, isFetching, refetch, error: versionError } =
-    trpc.model.versionList.useQuery({ modelId, isPublic });
+    trpc.model.versionList.useQuery({
+      modelId,
+      isPublic: isPublic !== undefined ? parseBooleanParam(isPublic) : undefined,
+    });
   if (versionError) {
     message.error("找不到模型版本");
   }

--- a/apps/ai/src/server/trpc/route/algorithm/algorithm.ts
+++ b/apps/ai/src/server/trpc/route/algorithm/algorithm.ts
@@ -23,7 +23,7 @@ import { getUpdatedSharedPath, unShareFileOrDir } from "src/server/utils/share";
 import { getClusterLoginNode } from "src/server/utils/ssh";
 import { z } from "zod";
 
-import { clusterExist } from "../utils";
+import { booleanQueryParam, clusterExist } from "../utils";
 
 
 export const getAlgorithms = procedure
@@ -39,8 +39,8 @@ export const getAlgorithms = procedure
     ...paginationSchema.shape,
     framework: z.nativeEnum(Framework).optional(),
     nameOrDesc: z.string().optional(),
-    clusterId:z.string().optional(),
-    isPublic:z.coerce.boolean().optional(),
+    clusterId: z.string().optional(),
+    isPublic: booleanQueryParam().optional(),
   }))
   .output(z.object({ items: z.array(z.object({
     id:z.number(),

--- a/apps/ai/src/server/trpc/route/algorithm/algorithm.ts
+++ b/apps/ai/src/server/trpc/route/algorithm/algorithm.ts
@@ -40,7 +40,7 @@ export const getAlgorithms = procedure
     framework: z.nativeEnum(Framework).optional(),
     nameOrDesc: z.string().optional(),
     clusterId:z.string().optional(),
-    isPublic:z.boolean().optional(),
+    isPublic:z.coerce.boolean().optional(),
   }))
   .output(z.object({ items: z.array(z.object({
     id:z.number(),

--- a/apps/ai/src/server/trpc/route/algorithm/algorithmVersion.ts
+++ b/apps/ai/src/server/trpc/route/algorithm/algorithmVersion.ts
@@ -41,7 +41,7 @@ export const getAlgorithmVersions = procedure
   .input(z.object({
     ...paginationSchema.shape,
     algorithmId: z.number(),
-    isPublic:z.boolean().optional(),
+    isPublic:z.coerce.boolean().optional(),
   }))
   .output(z.object({ items: z.array(z.object({
     id:z.number(),

--- a/apps/ai/src/server/trpc/route/algorithm/algorithmVersion.ts
+++ b/apps/ai/src/server/trpc/route/algorithm/algorithmVersion.ts
@@ -29,6 +29,8 @@ import { checkSharePermission, getUpdatedSharedPath, SHARED_TARGET,
 import { getClusterLoginNode, sshConnect } from "src/server/utils/ssh";
 import { z } from "zod";
 
+import { booleanQueryParam } from "../utils";
+
 export const getAlgorithmVersions = procedure
   .meta({
     openapi: {
@@ -41,7 +43,7 @@ export const getAlgorithmVersions = procedure
   .input(z.object({
     ...paginationSchema.shape,
     algorithmId: z.number(),
-    isPublic:z.coerce.boolean().optional(),
+    isPublic:booleanQueryParam().optional(),
   }))
   .output(z.object({ items: z.array(z.object({
     id:z.number(),

--- a/apps/ai/src/server/trpc/route/auth.ts
+++ b/apps/ai/src/server/trpc/route/auth.ts
@@ -70,7 +70,7 @@ export const auth = router({
     })
     .input(z.object({
       token:z.string(),
-      // fromAuth:z.coerce.boolean(),  //后续与audit集成时需使用
+      // fromAuth: booleanQueryParam(),  //后续与audit集成时需使用
     }))
     .output(z.void())
     .query(async ({ ctx: { res }, input }) => {

--- a/apps/ai/src/server/trpc/route/auth.ts
+++ b/apps/ai/src/server/trpc/route/auth.ts
@@ -70,7 +70,7 @@ export const auth = router({
     })
     .input(z.object({
       token:z.string(),
-      // fromAuth:z.boolean(),  //后续与audit集成时需使用
+      // fromAuth:z.coerce.boolean(),  //后续与audit集成时需使用
     }))
     .output(z.void())
     .query(async ({ ctx: { res }, input }) => {

--- a/apps/ai/src/server/trpc/route/dataset/dataset.ts
+++ b/apps/ai/src/server/trpc/route/dataset/dataset.ts
@@ -24,7 +24,7 @@ import { getUpdatedSharedPath, unShareFileOrDir } from "src/server/utils/share";
 import { getClusterLoginNode } from "src/server/utils/ssh";
 import { z } from "zod";
 
-import { clusterExist } from "../utils";
+import { booleanQueryParam, clusterExist } from "../utils";
 
 export const DatasetListSchema = z.object({
   id: z.number(),
@@ -54,7 +54,7 @@ export const list = procedure
     ...paginationSchema.shape,
     nameOrDesc: z.string().optional(),
     type: z.string().optional(),
-    isPublic: z.coerce.boolean().optional(),
+    isPublic: booleanQueryParam().optional(),
     clusterId: z.string().optional(),
   }))
   .output(z.object({ items: z.array(DatasetListSchema), count: z.number() }))

--- a/apps/ai/src/server/trpc/route/dataset/dataset.ts
+++ b/apps/ai/src/server/trpc/route/dataset/dataset.ts
@@ -54,7 +54,7 @@ export const list = procedure
     ...paginationSchema.shape,
     nameOrDesc: z.string().optional(),
     type: z.string().optional(),
-    isPublic: z.boolean().optional(),
+    isPublic: z.coerce.boolean().optional(),
     clusterId: z.string().optional(),
   }))
   .output(z.object({ items: z.array(DatasetListSchema), count: z.number() }))

--- a/apps/ai/src/server/trpc/route/dataset/datasetVersion.ts
+++ b/apps/ai/src/server/trpc/route/dataset/datasetVersion.ts
@@ -55,7 +55,7 @@ export const versionList = procedure
   .input(z.object({
     ...paginationSchema.shape,
     datasetId: z.number(),
-    isPublic: z.boolean().optional(),
+    isPublic: z.coerce.boolean().optional(),
   }))
   .output(z.object({ items: z.array(DatasetVersionListSchema), count: z.number() }))
   .query(async ({ input }) => {

--- a/apps/ai/src/server/trpc/route/dataset/datasetVersion.ts
+++ b/apps/ai/src/server/trpc/route/dataset/datasetVersion.ts
@@ -30,6 +30,8 @@ import { checkSharePermission, getUpdatedSharedPath, SHARED_TARGET,
 import { getClusterLoginNode, sshConnect } from "src/server/utils/ssh";
 import { z } from "zod";
 
+import { booleanQueryParam } from "../utils";
+
 export const DatasetVersionListSchema = z.object({
   id: z.number(),
   versionName: z.string(),
@@ -55,7 +57,7 @@ export const versionList = procedure
   .input(z.object({
     ...paginationSchema.shape,
     datasetId: z.number(),
-    isPublic: z.coerce.boolean().optional(),
+    isPublic: booleanQueryParam().optional(),
   }))
   .output(z.object({ items: z.array(DatasetVersionListSchema), count: z.number() }))
   .query(async ({ input }) => {

--- a/apps/ai/src/server/trpc/route/image/image.ts
+++ b/apps/ai/src/server/trpc/route/image/image.ts
@@ -29,7 +29,7 @@ import { getClusterLoginNode } from "src/server/utils/ssh";
 import { z } from "zod";
 
 import { clusters } from "../config";
-import { clusterExist } from "../utils";
+import { booleanQueryParam, clusterExist } from "../utils";
 
 class NoClusterError extends TRPCError {
   constructor(name: string, tag: string) {
@@ -76,9 +76,9 @@ export const list = procedure
   .input(z.object({
     ...paginationSchema.shape,
     nameOrTagOrDesc: z.string().optional(),
-    isPublic: z.coerce.boolean().optional(),
+    isPublic: booleanQueryParam().optional(),
     clusterId: z.string().optional(),
-    withExternal: z.coerce.boolean().optional(),
+    withExternal: booleanQueryParam().optional(),
   }))
   .output(z.object({ items: z.array(ImageListSchema), count: z.number() }))
   .query(async ({ input, ctx: { user } }) => {
@@ -305,7 +305,7 @@ export const deleteImage = procedure
       summary: "delete a image",
     },
   })
-  .input(z.object({ id: z.number(), force: z.coerce.boolean().optional() }))
+  .input(z.object({ id: z.number(), force: booleanQueryParam().optional() }))
   .output(z.void())
   .mutation(async ({ input, ctx: { user } }) => {
     const em = await forkEntityManager();
@@ -456,7 +456,7 @@ export const shareOrUnshareImage = procedure
       summary: "share a image",
     },
   })
-  .input(z.object({ id: z.number(), share: z.coerce.boolean() }))
+  .input(z.object({ id: z.number(), share: z.boolean() }))
   .output(z.void())
   .mutation(async ({ input, ctx: { user } }) => {
     const em = await forkEntityManager();

--- a/apps/ai/src/server/trpc/route/image/image.ts
+++ b/apps/ai/src/server/trpc/route/image/image.ts
@@ -76,9 +76,9 @@ export const list = procedure
   .input(z.object({
     ...paginationSchema.shape,
     nameOrTagOrDesc: z.string().optional(),
-    isPublic: z.boolean().optional(),
+    isPublic: z.coerce.boolean().optional(),
     clusterId: z.string().optional(),
-    withExternal: z.boolean().optional(),
+    withExternal: z.coerce.boolean().optional(),
   }))
   .output(z.object({ items: z.array(ImageListSchema), count: z.number() }))
   .query(async ({ input, ctx: { user } }) => {
@@ -305,7 +305,7 @@ export const deleteImage = procedure
       summary: "delete a image",
     },
   })
-  .input(z.object({ id: z.number(), force: z.boolean().optional() }))
+  .input(z.object({ id: z.number(), force: z.coerce.boolean().optional() }))
   .output(z.void())
   .mutation(async ({ input, ctx: { user } }) => {
     const em = await forkEntityManager();
@@ -456,7 +456,7 @@ export const shareOrUnshareImage = procedure
       summary: "share a image",
     },
   })
-  .input(z.object({ id: z.number(), share: z.boolean() }))
+  .input(z.object({ id: z.number(), share: z.coerce.boolean() }))
   .output(z.void())
   .mutation(async ({ input, ctx: { user } }) => {
     const em = await forkEntityManager();

--- a/apps/ai/src/server/trpc/route/jobs/apps.ts
+++ b/apps/ai/src/server/trpc/route/jobs/apps.ts
@@ -610,7 +610,7 @@ export const listAppSessions =
         summary: "List APP Sessions",
       },
     })
-    .input(z.object({ clusterId: z.string(), isRunning: z.boolean(), ...paginationSchema.shape }))
+    .input(z.object({ clusterId: z.string(), isRunning: z.coerce.boolean(), ...paginationSchema.shape }))
     .output(z.object({ sessions: z.array(AppSessionSchema) }))
     .query(async ({ input, ctx: { user } }) => {
 

--- a/apps/ai/src/server/trpc/route/jobs/apps.ts
+++ b/apps/ai/src/server/trpc/route/jobs/apps.ts
@@ -51,6 +51,8 @@ import { isPortReachable } from "src/utils/isPortReachable";
 import { BASE_PATH } from "src/utils/processEnv";
 import { z } from "zod";
 
+import { booleanQueryParam } from "../utils";
+
 const ImageSchema = z.object({
   name: z.string(),
   tag: z.string().optional(),
@@ -610,7 +612,11 @@ export const listAppSessions =
         summary: "List APP Sessions",
       },
     })
-    .input(z.object({ clusterId: z.string(), isRunning: z.coerce.boolean(), ...paginationSchema.shape }))
+    .input(z.object({
+      clusterId: z.string(),
+      isRunning: booleanQueryParam(),
+      ...paginationSchema.shape,
+    }))
     .output(z.object({ sessions: z.array(AppSessionSchema) }))
     .query(async ({ input, ctx: { user } }) => {
 

--- a/apps/ai/src/server/trpc/route/model/model.ts
+++ b/apps/ai/src/server/trpc/route/model/model.ts
@@ -25,7 +25,7 @@ import { getUpdatedSharedPath, unShareFileOrDir } from "src/server/utils/share";
 import { getClusterLoginNode } from "src/server/utils/ssh";
 import { z } from "zod";
 
-import { clusterExist } from "../utils";
+import { booleanQueryParam, clusterExist } from "../utils";
 
 export const ModelListSchema = z.object({
   id: z.number(),
@@ -52,7 +52,7 @@ export const list = procedure
   .input(z.object({
     ...paginationSchema.shape,
     nameOrDesc: z.string().optional(),
-    isPublic: z.coerce.boolean().optional(),
+    isPublic: booleanQueryParam().optional(),
     clusterId: z.string().optional(),
   }))
   .output(z.object({ items: z.array(ModelListSchema), count: z.number() }))

--- a/apps/ai/src/server/trpc/route/model/model.ts
+++ b/apps/ai/src/server/trpc/route/model/model.ts
@@ -52,7 +52,7 @@ export const list = procedure
   .input(z.object({
     ...paginationSchema.shape,
     nameOrDesc: z.string().optional(),
-    isPublic: z.boolean().optional(),
+    isPublic: z.coerce.boolean().optional(),
     clusterId: z.string().optional(),
   }))
   .output(z.object({ items: z.array(ModelListSchema), count: z.number() }))

--- a/apps/ai/src/server/trpc/route/model/modelVersion.ts
+++ b/apps/ai/src/server/trpc/route/model/modelVersion.ts
@@ -30,6 +30,8 @@ import { checkSharePermission, getUpdatedSharedPath, SHARED_TARGET, shareFileOrD
 import { getClusterLoginNode, sshConnect } from "src/server/utils/ssh";
 import { z } from "zod";
 
+import { booleanQueryParam } from "../utils";
+
 export const VersionListSchema = z.object({
   id: z.number(),
   modelId: z.number(),
@@ -54,7 +56,7 @@ export const versionList = procedure
   .input(z.object({
     ...paginationSchema.shape,
     modelId: z.number(),
-    isPublic: z.coerce.boolean().optional(),
+    isPublic: booleanQueryParam().optional(),
   }))
   .output(z.object({ items: z.array(VersionListSchema), count: z.number() }))
   .query(async ({ input }) => {

--- a/apps/ai/src/server/trpc/route/model/modelVersion.ts
+++ b/apps/ai/src/server/trpc/route/model/modelVersion.ts
@@ -54,7 +54,7 @@ export const versionList = procedure
   .input(z.object({
     ...paginationSchema.shape,
     modelId: z.number(),
-    isPublic: z.boolean().optional(),
+    isPublic: z.coerce.boolean().optional(),
   }))
   .output(z.object({ items: z.array(VersionListSchema), count: z.number() }))
   .query(async ({ input }) => {

--- a/apps/ai/src/server/trpc/route/utils.ts
+++ b/apps/ai/src/server/trpc/route/utils.ts
@@ -34,4 +34,6 @@ export function clusterExist(clusterId: string) {
 }
 
 export const booleanQueryParam =
-() => z.union([z.literal("true"), z.literal("false")]).transform((arg) => Boolean(arg));
+() => z.union([z.literal("true"), z.literal("false")]).transform((arg) =>
+  arg === "true",
+);

--- a/apps/ai/src/server/trpc/route/utils.ts
+++ b/apps/ai/src/server/trpc/route/utils.ts
@@ -32,3 +32,6 @@ export const pagination = z.object({
 export function clusterExist(clusterId: string) {
   return !!getSortedClusters(clusters).find((cluster) => cluster.id === clusterId);
 }
+
+export const booleanQueryParam =
+() => z.union([z.literal("true"), z.literal("false")]).transform((arg) => Boolean(arg));

--- a/apps/ai/src/utils/parse.ts
+++ b/apps/ai/src/utils/parse.ts
@@ -67,4 +67,6 @@ export const parseIp = (req: NextApiRequest): string | undefined => {
   return forwardedFor ?? req.socket?.remoteAddress;
 };
 
-
+export const parseBooleanParam = (bool: boolean): "true" | "false" => {
+  return bool ? "true" : "false";
+};


### PR DESCRIPTION
### 背景
trpc openapi 对于get请求，处理boolean参数时会将true和false都识别为字符串后 以true的逻辑调用
### 改动
将Get请求 input 里的`z.boolean()` ->```
z.union([z.literal("true"), z.literal("false")]).transform((arg) =>arg === "true"); ```，可以使trpc-openapi正确处理input里的boolean参数