### PR TITLE
feat(web): xterm npm 包更名，修改导入

### DIFF
--- a/.changeset/grumpy-spoons-guess.md
+++ b/.changeset/grumpy-spoons-guess.md
@@ -1,0 +1,6 @@
+---
+"@scow/portal-web": patch
+"@scow/ai": patch
+---
+
+xterm npm 包更名

--- a/apps/ai/src/app/(auth)/jobShell/[clusterId]/[jobId]/page.tsx
+++ b/apps/ai/src/app/(auth)/jobShell/[clusterId]/[jobId]/page.tsx
@@ -12,7 +12,7 @@
 
 "use client";
 
-import "xterm/css/xterm.css";
+import "@xterm/xterm/css/xterm.css";
 
 import { Button, Space } from "antd";
 import dynamic from "next/dynamic";

--- a/apps/portal-web/package.json
+++ b/apps/portal-web/package.json
@@ -73,8 +73,8 @@
     "tslib": "2.6.2",
     "typescript": "5.4.3",
     "ws": "8.16.0",
-    "xterm": "5.3.0",
-    "xterm-addon-fit": "0.8.0"
+    "@xterm/xterm": "5.5.0",
+    "@xterm/addon-fit": "0.10.0"
   },
   "devDependencies": {
     "@ddadaal/next-typed-api-routes-cli": "0.9.1",

--- a/apps/portal-web/src/pageComponents/shell/Shell.tsx
+++ b/apps/portal-web/src/pageComponents/shell/Shell.tsx
@@ -11,6 +11,8 @@
  */
 
 import { debounce } from "@scow/lib-web/build/utils/debounce";
+import { FitAddon } from "@xterm/addon-fit";
+import { Terminal } from "@xterm/xterm";
 import { join } from "path";
 import { useEffect, useRef } from "react";
 import { urlToDownload } from "src/pageComponents/filemanager/api";
@@ -18,8 +20,6 @@ import { ShellInputData, ShellOutputData } from "src/server/setup/shell";
 import { User } from "src/stores/UserStore";
 import { publicConfig } from "src/utils/config";
 import { styled } from "styled-components";
-import { Terminal } from "xterm";
-import { FitAddon } from "xterm-addon-fit";
 
 const TerminalContainer = styled.div`
   background-color: black;

--- a/apps/portal-web/src/pages/shell/[cluster]/[loginNode]/[[...path]].tsx
+++ b/apps/portal-web/src/pages/shell/[cluster]/[loginNode]/[[...path]].tsx
@@ -10,7 +10,7 @@
  * See the Mulan PSL v2 for more details.
  */
 
-import "xterm/css/xterm.css";
+import "@xterm/xterm/css/xterm.css";
 
 import { getI18nConfigCurrentText } from "@scow/lib-web/build/utils/systemLanguage";
 import { Button, Popover, Space, Typography } from "antd";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1038,6 +1038,12 @@ importers:
       '@uiw/react-codemirror':
         specifier: 4.21.20
         version: 4.21.20(@babel/runtime@7.24.4)(@codemirror/autocomplete@6.6.0)(@codemirror/language@6.10.1)(@codemirror/lint@6.0.0)(@codemirror/search@6.2.3)(@codemirror/state@6.4.0)(@codemirror/theme-one-dark@6.1.0)(@codemirror/view@6.26.1)(codemirror@6.0.1)(react-dom@18.2.0)(react@18.2.0)
+      '@xterm/addon-fit':
+        specifier: 0.10.0
+        version: 0.10.0(@xterm/xterm@5.5.0)
+      '@xterm/xterm':
+        specifier: 5.5.0
+        version: 5.5.0
       antd:
         specifier: 5.16.0
         version: 5.16.0(react-dom@18.2.0)(react@18.2.0)
@@ -1107,12 +1113,6 @@ importers:
       ws:
         specifier: 8.16.0
         version: 8.16.0
-      xterm:
-        specifier: 5.3.0
-        version: 5.3.0
-      xterm-addon-fit:
-        specifier: 0.8.0
-        version: 0.8.0(xterm@5.3.0)
     devDependencies:
       '@ddadaal/next-typed-api-routes-cli':
         specifier: 0.9.1


### PR DESCRIPTION
The npm package `xterm` has been renamed to `@xterm/xterm`, and `xterm-addon-fit` has been renamed to `@xterm/addon-fit`.
This change has resulted in the automatic update of these dependencies not working. I renamed these two packages in portal-web's package.json and conducted a test.