### PR TITLE
feat: ai加上国际化的Provider

### DIFF
--- a/.changeset/strange-lemons-notice.md
+++ b/.changeset/strange-lemons-notice.md
@@ -1,0 +1,5 @@
+---
+"@scow/ai": patch
+---
+
+ai 加上国际化的 Provider

--- a/apps/ai/src/app/clientLayout.tsx
+++ b/apps/ai/src/app/clientLayout.tsx
@@ -18,6 +18,9 @@ import { usePathname } from "next/navigation";
 import { ErrorBoundary } from "src/components/ErrorBoundary";
 import { Loading } from "src/components/Loading";
 import { TopProgressBar } from "src/components/TopProgressBar";
+import { Provider } from "src/i18n";
+import en from "src/i18n/en";
+import zh_cn from "src/i18n/zh_cn";
 import { AntdConfigProvider } from "src/layouts/AntdConfigProvider";
 import { DarkModeCookie, DarkModeProvider } from "src/layouts/darkMode";
 import { RootErrorContent } from "src/layouts/error/RootErrorContent";
@@ -27,6 +30,11 @@ import { UiConfig } from "src/server/trpc/route/config";
 import { trpc } from "src/utils/trpc";
 
 import { UiConfigContext } from "./uiContext";
+
+const languagesMap = {
+  "zh_cn": zh_cn,
+  "en": en,
+};
 
 export function ClientLayout(props: {
   children: React.ReactNode,
@@ -49,36 +57,44 @@ export function ClientLayout(props: {
     ?? primaryColor?.defaultColor ?? uiConfig.defaultPrimaryColor;
 
   return (
-    <StyleProvider hashPriority="high" transformers={[legacyLogicalPropertiesTransformer]}>
-      <StyledComponentsRegistry>
-        <AntdStyleRegistry>
-          <body>
-            {
-              useConfig.isLoading ?
-                <Loading />
-                : (
-                  <DarkModeProvider initial={props.initialDark}>
-                    <AntdConfigProvider color={color}>
-                      <GlobalStyle />
-                      <TopProgressBar />
-                      <ErrorBoundary Component={RootErrorContent} pathname={pathname ?? ""}>
-                        <UiConfigContext.Provider
-                          value={{
-                            hostname,
-                            uiConfig,
-                          }}
-                        >
-                          {props.children}
-                        </UiConfigContext.Provider>
-                      </ErrorBoundary>
-                    </AntdConfigProvider>
-                  </DarkModeProvider>
-                )
-            }
+    <Provider initialLanguage={{
+      // ai还未开发国际化，先直接写zh_cn
+      id: "zh_cn",
+      definitions: languagesMap.zh_cn,
+    }}
+    >
+      <StyleProvider hashPriority="high" transformers={[legacyLogicalPropertiesTransformer]}>
+        <StyledComponentsRegistry>
+          <AntdStyleRegistry>
+            <body>
+              {
+                useConfig.isLoading ?
+                  <Loading />
+                  : (
+                    <DarkModeProvider initial={props.initialDark}>
+                      <AntdConfigProvider color={color}>
+                        <GlobalStyle />
+                        <TopProgressBar />
+                        <ErrorBoundary Component={RootErrorContent} pathname={pathname ?? ""}>
+                          <UiConfigContext.Provider
+                            value={{
+                              hostname,
+                              uiConfig,
+                            }}
+                          >
+                            {props.children}
+                          </UiConfigContext.Provider>
+                        </ErrorBoundary>
+                      </AntdConfigProvider>
+                    </DarkModeProvider>
+                  )
+              }
 
-          </body>
-        </AntdStyleRegistry>
-      </StyledComponentsRegistry>
-    </StyleProvider>
+            </body>
+          </AntdStyleRegistry>
+        </StyledComponentsRegistry>
+      </StyleProvider>
+    </Provider>
+
   );
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/61f9a74d-5762-4108-b61b-be05f1c76741)
## 回归测试ai时发现没法打开shell页面，报错如图，缺少Provider
