### PR TITLE
fix(mis)： 修复系统初始化时作业价格表设置页面报错问题

### DIFF
--- a/.changeset/twelve-mugs-pump.md
+++ b/.changeset/twelve-mugs-pump.md
@@ -1,0 +1,7 @@
+---
+"@scow/mis-web": patch
+"@scow/config": patch
+"@scow/lib-web": patch
+---
+
+修复系统初始化时作业价格表设置页面查询参数报错问题

--- a/apps/mis-web/src/pages/_app.tsx
+++ b/apps/mis-web/src/pages/_app.tsx
@@ -256,9 +256,7 @@ MyApp.getInitialProps = async (appContext: AppContext) => {
       }
     }
 
-    const clustersRuntimeInfo = token ?
-      await api.getClustersRuntimeInfo({ query: { token } }).then((x) => x, () => undefined)
-      : await api.getClustersRuntimeInfo({ query: { } }).then((x) => x, () => undefined);
+    const clustersRuntimeInfo = await api.getClustersRuntimeInfo({ query: { token } }).then((x) => x, () => undefined);
 
     // get deployed clusters' simple info (only clusterId, displayName and priority)
     const simpleClustersInfo
@@ -266,7 +264,7 @@ MyApp.getInitialProps = async (appContext: AppContext) => {
 
     extra.initialSimpleClustersInfo = simpleClustersInfo?.clustersInfo;
 
-    const publicConfigClusters = Object.keys(extra.clusterConfigs).length > 0 ?
+    const publicConfigClusters = extra.clusterConfigs && Object.keys(extra.clusterConfigs).length > 0 ?
       getPublicConfigClusters(extra.clusterConfigs) : getPublicConfigClusters(extra.initialSimpleClustersInfo) ?? {};
 
     const activatedClusters

--- a/apps/mis-web/src/stores/ClusterInfoStore.ts
+++ b/apps/mis-web/src/stores/ClusterInfoStore.ts
@@ -22,10 +22,16 @@ export function ClusterInfoStore(
   initialSimpleClusters: Record<string, SimpleClusterSchema>,
 ) {
 
-  const publicConfigClusters = getPublicConfigClusters(clusterConfigs)
-    ?? getPublicConfigClusters(initialSimpleClusters) ?? {};
+  let publicConfigClusters: Record<string, Cluster> = {};
+  let clusterSortedIdList: string[] = [];
 
-  const clusterSortedIdList = getSortedClusterIds(clusterConfigs) ?? getSortedClusterIds(initialSimpleClusters) ?? [];
+  if (Object.keys(clusterConfigs).length > 0) {
+    clusterSortedIdList = getSortedClusterIds(clusterConfigs);
+    publicConfigClusters = getPublicConfigClusters(clusterConfigs);
+  } else {
+    clusterSortedIdList = getSortedClusterIds(initialSimpleClusters ?? {});
+    publicConfigClusters = getPublicConfigClusters(initialSimpleClusters ?? {});
+  }
 
   const [activatedClusters, setActivatedClusters]
    = useState<Record<string, Cluster>>(initialActivatedClusters);

--- a/libs/config/src/cluster.ts
+++ b/libs/config/src/cluster.ts
@@ -21,7 +21,7 @@ const CLUSTER_CONFIG_BASE_PATH = "clusters";
 export const SimpleClusterSchema = Type.Object({
   clusterId: Type.String(),
   displayName: createI18nStringSchema({ description: "集群名称" }),
-  priority: Type.Number(),
+  priority: Type.Number({ description: "集群使用的优先级, 数字越小越先展示", default: Number.MAX_SAFE_INTEGER }),
 });
 export type SimpleClusterSchema = Static<typeof SimpleClusterSchema>;
 

--- a/libs/web/src/utils/cluster.ts
+++ b/libs/web/src/utils/cluster.ts
@@ -16,8 +16,7 @@ export const getSortedClusterIds = (clusters: Record<string, Partial<SimpleClust
   return Object.keys(clusters)
     .sort(
       (a, b) => {
-        return (clusters[a].priority ?? Number.MAX_SAFE_INTEGER)
-          - (clusters[b].priority ?? Number.MIN_SAFE_INTEGER);
+        return clusters[a].priority! - clusters[b].priority!;
       },
     );
 };


### PR DESCRIPTION
### 问题

系统初始化时 作业价格表设置页面 因集群排序参数为空数组报错
原因为管理系统集群排序参数的上下文context的获取逻辑中集群配置信息数据为{ }时也可以获取排序结果为[ ]

### 修改后