### PR TITLE
fix(mis): 账户消费记录扣费记录改回精度为2

### DIFF
--- a/apps/mis-web/src/pageComponents/finance/ChargeTable.tsx
+++ b/apps/mis-web/src/pageComponents/finance/ChargeTable.tsx
@@ -325,7 +325,7 @@ export const ChargeTable: React.FC<Props> = ({
           <Table.Column<ChargeInfo>
             dataIndex="amount"
             title={t(p("amount"))}
-            render={(v) => v.toFixed(3)}
+            render={(v) => v.toFixed(2)}
             sorter={true}
           />
           <Table.Column<ChargeInfo>


### PR DESCRIPTION
![image](https://github.com/PKUHPC/SCOW/assets/78541912/daf893f1-145a-4b8e-871f-e64c9f45e06c)
![image](https://github.com/PKUHPC/SCOW/assets/78541912/44fcad37-b4c0-4864-b491-d967153254ba)
扣费金额从三位小数改回两位小数