### PR TITLE
feat(mis): 平台数据统计缓存基本修复

### DIFF
--- a/apps/mis-server/src/entities/QueryCache.ts
+++ b/apps/mis-server/src/entities/QueryCache.ts
@@ -38,6 +38,6 @@ export class QueryCache {
     }
     this.queryKey = init.queryKey;
     this.queryResult = init.queryResult;
-    this.timestamp = new Date();
+    this.timestamp = init.timestamp ?? new Date();
   }
 }

--- a/apps/mis-server/src/utils/cache.ts
+++ b/apps/mis-server/src/utils/cache.ts
@@ -13,21 +13,38 @@
 import { MySqlDriver, QueryBuilder, SqlEntityManager } from "@mikro-orm/mysql";
 import { QueryCache } from "src/entities/QueryCache";
 
-export const queryWithCache = async ({ em, queryKeys, queryQb }: {
+export const queryWithCache = async ({ em, queryKeys, queryQb, cacheOptions }: {
   em: SqlEntityManager<MySqlDriver>
   queryKeys: string[],
   queryQb: QueryBuilder<any>,
+  cacheOptions?: {
+    maxAge?: number,
+    enabled?: boolean,
+  },
 }) => {
+  const { maxAge = 5 * 60 * 1000, enabled = true } = cacheOptions || {};
+
+  if (!enabled) {
+    return await queryQb.execute();
+  }
 
   const queryKey = queryKeys.join(":");
 
-  const queryCache = await em.findOne(QueryCache, {
-    queryKey,
-  });
+  const queryCache = await em.findOne(QueryCache, { queryKey });
+
+  const now = new Date();
 
   if (!queryCache) {
     const newResult = await queryQb.execute();
-    const queryCache = new QueryCache({ queryKey, queryResult: newResult });
+    const newQueryCache = new QueryCache({ queryKey, queryResult: newResult, timestamp: now });
+    await em.persistAndFlush(newQueryCache);
+    return newResult;
+  }
+
+  if ((now.getTime() - queryCache.timestamp.getTime()) > maxAge) {
+    const newResult = await queryQb.execute();
+    queryCache.queryResult = newResult;
+    queryCache.timestamp = now;
     await em.persistAndFlush(queryCache);
     return newResult;
   } else {


### PR DESCRIPTION
平台管理->平台数据统计：
这些数据滞后有误且有缓存。干扰了整个页面可视图表何数据的准确性。
以账户充值为例类推
## 修改前
### 进入时
可视图表显示本周没有账户充值
本例中为2024-04-17 -> 2024-04-24
![1713950395375](https://github.com/PKUHPC/scow-internal-dev/assets/78541912/fcd542ca-9492-4924-9c6e-d75e0e07516f)
### 调整日期筛选到今天
2024-04-24 -> 2024-04-24
可见有账户充值
![1713950512545](https://github.com/PKUHPC/scow-internal-dev/assets/78541912/e38084a9-e733-4e55-80a8-40a7a59b0230)
但是此时筛选回到2024-04-17 -> 2024-04-24
仍然没有账户充值（被缓存）
切换成2024-04-23 -> 2024-04-24
则有账户充值

因此，应当修改本页面，使平台数据统计数据显示正确，避免错误的缓存无法变更。
## 修改后
> 默认缓存时间为5分钟
![image](https://github.com/PKUHPC/SCOW/assets/78541912/2495a834-9090-40b5-936e-3f5ee486904e)
