### PR TITLE
fix(portal-server): 修复获取 scowdClient 时拼接地址的错误

### DIFF
--- a/.changeset/khaki-cheetahs-warn.md
+++ b/.changeset/khaki-cheetahs-warn.md
@@ -1,0 +1,6 @@
+---
+"@scow/portal-server": patch
+"@scow/utils": patch
+---
+
+修复获取 scowdClient 时拼接地址的错误

--- a/apps/portal-server/src/utils/scowd.ts
+++ b/apps/portal-server/src/utils/scowd.ts
@@ -15,6 +15,7 @@ import { ServiceError, status } from "@grpc/grpc-js";
 import { getLoginNode } from "@scow/config/build/cluster";
 import { getScowdClient as getClient, ScowdClient } from "@scow/lib-scowd/build/client";
 import { createScowdCertificates } from "@scow/lib-scowd/build/ssl";
+import { removePort } from "@scow/utils";
 import { configClusters } from "src/config/clusters";
 import { config } from "src/config/env";
 
@@ -28,7 +29,8 @@ export function getLoginNodeScowdUrl(cluster: string, host: string): string | un
   if (!loginNode) return undefined;
 
   const { address, scowdPort } = loginNode;
-  return config.SCOWD_SSL_ENABLED ? `https://${address}:${scowdPort}` : `http://${address}:${scowdPort}`;
+  return config.SCOWD_SSL_ENABLED
+    ? `https://${removePort(address)}:${scowdPort}` : `http://${removePort(address)}:${scowdPort}`;
 }
 
 const scowdClientForClusters = Object.entries(configClusters).reduce((prev, [cluster]) => {

--- a/libs/utils/src/url.ts
+++ b/libs/utils/src/url.ts
@@ -52,3 +52,14 @@ export function normalizePathnameWithQuery(pathnameWithQuery: string) {
 
   return normalize(pathname) + qs;
 }
+
+/**
+ * Remove port from address
+ * @param address IP address or hostname possibly with port
+ * @returns address without port
+ */
+export function removePort(address: string): string {
+  // Remove :port if present
+  return address.replace(/:\d+$/, "");
+}
+


### PR DESCRIPTION
scow 在获取 scowdClient 时是通过 login 的地址拼接对应 scowd  的 port 的方式获得的 scowd 的完整地址。之前未考虑到 login地址中可能会带上端口，拼接的时候就会出错。所以本次修复主要是移除 login 地址中的端口号再进行拼接