### PR TITLE
chore: 固定 github workflow 中 ifaxity/wait-on-action的版本

### DIFF
--- a/.github/workflows/test-build-publish.yaml
+++ b/.github/workflows/test-build-publish.yaml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Wait for ports
         if: vars.RUN_TESTS == 'true'
-        uses: ifaxity/wait-on-action@main
+        uses: ifaxity/wait-on-action@v1.1.0
         with:
           log: true
           verbose: true


### PR DESCRIPTION
目前由于ifaxity/wait-on-action 仓库发布了1.2.0版本 会遇到 报错 https://github.com/iFaxity/wait-on-action/issues/23， 故暂时将该仓库固定在v1.1.0版本保证scow的ci正常跑通