### PR TITLE
feat(portal): 修改了portal中部分UI样式

### DIFF
--- a/.changeset/spotty-wombats-impress.md
+++ b/.changeset/spotty-wombats-impress.md
@@ -1,0 +1,9 @@
+---
+"@scow/portal-web": patch
+"@scow/demo-vagrant": patch
+"@scow/mis-web": patch
+"@scow/auth": patch
+"@scow/ai": patch
+---
+
+修改了 portal 中的部分 UI 样式,bannerTop 导航文字

--- a/apps/ai/src/app/(auth)/layout.tsx
+++ b/apps/ai/src/app/(auth)/layout.tsx
@@ -95,7 +95,7 @@ export default function Layout(
             icon={<DesktopOutlined style={{ paddingRight: 2 }} />}
             link={publicConfig.PORTAL_URL}
             // linkText={t("baseLayout.linkTextAI")}
-            linkText="SCOW HPC"
+            linkText="HPC"
           />
           {/* {
             systemLanguageConfig.isUsingI18n ? (

--- a/apps/mis-web/src/i18n/en.ts
+++ b/apps/mis-web/src/i18n/en.ts
@@ -157,7 +157,7 @@ export default {
         operationLog: "Operation Log",
         statistic: "Statistic",
       },
-      navLinkTextPortal: "SCOW HPC",
+      navLinkTextPortal: "HPC",
       navLinkTextAI: "SCOW AI",
       dashboard: "Dashboard",
       user: {

--- a/apps/mis-web/src/i18n/zh_cn.ts
+++ b/apps/mis-web/src/i18n/zh_cn.ts
@@ -157,7 +157,7 @@ export default {
         operationLog:"操作日志",
         statistic: "平台数据统计",
       },
-      navLinkTextPortal: "SCOW HPC",
+      navLinkTextPortal: "超算平台",
       navLinkTextAI: "SCOW AI",
       dashboard: "仪表盘",
       user: {

--- a/apps/portal-web/src/pageComponents/dashboard/OverviewTable.tsx
+++ b/apps/portal-web/src/pageComponents/dashboard/OverviewTable.tsx
@@ -94,6 +94,13 @@ export const OverviewTable: React.FC<Props> = ({ clusterInfo, failedClusters, is
 
   const selectItem = useMemo(() => clusterInfo[selectId], [clusterInfo, selectId]);
 
+  // 定义一个函数来获取颜色，根据给定的使用率
+  const getColorByUsage = (usage: number) => {
+    if (usage >= 90) return "red";
+    if (usage >= 70) return "orange";
+    return "green";
+  };
+
   return (
     <Container>
       <Table
@@ -141,19 +148,37 @@ export const OverviewTable: React.FC<Props> = ({ clusterInfo, failedClusters, is
           title={t(p("usageRatePercentage"))}
           sorter={(a, b, sortOrder) =>
             compareWithUndefined(a.info?.usageRatePercentage, b.info?.usageRatePercentage, sortOrder)}
-          render={(_, r) => r.info?.usageRatePercentage !== undefined ? r.info?.usageRatePercentage + "%" : "-"}
+          render={(_, r) => (
+            <span style={{ color: r.info?.usageRatePercentage ?
+              getColorByUsage(r.info?.usageRatePercentage) : "black" }}
+            >
+              {r.info?.usageRatePercentage ? `${r.info.usageRatePercentage}%` : "-"}
+            </span>
+          )}
         />
         <Table.Column<TableProps>
           dataIndex="cpuUsage"
           title={t(p("cpuUsage"))}
           sorter={(a, b, sortOrder) => compareWithUndefined(a.info?.cpuUsage, b.info?.cpuUsage, sortOrder)}
-          render={(_, r) => r.info?.cpuUsage !== undefined ? r.info?.cpuUsage + "%" : "-"}
+          render={(_, r) => (
+            <span style={{ color: r.info?.cpuUsage ?
+              getColorByUsage(Number(r.info?.cpuUsage)) : "black" }}
+            >
+              {r.info?.cpuUsage !== undefined ? Number(r.info?.cpuUsage).toFixed(2) + "%" : "-"}
+            </span>
+          )}
         />
         <Table.Column<TableProps>
           dataIndex="gpuUsage"
           title={t(p("gpuUsage"))}
           sorter={(a, b, sortOrder) => compareWithUndefined(a.info?.gpuUsage, b.info?.gpuUsage, sortOrder) }
-          render={(_, r) => r.info?.gpuUsage !== undefined ? r.info?.gpuUsage + "%" : "-" }
+          render={(_, r) => (
+            <span style={{ color: r.info?.gpuUsage ?
+              getColorByUsage(Number(r.info?.gpuUsage)) : "black" }}
+            >
+              {r.info?.gpuUsage !== undefined ? Number(r.info?.gpuUsage).toFixed(2) + "%" : "-"}
+            </span>
+          )}
         />
         <Table.Column<TableProps>
           dataIndex="pendingJobCount"


### PR DESCRIPTION
1.做了什么
portal中使用率颜色会根据数字大小发生变化，并且保留两位小数
![image](https://github.com/PKUHPC/SCOW/assets/72734623/bfc38d79-7380-46a0-bc1e-22e7500b4414)
2.
mis中导航栏HPC->超算平台
![image](https://github.com/PKUHPC/SCOW/assets/72734623/273a0fdd-ab90-4a51-8057-b20f1086fbdf)


**此PR原本是#1238中的内容，但是根据李老师要求，从#1238独立出来**