### PR TITLE
fix(mis): 修复了mis系统下，消费记录查询中输入筛选条件后分页不正确的问题

### DIFF
--- a/.changeset/fuzzy-hounds-camp.md
+++ b/.changeset/fuzzy-hounds-camp.md
@@ -1,0 +1,5 @@
+---
+"@scow/grpc-api": minor
+---
+
+GetPaginatedChargeRecords 添加字段 user_id_or_name，将 GetChargeRecordsTotalCount 中的 userIds 改为 user_id_or_name.

--- a/.changeset/pink-crabs-pay.md
+++ b/.changeset/pink-crabs-pay.md
@@ -1,0 +1,6 @@
+---
+"@scow/mis-server": patch
+"@scow/mis-web": patch
+---
+
+解决了 mis 系统中消费记录查询用户输入筛选条件后分页不正确的问题。

--- a/apps/mis-server/tests/charging/charging.test.ts
+++ b/apps/mis-server/tests/charging/charging.test.ts
@@ -16,8 +16,7 @@ import { ChannelCredentials } from "@grpc/grpc-js";
 import * as grpc from "@grpc/grpc-js";
 import { SqlEntityManager } from "@mikro-orm/mysql";
 import { Decimal, moneyToNumber, numberToMoney } from "@scow/lib-decimal";
-import { SortOrder } from "@scow/protos/build/common/sort_order";
-import { ChargeRequest, ChargingServiceClient, GetPaginatedChargeRecordsRequest_SortBy, PaymentRecord, PayRequest,
+import { ChargeRequest, ChargingServiceClient, PaymentRecord, PayRequest,
 } from "@scow/protos/build/server/charging";
 import dayjs from "dayjs";
 import { createServer } from "src/app";
@@ -491,6 +490,7 @@ it("returns charge records with query of accountOfTenant", async () => {
     pageSize:10,
     userIds: [],
     types:[request1.type],
+    userIdOrName: [],
   });
 
   expect(reply1.results).toHaveLength(1);
@@ -549,6 +549,7 @@ it("returns charge records with query of tenant", async () => {
     types:extractTypesFromObjects([request1, request2]),
     sortBy:undefined,
     sortOrder:undefined,
+    userIdOrName: [],
   });
 
   expect(reply.results).toHaveLength(2);
@@ -648,6 +649,7 @@ it("returns charge records with query of allTenants", async () => {
     endTime: queryEndTime.toISOString(),
     types: [request1.type],
     userIds: [],
+    userIdOrName: [],
   });
 
   expect(reply.results).toHaveLength(1);
@@ -724,6 +726,7 @@ it("returns charge records with query of accountsOfTenant", async () => {
     userIds: [],
     sortBy:undefined,
     sortOrder:undefined,
+    userIdOrName: [],
   });
 
   expect(reply.results).toHaveLength(2);
@@ -833,6 +836,7 @@ it("returns charge records with query allAccountOfAllTenants", async () => {
     userIds: ["user_1", "user_2"], types:extractTypesFromObjects([request1, request2, request3, request4]),
     sortBy:undefined,
     sortOrder:undefined,
+    userIdOrName: [],
   });
 
   expect(reply.results).toHaveLength(2);
@@ -1022,7 +1026,7 @@ it("returns charge records' total results", async () => {
     startTime: queryStartTime.toISOString(),
     endTime: queryEndTime.toISOString(),
     target:{ $case:"accountsOfAllTenants", accountsOfAllTenants:{ accountNames:[]} },
-    userIds: [], types:extractTypesFromObjects(requestArr),
+    userIdOrName: [], types:extractTypesFromObjects(requestArr),
   });
 
   expect(reply1.totalAmount).toStrictEqual(numberToMoney(130));
@@ -1033,7 +1037,7 @@ it("returns charge records' total results", async () => {
     startTime: queryStartTime.toISOString(),
     endTime: queryEndTime.toISOString(),
     target:{ $case:"accountsOfAllTenants", accountsOfAllTenants:{ accountNames:[]} },
-    userIds: [], types:[request1.type],
+    userIdOrName: [], types:[request1.type],
   });
 
   expect(reply2.totalAmount).toStrictEqual(numberToMoney(100));
@@ -1133,6 +1137,7 @@ it("returns charge records with query of accounts", async () => {
     types:extractTypesFromObjects([request1, request3]),
     sortBy:undefined,
     sortOrder:undefined,
+    userIdOrName: [],
   });
 
   expect(reply1.results).toHaveLength(2);
@@ -1157,6 +1162,7 @@ it("returns charge records with query of accounts", async () => {
     pageSize:10,
     userIds: [],
     types:extractTypesFromObjects([request2]),
+    userIdOrName: [],
   });
 
   expect(reply2.results).toHaveLength(0);
@@ -1173,6 +1179,7 @@ it("returns charge records with query of accounts", async () => {
     types:extractTypesFromObjects([request1, request2, request3, request4]),
     sortBy:undefined,
     sortOrder:undefined,
+    userIdOrName: [],
   });
 
   expect(reply3.results).toHaveLength(2);

--- a/apps/mis-web/src/pageComponents/finance/ChargeTable.tsx
+++ b/apps/mis-web/src/pageComponents/finance/ChargeTable.tsx
@@ -130,13 +130,9 @@ export const ChargeTable: React.FC<Props> = ({
       pageSize: pageInfo.pageSize,
       sortBy: sorter.field,
       sortOrder: sorter.order,
+      userIdOrName:convertUserIdArray(query.userIds),
     } });
