### PR TITLE
fix(mis): 系统初始化时可用集群报错

### DIFF
--- a/.changeset/chilled-schools-pull.md
+++ b/.changeset/chilled-schools-pull.md
@@ -1,0 +1,8 @@
+---
+"@scow/mis-web": patch
+"@scow/config": patch
+"@scow/lib-ssh": patch
+"@scow/lib-web": patch
+---
+
+修复系统初始化时因无法通过鉴权可用集群为空的问题

--- a/apps/mis-web/src/apis/api.mock.ts
+++ b/apps/mis-web/src/apis/api.mock.ts
@@ -503,6 +503,16 @@ export const mockApi: MockApi<typeof api> = {
     },
   } }),
 
+  getSimpleClustersInfoFromConfigFiles: async () => ({
+    clustersInfo: {
+      hpc01: {
+        displayName: "hpc01Name",
+        priority: 1,
+        clusterId: "hpc01",
+      },
+    },
+  }),
+
   getClustersConnectionInfo: async () => ({ results: [{
     clusterId: "hpc01",
     schedulerName: "hpc",

--- a/apps/mis-web/src/apis/api.ts
+++ b/apps/mis-web/src/apis/api.ts
@@ -13,7 +13,7 @@
 /* eslint-disable max-len */
 
 import { apiClient } from "src/apis/client";
-import type { getClusterConfigFilesSchema } from "src/pages/api//clusterConfigsInfo";
+import type { GetClusterConfigFilesSchema } from "src/pages/api//clusterConfigsInfo";
 import type { ActivateClusterSchema } from "src/pages/api/admin/activateCluster";
 import type { ChangeJobPriceSchema } from "src/pages/api/admin/changeJobPrice";
 import type { ChangePasswordAsPlatformAdminSchema } from "src/pages/api/admin/changePassword";
@@ -93,6 +93,7 @@ import type { GetOperationLogsSchema } from "src/pages/api/log/getOperationLog";
 import type { ChangeEmailSchema } from "src/pages/api/profile/changeEmail";
 import type { ChangePasswordSchema } from "src/pages/api/profile/changePassword";
 import type { CheckPasswordSchema } from "src/pages/api/profile/checkPassword";
+import { GetSimpleClustersInfoFromConfigFilesSchema } from "src/pages/api/simpleClustersInfo";
 import type { DewhitelistAccountSchema } from "src/pages/api/tenant/accountWhitelist/dewhitelistAccount";
 import type { GetWhitelistedAccountsSchema } from "src/pages/api/tenant/accountWhitelist/getWhitelistedAccounts";
 import type { WhitelistAccountSchema } from "src/pages/api/tenant/accountWhitelist/whitelistAccount";
@@ -167,7 +168,7 @@ export const api = {
   authCallback: apiClient.fromTypeboxRoute<typeof AuthCallbackSchema>("GET", "/api/auth/callback"),
   logout: apiClient.fromTypeboxRoute<typeof LogoutSchema>("DELETE", "/api/auth/logout"),
   validateToken: apiClient.fromTypeboxRoute<typeof ValidateTokenSchema>("GET", "/api/auth/validateToken"),
-  getClusterConfigFiles: apiClient.fromTypeboxRoute<typeof getClusterConfigFilesSchema>("GET", "/api//clusterConfigsInfo"),
+  getClusterConfigFiles: apiClient.fromTypeboxRoute<typeof GetClusterConfigFilesSchema>("GET", "/api//clusterConfigsInfo"),
   getUserStatus: apiClient.fromTypeboxRoute<typeof GetUserStatusSchema>("GET", "/api/dashboard/status"),
   exportAccount: apiClient.fromTypeboxRoute<typeof ExportAccountSchema>("GET", "/api/file/exportAccount"),
   exportChargeRecord: apiClient.fromTypeboxRoute<typeof ExportChargeRecordSchema>("GET", "/api/file/exportChargeRecord"),
@@ -226,4 +227,5 @@ export const api = {
   queryStorageUsage: apiClient.fromTypeboxRoute<typeof QueryStorageUsageSchema>("GET", "/api/users/storageUsage"),
   unblockUserInAccount: apiClient.fromTypeboxRoute<typeof UnblockUserInAccountSchema>("PUT", "/api/users/unblockInAccount"),
   unsetAdmin: apiClient.fromTypeboxRoute<typeof UnsetAdminSchema>("PUT", "/api/users/unsetAdmin"),
+  getSimpleClustersInfoFromConfigFiles: apiClient.fromTypeboxRoute<typeof GetSimpleClustersInfoFromConfigFilesSchema>("GET", "/api//simpleClustersInfo"),
 };

--- a/apps/mis-web/src/stores/ClusterInfoStore.ts
+++ b/apps/mis-web/src/stores/ClusterInfoStore.ts
@@ -10,23 +10,24 @@
  * See the Mulan PSL v2 for more details.
  */
 
-import { ClusterConfigSchema } from "@scow/config/build/cluster";
+import { ClusterConfigSchema, SimpleClusterSchema } from "@scow/config/build/cluster";
 import { getSortedClusterIds } from "@scow/lib-web/build/utils/cluster";
 import { useEffect, useState } from "react";
 import { Cluster, getPublicConfigClusters } from "src/utils/cluster";
 
 // export function ClusterInfoStore(
 export function ClusterInfoStore(
-  clusterConfigs: {[clusterId: string]: ClusterConfigSchema},
-  initialActivatedClusters: {[clusterId: string]: Cluster},
+  clusterConfigs: Record<string, ClusterConfigSchema>,
+  initialActivatedClusters: Record<string, Cluster>,
+  initialSimpleClusters: Record<string, SimpleClusterSchema>,
 ) {
 
-  const publicConfigClusters = getPublicConfigClusters(clusterConfigs);
+  const publicConfigClusters = getPublicConfigClusters(clusterConfigs) ?? getPublicConfigClusters(initialSimpleClusters) ?? {};
 
-  const clusterSortedIdList = getSortedClusterIds(clusterConfigs);
+  const clusterSortedIdList = getSortedClusterIds(clusterConfigs) ?? getSortedClusterIds(initialSimpleClusters) ?? [];
 
   const [activatedClusters, setActivatedClusters]
-   = useState<{[clusterId: string]: Cluster}>(initialActivatedClusters);
+   = useState<Record<string, Cluster>>(initialActivatedClusters);
 
   const initialDefaultClusterId = clusterSortedIdList.find((x) => {
     return Object.keys(initialActivatedClusters).find((c) => c === x);

--- a/apps/mis-web/src/utils/cluster.ts
+++ b/apps/mis-web/src/utils/cluster.ts
@@ -10,7 +10,7 @@
  * See the Mulan PSL v2 for more details.
  */
 
-import { ClusterConfigSchema } from "@scow/config/build/cluster";
+import { ClusterConfigSchema, SimpleClusterSchema } from "@scow/config/build/cluster";
 import { I18nStringType } from "@scow/config/build/i18n";
 import { getI18nConfigCurrentText } from "@scow/lib-web/build/utils/systemLanguage";
 
@@ -19,13 +19,13 @@ export type Cluster = { id: string; name: I18nStringType; }
 export const getClusterName = (
   clusterId: string,
   languageId: string,
-  publicConfigClusters: { [clusterId: string]: Cluster },
+  publicConfigClusters: Record<string, Cluster>,
 ) => {
   return getI18nConfigCurrentText(publicConfigClusters[clusterId]?.name, languageId) || clusterId;
 };
 
 export const getSortedClusterValues =
-  (publicConfigClusters: { [clusterId: string]: Cluster },
+  (publicConfigClusters: Record<string, Cluster>,
     clusterSortedIdList: string[],
   ): Cluster[] => {
 
@@ -39,18 +39,19 @@ export const getSortedClusterValues =
 
 
 export const getPublicConfigClusters =
-  (configClusters: Record<string, ClusterConfigSchema>):
-  { [clusterId: string]: Cluster } => {
+  (configClusters: Record<string, Partial<SimpleClusterSchema>>):
+  Record<string, Cluster> => {
 
-    const publicConfigClusters: { [clusterId: string]: Cluster; } = {};
+    const publicConfigClusters: Record<string, Cluster> = {};
 
     Object.keys(configClusters).forEach((clusterId) => {
       const cluster = {
         id: clusterId,
-        name: configClusters[clusterId].displayName,
+        name: configClusters[clusterId].displayName!!,
       };
       publicConfigClusters[clusterId] = cluster;
     });
 
     return publicConfigClusters;
   };
+

--- a/apps/mis-web/src/utils/cluster.ts
+++ b/apps/mis-web/src/utils/cluster.ts
@@ -10,7 +10,7 @@
  * See the Mulan PSL v2 for more details.
  */
 
-import { ClusterConfigSchema, SimpleClusterSchema } from "@scow/config/build/cluster";
+import { SimpleClusterSchema } from "@scow/config/build/cluster";
 import { I18nStringType } from "@scow/config/build/i18n";
 import { getI18nConfigCurrentText } from "@scow/lib-web/build/utils/systemLanguage";
 
@@ -47,7 +47,7 @@ export const getPublicConfigClusters =
     Object.keys(configClusters).forEach((clusterId) => {
       const cluster = {
         id: clusterId,
-        name: configClusters[clusterId].displayName!!,
+        name: configClusters[clusterId].displayName!,
       };
       publicConfigClusters[clusterId] = cluster;
     });

--- a/libs/config/src/cluster.ts
+++ b/libs/config/src/cluster.ts
@@ -18,6 +18,13 @@ import { Logger } from "ts-log";
 
 const CLUSTER_CONFIG_BASE_PATH = "clusters";
 
+export const SimpleClusterSchema = Type.Object({
+  clusterId: Type.String(),
+  displayName: createI18nStringSchema({ description: "集群名称" }),
+  priority: Type.Number(),
+});
+export type SimpleClusterSchema = Static<typeof SimpleClusterSchema>;
+
 export enum k8sRuntime {
   docker = "docker",
   containerd = "containerd",
@@ -25,7 +32,7 @@ export enum k8sRuntime {
 
 const LoginNodeConfigSchema = Type.Object({
   name: createI18nStringSchema({ description: "登录节点展示名" }),
-  address: Type.String({ description: "集群的登录节点地址" }),  
+  address: Type.String({ description: "集群的登录节点地址" }),
   scowd: Type.Optional(Type.Object({
     port: Type.Number({ description: "scowd 端口号" }),
   }, { description: "scowd 相关配置" })),

--- a/libs/ssh/src/ssh.ts
+++ b/libs/ssh/src/ssh.ts
@@ -210,7 +210,6 @@ export async function executeAsUser(
  */
 export async function testRootUserSshLogin(host: string, keyPair: KeyPair, logger: Logger) {
   return await sshConnect(host, "root", keyPair, logger, async () => undefined).catch((e) => e);
-
 }
 
 /**

--- a/libs/web/src/utils/cluster.ts
+++ b/libs/web/src/utils/cluster.ts
@@ -10,13 +10,14 @@
  * See the Mulan PSL v2 for more details.
  */
 
-import { Cluster as ClusterWithConfig, ClusterConfigSchema } from "@scow/config/build/cluster";
+import { Cluster as ClusterWithConfig, ClusterConfigSchema, SimpleClusterSchema } from "@scow/config/build/cluster";
 
-export const getSortedClusterIds = (clusters: Record<string, ClusterConfigSchema>): string[] => {
+export const getSortedClusterIds = (clusters: Record<string, Partial<SimpleClusterSchema>>): string[] => {
   return Object.keys(clusters)
     .sort(
       (a, b) => {
-        return clusters[a].priority - clusters[b].priority;
+        return (clusters[a].priority ?? Number.MAX_SAFE_INTEGER)
+          - (clusters[b].priority ?? Number.MIN_SAFE_INTEGER);
       },
     );
 };


### PR DESCRIPTION
### 问题

因初始化时无法通过token或auth鉴权，导致系统初始化时的可用集群查询结果为空
![image](https://github.com/PKUHPC/SCOW/assets/43978285/8b5fa308-6044-4622-9e81-15e055d7fa01)

### 修改

在管理系统的web端原有获取集群配置信息接口以外增加返回简单集群信息的web接口 `getSimpleClustersInfoFromConfigFiles`
返回信息仅包含 `clusterId, displayName,` 及用于优先级排序的 `priority`

在`getSimpleClustersInfoFromConfigFiles` 及获取当前集群在线信息接口中` getClustersRuntimeInfo` 增加是否已初始化判断，未初始化时允许所有人获取简单集群在线信息

### 修改后

系统初始化时获取集群信息正常，各操作正常，初始化完成后登录正常

![集群停用初始化](https://github.com/PKUHPC/SCOW/assets/43978285/3149453e-f0b0-495b-8c40-8edf391211ed)
<img width="677" alt="faa3afca5e2e2cc4219edc077f2ef6f" src="https://github.com/PKUHPC/SCOW/assets/43978285/59f8b8a9-222d-492f-bb33-89bdc404d54e">

