### PR TITLE
fix(portal-web): 解决门户系统本地开发环境Hydration报错

### DIFF
--- a/.changeset/afraid-adults-whisper.md
+++ b/.changeset/afraid-adults-whisper.md
@@ -1,0 +1,5 @@
+---
+"@scow/portal-web": patch
+---
+
+修复了本地开发环境出现 Hydration 报错的问题

--- a/apps/portal-web/src/pages/_app.tsx
+++ b/apps/portal-web/src/pages/_app.tsx
@@ -147,6 +147,8 @@ interface ExtraProps {
   initialLanguage: string;
   clusterConfigs: { [clusterId: string]: ClusterConfigSchema };
   initialCurrentClusters: Cluster[];
+  // 用于获取桌面功能是否可用，如集群配置文件中没有配置则判断门户的配置文件，需要通过SSR进行传递
+  initialPortalRuntimeDesktopEnabled: boolean;
 }
 
 type Props = AppProps & { extra: ExtraProps };
@@ -162,7 +164,11 @@ function MyApp({ Component, pageProps, extra }: Props) {
   });
 
   const clusterInfoStore = useConstant(() => {
-    return createStore(ClusterInfoStore, extra.clusterConfigs, extra.initialCurrentClusters);
+    return createStore(ClusterInfoStore,
+      extra.clusterConfigs,
+      extra.initialCurrentClusters,
+      extra.initialPortalRuntimeDesktopEnabled,
+    );
   });
 
   const loginNodeStore = useConstant(() => createStore(LoginNodeStore, loginNodes,
@@ -233,6 +239,9 @@ MyApp.getInitialProps = async (appContext: AppContext) => {
     initialLanguage: "",
     clusterConfigs: {},
     initialCurrentClusters: [],
+    // 通过SSR获取门户系统配置文件中是否可用桌面功能
+    // enabled: Type.Boolean({ description: "是否启动登录节点上的桌面功能", default: true }),
+    initialPortalRuntimeDesktopEnabled: true,
   };
 
   // This is called on server on first load, and on client on every page transition
@@ -264,6 +273,9 @@ MyApp.getInitialProps = async (appContext: AppContext) => {
         if (clusterConfigs && Object.keys(clusterConfigs).length > 0) {
 
           extra.clusterConfigs = clusterConfigs;
+
+          extra.initialPortalRuntimeDesktopEnabled = runtimeConfig.PORTAL_CONFIG.loginDesktop.enabled;
+
           const publicConfigClusters
                 = Object.values(getPublicConfigClusters(clusterConfigs));
 

--- a/apps/portal-web/src/utils/cluster.ts
+++ b/apps/portal-web/src/utils/cluster.ts
@@ -24,14 +24,13 @@ import { runtimeConfig } from "./config";
  * @returns {boolean} desktop login enable
  */
 export function getDesktopEnabled(
-  clusters: Record<string, ClusterConfigSchema>) {
-
+  clusters: Record<string, ClusterConfigSchema>,
+  portalRuntimeDesktopEnabled: boolean) {
   const clusterDesktopEnabled = Object.keys(clusters).reduce(
     ((pre, cur) => {
       const curClusterDesktopEnabled = clusters?.[cur]?.loginDesktop?.enabled !== undefined
         ? !!clusters[cur]?.loginDesktop?.enabled
-        : runtimeConfig.PORTAL_CONFIG?.loginDesktop?.enabled;
-
+        : portalRuntimeDesktopEnabled;
       return pre || curClusterDesktopEnabled;
     }), false,
   );
@@ -39,7 +38,19 @@ export function getDesktopEnabled(
   return clusterDesktopEnabled;
 }
 
+/**
+ * 当两个以上（含两个）集群下都配置了文件传输功能时，才开启
+ * @param {Record<String, import("@scow/config/build/cluster").ClusterConfigSchema>} clusters
+ * @returns {boolean} fileTransferEnabled
+ */
+export function getFileTransferEnabled(
+  clusters: Record<string, ClusterConfigSchema>) {
 
+  const fileTransferEnabled = Object.values(clusters).filter(
+    (cluster) => cluster.crossClusterFileTransfer?.enabled).length > 1;
+
+  return fileTransferEnabled;
+}
 
 export type Cluster = { id: string; name: I18nStringType; }
 


### PR DESCRIPTION
### 问题背景

在获取能否使用桌面功能时在前端调用的函数中使用了后端才能获取的RuntimeConfig.PORTAL_CONFIG的数据|
导致浏览前前后端渲染不一致，出现Hydration报错

### 修复后

修复上述问题，并更新 ClusterInfoStore中的是否可以使用桌面功能/是否可以使用文件传输功能 需监听当前在线集群


// TODO 部署环境各页面无影响测试