-    // 对返回数据进行过滤，筛选出符合搜索结果的userID或userName
-    if (query.userIds) {
-      getChargesInfo.results = getChargesInfo.results.filter((v) => {
-        return v.userId == query.userIds || v.userName == query.userIds;
-      });
-    }
+
     return getChargesInfo;
   }, [query, pageInfo]);
 
@@ -150,7 +146,7 @@ export const ChargeTable: React.FC<Props> = ({
         types: query.types,
         isPlatformRecords,
         searchType,
-        userIds: convertUserIdArray(query.userIds),
+        userIdOrName:convertUserIdArray(query.userIds),
       },
     });
   }, [query]);

--- a/apps/mis-web/src/pages/api/finance/charges.ts
+++ b/apps/mis-web/src/pages/api/finance/charges.ts
@@ -60,6 +60,7 @@ export const ChargeInfo = Type.Object({
   userId: Type.Optional(Type.String()),
   userName: Type.Optional(Type.String()),
   metadata: Type.Optional(MetadataMap),
+  userIdOrName:Type.Optional(Type.String()),
 });
 export type ChargeInfo = Static<typeof ChargeInfo>;
 
@@ -105,6 +106,9 @@ export const GetChargesSchema = typeboxRouteSchema({
     sortBy:Type.Optional(ChargesSortBy),
 
     sortOrder:Type.Optional(ChargesSortOrder),
+
+    // 消费的用户id或者name
+    userIdOrName:  Type.Optional(Type.Array(Type.String())),
   }),
 
   responses: {
@@ -196,7 +200,7 @@ export const buildChargesRequestTarget = (accountNames: string[] | undefined, te
 
 export default typeboxRoute(GetChargesSchema, async (req, res) => {
   const { endTime, startTime, accountNames, isPlatformRecords,
-    searchType, types, userIds, page, pageSize, sortBy, sortOrder } = req.query;
+    searchType, types, userIds, page, pageSize, sortBy, sortOrder, userIdOrName } = req.query;
 
   const info = await getUserInfoForCharges(accountNames, req, res);
   if (!info) return;
@@ -218,6 +222,7 @@ export default typeboxRoute(GetChargesSchema, async (req, res) => {
     pageSize,
     sortBy:mapChargesSortBy,
     sortOrder:mapChargesSortOrder,
+    userIdOrName:userIdOrName ?? [],
   }), []);
 
   const respUserIds = Array.from(new Set(reply.results.map((x) => x.userId).filter((x) => !!x) as string[]));

--- a/apps/mis-web/src/pages/api/finance/getChargeRecordsTotalCount.ts
+++ b/apps/mis-web/src/pages/api/finance/getChargeRecordsTotalCount.ts
@@ -39,9 +39,6 @@ export const GetChargeRecordsTotalCountSchema = typeboxRouteSchema({
     // 消费类型
     types: Type.Optional(Type.Array(Type.String())),
 
-    // 消费的用户id
-    userIds: Type.Optional(Type.Array(Type.String())),
-
     accountNames: Type.Optional(Type.Array(Type.String())),
 
     // 是否为平台管理下的记录：如果是则需查询所有租户，如果不是只查询当前租户
@@ -49,6 +46,10 @@ export const GetChargeRecordsTotalCountSchema = typeboxRouteSchema({
 
     // 查询消费记录种类：平台账户消费记录或租户消费记录
     searchType: Type.Optional(Type.Enum(SearchType)),
+
+    // 消费的用户id或姓名
+    userIdOrName: Type.Optional(Type.Array(Type.String())),
+
   }),
 
   responses: {
@@ -60,7 +61,7 @@ export const GetChargeRecordsTotalCountSchema = typeboxRouteSchema({
 });
 
 export default typeboxRoute(GetChargeRecordsTotalCountSchema, async (req, res) => {
-  const { endTime, startTime, accountNames, isPlatformRecords, searchType, types, userIds } = req.query;
+  const { endTime, startTime, accountNames, isPlatformRecords, searchType, types, userIdOrName } = req.query;
   const info = await getUserInfoForCharges(accountNames, req, res);
   if (!info) return;
 
@@ -72,8 +73,8 @@ export default typeboxRoute(GetChargeRecordsTotalCountSchema, async (req, res) =
     startTime,
     endTime,
     types:types ?? [],
-    userIds: userIds ?? [],
     target: buildChargesRequestTarget(accountNames, tenantOfAccount, searchType, isPlatformRecords),
+    userIdOrName:userIdOrName ?? [],
   }), ["totalAmount", "totalCount"]);
 
   return {

--- a/protos/server/charging.proto
+++ b/protos/server/charging.proto
@@ -153,6 +153,8 @@ message GetPaginatedChargeRecordsRequest {
 
 
   optional common.SortOrder sort_order = 14;
+
+  repeated string user_id_or_name = 15;
 }
 
 message GetPaginatedChargeRecordsResponse {
@@ -178,7 +180,8 @@ message GetChargeRecordsTotalCountRequest {
     // 返回所有租户的租户消费记录
     AllTenantsTarget all_tenants = 8;
   }
-  repeated string user_ids = 9;
+
+  repeated string user_id_or_name = 9;
 }
 
 message GetChargeRecordsTotalCountResponse {


### PR DESCRIPTION
1.做了什么：
修复前：
![image](https://github.com/PKUHPC/SCOW/assets/72734623/79c7405a-b6e2-4fc6-a6ea-a3e3e329fb81)
修复后：
![image](https://github.com/PKUHPC/SCOW/assets/72734623/72940497-b1aa-4ecf-8e50-8da8c2bca836)

为GetPaginatedChargeRecords 添加字段 user_id_or_name，将 GetChargeRecordsTotalCount 中的 userIds 改为 user_id_or_name.

