### PR TITLE
fix(mis): 修复消费记录为空时报错

### DIFF
--- a/apps/mis-server/src/services/charging.ts
+++ b/apps/mis-server/src/services/charging.ts
@@ -525,7 +525,7 @@ export const chargingServiceServer = plugin((server) => {
       }
 
       return [{
-        totalAmount: decimalToMoney(new Decimal(result.total_amount ?? result[0].total_amount)),
+        totalAmount: decimalToMoney(new Decimal(result.total_amount ?? result[0]?.total_amount ?? 0)),
         totalCount: result.total_count ?? result[0].total_count,
       }];
     },


### PR DESCRIPTION
![image](https://github.com/PKUHPC/SCOW/assets/78541912/69031ed6-0b15-4f40-9ea1-a57ee633dbe8)
账户消费记录页面，查询结果为空的时候报错