### PR TITLE
chore: 修复centos7包管理镜像地址

### DIFF
--- a/dev/ldap/Dockerfile
+++ b/dev/ldap/Dockerfile
@@ -13,6 +13,11 @@ FROM centos:7
 WORKDIR /ldap
 COPY dev/ldap/provider.sh .
 
+# https://serverfault.com/a/1161847
+RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
+RUN sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
+RUN sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
+
 RUN ulimit -n 10240;./provider.sh docker
 
 VOLUME [ "/var/lib/ldap" ]


### PR DESCRIPTION
https://serverfault.com/questions/1161816/mirrorlist-centos-org-no-longer-resolve

CentOS 7在2024年7月1日EOL了，默认的mirrors.centos.org的包镜像地址消失了，测试用的LDAP镜像使用的CentOS7无法安装包了。本PR根据上面的链接使用vault.centos.org地址作为centos 7的包镜像地址。
