### PR TITLE
fix: prevent copying a folder into itself or its subfolders to match …

### DIFF
--- a/apps/portal-web/src/i18n/en.ts
+++ b/apps/portal-web/src/i18n/en.ts
@@ -268,6 +268,8 @@ export default {
           existModalOk: "Confirm",
           errorMessage: "{} error! A total of {} files/directories, {} succeeded, {} abandoned, {} failed",
           successMessage: "{} succeeded! A total of {} files/directories, {} succeeded, {} abandoned",
+          invalidCopyTitle: "Invalid Copy Operation",
+          invalidCopyContent: "Cannot copy a folder into itself or its subfolder: {}",
         },
         delete: {
           confirmTitle: "Confirm Deletion",

--- a/apps/portal-web/src/i18n/zh_cn.ts
+++ b/apps/portal-web/src/i18n/zh_cn.ts
@@ -268,6 +268,8 @@ export default {
           existModalOk: "确认",
           errorMessage: "{}错误！总计{}项文件/目录，其中成功{}项，放弃{}项，失败{}项",
           successMessage: "{}成功！总计{}项文件/目录，其中成功{}项，放弃{}项",
+          invalidCopyTitle: "无效的复制操作",
+          invalidCopyContent: "不能将文件夹复制到自身或子文件夹: {}",
         },
         delete: {
           confirmTitle: "确认删除",

--- a/apps/portal-web/src/pageComponents/filemanager/FileManager.tsx
+++ b/apps/portal-web/src/pageComponents/filemanager/FileManager.tsx
@@ -209,6 +209,17 @@ export const FileManager: React.FC<Props> = ({ cluster, path, urlPrefix, scowdEn
     let abandonCount: number = 0;
     const allCount = operation.selected.length;
     for (const x of operation.selected) {
+      const fromPath = join(operation.originalPath, x.name);
+      const toPath = join(path, x.name);
+
+      // 阻止复制到自身或子目录
+      if (toPath === fromPath || toPath.startsWith(fromPath + "/")) {
+        modal.error({
+          title: t(p("moveCopy.invalidCopyTitle")),
+          content: t(p("moveCopy.invalidCopyContent"), [x.name]),
+        });
+        continue;
+      }
       try {
 
         const exists = await api.fileExist({ query: { cluster: cluster.id, path: join(path, x.name) } });


### PR DESCRIPTION
**本次代码变更有以下几点：**

- 修复了文件夹复制逻辑，**禁止将文件夹复制到自身或其子文件夹**
- 新增了路径校验逻辑，使操作行为与 **Linux 文件系统规范** 保持一致  